### PR TITLE
Add hero image upload hint to CMS configs

### DIFF
--- a/public/cms/config.yml
+++ b/public/cms/config.yml
@@ -37,3 +37,4 @@ collections:
         label: 'Hero Image'
         widget: 'image'
         required: false
+        hint: 'Upload a 1800×1200 JPG/PNG for best results.'

--- a/public/config.yml
+++ b/public/config.yml
@@ -22,4 +22,7 @@ collections:
           ['^[a-z0-9-]+$', 'Use lowercase letters, numbers, and dashes only']
       - { name: 'intro', label: 'Intro (optional)', required: false }
       - { name: 'realmLink', label: 'Realm Link (the private URL)' }
-      - { name: 'heroImage', label: 'Hero Image', widget: 'image' }
+      - name: 'heroImage'
+        label: 'Hero Image'
+        widget: 'image'
+        hint: 'Upload a 1800×1200 JPG/PNG for best results.'


### PR DESCRIPTION
## Summary
- add helper text to the hero image field in both CMS configuration files so authors see the target 1800×1200 asset guidance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc34e754a883248061396cf317d861