### PR TITLE
Refine curated page hero and add media card

### DIFF
--- a/src/CuratedPage.js
+++ b/src/CuratedPage.js
@@ -27,6 +27,7 @@ export default function CuratedPage() {
 
   const site = typeof window !== "undefined" ? window.location.origin : "";
   const ogImage = page.heroImage?.startsWith("/") ? `${site}${page.heroImage}` : page.heroImage || "";
+  const hasHeroImage = Boolean(page.heroImage);
 
   return (
     <>
@@ -39,13 +40,6 @@ export default function CuratedPage() {
 
       {/* HERO */}
       <section style={hero.wrap}>
-        <div style={hero.media}>
-          <img
-            src={page.heroImage || "/og-home.jpg"}
-            alt="Curated collection hero"
-            style={hero.image}
-          />
-        </div>
         <div style={hero.overlay} />
         <div style={hero.inner}>
           <h1 style={hero.title}>{page.title}</h1>
@@ -60,6 +54,21 @@ export default function CuratedPage() {
           {/* empty on purpose—single-focus page; if you want bullets, place them here */}
         </div>
         <div style={content.right}>
+          <div style={mediaCard.frame}>
+            <div style={mediaCard.ratioBox}>
+              {hasHeroImage ? (
+                <img
+                  src={page.heroImage}
+                  alt="Featured properties preview"
+                  style={mediaCard.image}
+                />
+              ) : (
+                <div style={mediaCard.placeholder} aria-hidden="true">
+                  <span style={mediaCard.placeholderLabel}>Curated homes map</span>
+                </div>
+              )}
+            </div>
+          </div>
           <LeadForm slug={page.slug} title={page.title} realmLink={page.realmLink} />
           <div style={disclosure.box}>
             <strong>Matthew Mulhall</strong> — Real Estate Agent — HomeLife Optimum Realty — Finally Home Agents
@@ -77,17 +86,13 @@ const hero = {
     alignItems: "end",
     height: "min(65vh, clamp(280px, 55vw, 520px))",
     overflow: "hidden",
-  },
-  media: { position: "absolute", inset: 0, overflow: "hidden" },
-  image: {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-    objectPosition: "center",
-    filter: "saturate(.95)",
+    backgroundImage: "url(/Images/northside-map.svg)",
+    backgroundSize: "cover",
+    backgroundPosition: "center",
+    backgroundRepeat: "no-repeat",
   },
   overlay: { position: "absolute", inset: 0, background: "linear-gradient(180deg, rgba(0,0,0,.35), rgba(0,0,0,.55))" },
-  inner: { position: "relative", maxWidth: 1080, margin: "0 auto", padding: "60px 20px" },
+  inner: { position: "relative", zIndex: 1, maxWidth: 1080, margin: "0 auto", padding: "60px 20px" },
   title: { color: "#fff", fontSize: 36, lineHeight: 1.1, margin: 0 },
   sub: { color: "rgba(255,255,255,.92)", fontSize: 18, marginTop: 8, maxWidth: 720 },
   trust: { color: "rgba(255,255,255,.85)", fontSize: 13, marginTop: 14 },
@@ -100,6 +105,48 @@ const content = {
   },
   left: { minHeight: 1 },
   right: { position: "relative" },
+};
+
+const mediaCard = {
+  frame: {
+    marginBottom: 24,
+    borderRadius: 16,
+    border: "1px solid #e5e5e5",
+    overflow: "hidden",
+    background: "#f8f8f8",
+  },
+  ratioBox: {
+    position: "relative",
+    width: "100%",
+    paddingBottom: "66.6667%",
+    background: "#f0f2f5",
+  },
+  image: {
+    position: "absolute",
+    inset: 0,
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+  },
+  placeholder: {
+    position: "absolute",
+    inset: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: "#6b7280",
+    fontSize: 14,
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+    background: "linear-gradient(135deg, rgba(255,255,255,0.95), rgba(229,231,235,0.95))",
+  },
+  placeholderLabel: {
+    padding: "0 12px",
+    border: "1px dashed rgba(107,114,128,0.6)",
+    borderRadius: 999,
+    fontWeight: 600,
+    letterSpacing: 1,
+  },
 };
 
 const disclosure = {


### PR DESCRIPTION
## Summary
- lock the curated page hero to the illustrated map background while keeping the headline overlay unchanged
- surface the optional uploaded image inside the content column within a fixed-aspect media card and crop with object-fit cover
- include a styled placeholder so the layout remains balanced when no custom image has been provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc3203df508324a7573c882d50ea99