### PR TITLE
Use curated hero fallback image

### DIFF
--- a/src/CuratedPage.js
+++ b/src/CuratedPage.js
@@ -18,6 +18,8 @@ function useCurated(slug) {
   return { page, err };
 }
 
+const HERO_BACKGROUND = "/Images/northside-map.svg";
+
 export default function CuratedPage() {
   const { slug } = useParams();
   const { page, err } = useCurated(slug);
@@ -25,8 +27,9 @@ export default function CuratedPage() {
   if (err) return <main style={{maxWidth:960,margin:"40px auto"}}>Not found.</main>;
   if (!page) return <main style={{maxWidth:960,margin:"40px auto"}}>Loading…</main>;
 
-  const fallbackHero = "/Images/northside-map.svg";
-  const heroImageSrc = page.heroImage || fallbackHero;
+  const heroImage =
+    typeof page.heroImage === "string" ? page.heroImage.trim() : page.heroImage;
+  const heroImageSrc = heroImage ? heroImage : HERO_BACKGROUND;
   const site = typeof window !== "undefined" ? window.location.origin : "";
   const ogImage = heroImageSrc.startsWith("/") ? `${site}${heroImageSrc}` : heroImageSrc;
 


### PR DESCRIPTION
## Summary
- add a hero background constant for curated pages
- default curated hero image to the constant when the page data lacks a hero image
- recompute the Open Graph image from the resolved hero image while preserving absolute URL logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc3d0ea25883249f5a43074e2c70b6