### PR TITLE
Align curated messaging with 10-second delivery promise

### DIFF
--- a/src/CuratedPage.js
+++ b/src/CuratedPage.js
@@ -50,7 +50,7 @@ export default function CuratedPage() {
         <div style={hero.inner}>
           <h1 style={hero.title}>{page.title}</h1>
           {page.intro && <p style={hero.sub}>{page.intro}</p>}
-          <p style={hero.trust}>🔒 We’ll email you the private link. No spam.</p>
+          <p style={hero.trust}>🔒 We’ll email you the private link within 10 seconds. No spam.</p>
         </div>
       </section>
 

--- a/src/components/LeadForm.jsx
+++ b/src/components/LeadForm.jsx
@@ -61,7 +61,7 @@ export default function LeadForm({ slug, title, realmLink }) {
     <div style={styles.card}>
       <h3 style={{ marginBottom: 12 }}>Get the listings by email</h3>
       <p style={{ marginTop: -4, marginBottom: 16, fontSize: 14, opacity: 0.8 }}>
-        We’ll send the link to your inbox in minutes.
+        We’ll send the link to your inbox within 10 seconds.
       </p>
 
       <form onSubmit={onSubmit}>
@@ -135,7 +135,7 @@ export default function LeadForm({ slug, title, realmLink }) {
         {status.err && <p style={{ color: "#c0392b", marginTop: 10 }}>{status.err}</p>}
         {status.ok && (
           <p style={{ color: "#2ecc71", marginTop: 10 }}>
-            Success! Check your inbox for the link. Redirecting…
+            Success! Check your inbox—the link should arrive within 10 seconds. Redirecting…
           </p>
         )}
 


### PR DESCRIPTION
## Summary
- update the curated hero trust blurb to promise email delivery within 10 seconds
- refresh the lead form introduction and confirmation messaging to match the 10-second commitment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc32050bbc83248b5384c9be819d5a