### PR TITLE
Revamp collection landing and add thank-you page

### DIFF
--- a/public/cms/config.yml
+++ b/public/cms/config.yml
@@ -16,8 +16,14 @@ collections:
     identifier_field: 'slug' # Use slug as the unique id
     slug: '{{slug}}' # File name uses the slug field
     fields:
-      - name: 'title'
-        label: 'Page Title'
+      - name: 'headline'
+        label: 'Headline'
+
+      - name: 'subheadline'
+        label: 'Subheadline'
+        widget: 'text'
+        required: false
+        default: 'Bigger lots, more value, and less traffic — get the listings now.'
 
       - name: 'slug'
         label: 'Slug (URL part)'
@@ -26,12 +32,36 @@ collections:
           - '^[a-z0-9-]+$'
           - 'Use lowercase letters, numbers, and dashes only'
 
-      - name: 'intro'
-        label: 'Intro (optional)'
-        required: false
-
       - name: 'realmLink'
         label: 'Realm Link (the private URL)'
+
+      - name: 'ctaText'
+        label: 'CTA Button Text'
+        required: false
+        default: 'Send Me the Listings'
+
+      - name: 'showWhatsappLink'
+        label: 'Show WhatsApp link in footer'
+        widget: 'boolean'
+        required: false
+        default: false
+
+      - name: 'whatsappUrl'
+        label: 'WhatsApp URL'
+        required: false
+
+      - name: 'thankYouGuideLabel'
+        label: 'Buyer’s Guide Label (optional)'
+        required: false
+
+      - name: 'thankYouGuideUrl'
+        label: 'Buyer’s Guide PDF URL (optional)'
+        required: false
+
+      - name: 'seoDescription'
+        label: 'SEO Description'
+        widget: 'text'
+        required: false
 
       - name: 'heroImage'
         label: 'Hero Image'
@@ -39,22 +69,8 @@ collections:
         required: false
         hint: 'Upload a 1920×1080 (16:9) JPG/PNG for best results.'
 
-      - name: 'highlights'
-        label: 'Highlights (optional)'
-        widget: 'list'
+      - name: 'legacyTitle'
+        label: 'Legacy Page Title'
+        widget: 'string'
         required: false
-        summary: '{{headline}}'
-        fields:
-          - name: 'icon'
-            label: 'Icon or Emoji'
-            widget: 'string'
-            required: false
-            hint: 'Use a single emoji or up to two characters.'
-          - name: 'headline'
-            label: 'Headline'
-            widget: 'string'
-            required: false
-          - name: 'supporting'
-            label: 'Supporting Text'
-            widget: 'text'
-            required: false
+        hint: 'Optional: only needed if older automations depend on the original title field.'

--- a/public/config.yml
+++ b/public/config.yml
@@ -16,40 +16,50 @@ collections:
     identifier_field: 'slug'
     slug: '{{slug}}'
     fields:
-      - name: 'title'
-        label: 'Page Title'
+      - name: 'headline'
+        label: 'Headline'
+      - name: 'subheadline'
+        label: 'Subheadline'
+        widget: 'text'
+        required: false
+        default: 'Bigger lots, more value, and less traffic — get the listings now.'
       - name: 'slug'
         label: 'Slug (URL part)'
         widget: 'string'
         pattern:
           - '^[a-z0-9-]+$'
           - 'Use lowercase letters, numbers, and dashes only'
-      - name: 'intro'
-        label: 'Intro (optional)'
-        required: false
       - name: 'realmLink'
         label: 'Realm Link (the private URL)'
+      - name: 'ctaText'
+        label: 'CTA Button Text'
+        required: false
+        default: 'Send Me the Listings'
+      - name: 'showWhatsappLink'
+        label: 'Show WhatsApp link in footer'
+        widget: 'boolean'
+        required: false
+        default: false
+      - name: 'whatsappUrl'
+        label: 'WhatsApp URL'
+        required: false
+      - name: 'thankYouGuideLabel'
+        label: 'Buyer’s Guide Label (optional)'
+        required: false
+      - name: 'thankYouGuideUrl'
+        label: 'Buyer’s Guide PDF URL (optional)'
+        required: false
+      - name: 'seoDescription'
+        label: 'SEO Description'
+        widget: 'text'
+        required: false
       - name: 'heroImage'
         label: 'Hero Image'
         widget: 'image'
         required: false
         hint: 'Upload a 1920×1080 (16:9) JPG/PNG for best results.'
-      - name: 'highlights'
-        label: 'Highlights (optional)'
-        widget: 'list'
+      - name: 'legacyTitle'
+        label: 'Legacy Page Title'
+        widget: 'string'
         required: false
-        summary: '{{headline}}'
-        fields:
-          - name: 'icon'
-            label: 'Icon or Emoji'
-            widget: 'string'
-            required: false
-            hint: 'Use a single emoji or up to two characters.'
-          - name: 'headline'
-            label: 'Headline'
-            widget: 'string'
-            required: false
-          - name: 'supporting'
-            label: 'Supporting Text'
-            widget: 'text'
-            required: false
+        hint: 'Optional: only needed if older automations depend on the original title field.'

--- a/public/data/collections/northsidegta.json
+++ b/public/data/collections/northsidegta.json
@@ -1,7 +1,14 @@
 {
-  "title": "Homes Under $1,000,000",
+  "headline": "Top 10 Homes Under $900,000 in the NorthSide GTA",
+  "subheadline": "Freshly listed detached and semi-detached homes that deliver bigger yards and less traffic — ready for you to tour.",
   "slug": "northsidegta",
-  "intro": "testing intro",
-  "realmLink": "northsidegta.ca/buyers",
-  "heroImage": "/uploads/bannerimagenew-1-.jpg"
+  "realmLink": "https://northsidegta.ca/buyers",
+  "ctaText": "Send Me the Listings",
+  "showWhatsappLink": true,
+  "whatsappUrl": "https://wa.me/16471234567",
+  "thankYouGuideLabel": "Download the NorthSide GTA Buyer’s Guide",
+  "thankYouGuideUrl": "https://northsidegta.ca/guides/buyers-guide.pdf",
+  "seoDescription": "Unlock curated NorthSide GTA homes under $900K. Bigger lots, more value, and listings you can’t find on the public sites.",
+  "heroImage": "/uploads/bannerimagenew-1-.jpg",
+  "legacyTitle": "Homes Under $1,000,000"
 }

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import VipPage          from "./vip";
 import SignWithUsPage   from "./SignWithUsPage";
 import HomeAnalysisPage from "./HomeAnalysisPage";
 import TownPage         from "./TownPage";
+import ThankYouPage     from "./ThankYouPage";
 
 // Load the town slugs right here (no helper to avoid any cyclic import)
 import towns from "./towns.json";
@@ -47,6 +48,7 @@ function App() {
         {/* Core pages */}
         <Route path="/"             element={<HomePage />} />
         <Route path="/collections/:slug" element={<CuratedPage />} />
+        <Route path="/thank-you"     element={<ThankYouPage />} />
         <Route path="/about"        element={<AboutPage />} />
         <Route path="/buyers"       element={<BuyersPage />} />
         <Route path="/sellers"      element={<SellersPage />} />

--- a/src/CuratedPage.js
+++ b/src/CuratedPage.js
@@ -19,6 +19,8 @@ function useCurated(slug) {
 }
 
 const HERO_BACKGROUND = "/Images/northside-map.svg";
+const DEFAULT_SUBHEADLINE =
+  "Bigger lots, more value, and less traffic — get the listings now.";
 
 export default function CuratedPage() {
   const { slug } = useParams();
@@ -27,207 +29,136 @@ export default function CuratedPage() {
   if (err) return <main style={{maxWidth:960,margin:"40px auto"}}>Not found.</main>;
   if (!page) return <main style={{maxWidth:960,margin:"40px auto"}}>Loading…</main>;
 
-  const heroImage =
-    typeof page.heroImage === "string" ? page.heroImage.trim() : page.heroImage;
+  const heroImage = typeof page.heroImage === "string" ? page.heroImage.trim() : page.heroImage;
   const heroImageSrc = heroImage ? heroImage : HERO_BACKGROUND;
   const site = typeof window !== "undefined" ? window.location.origin : "";
   const ogImage = heroImageSrc.startsWith("/") ? `${site}${heroImageSrc}` : heroImageSrc;
 
-  const hasHighlights = Array.isArray(page.highlights) && page.highlights.length > 0;
+  const legacyTitle =
+    (typeof page.title === "string" && page.title.trim()) ||
+    (typeof page.legacyTitle === "string" && page.legacyTitle.trim()) ||
+    "";
+  const headline =
+    (typeof page.headline === "string" && page.headline.trim()) ||
+    legacyTitle ||
+    "Curated Listings";
+  const subheadline =
+    (typeof page.subheadline === "string" && page.subheadline.trim()) || DEFAULT_SUBHEADLINE;
+  const ctaText =
+    (typeof page.ctaText === "string" && page.ctaText.trim()) || "Send Me the Listings";
+  const seoDescription =
+    (typeof page.seoDescription === "string" && page.seoDescription.trim()) || subheadline;
+
+  const redirectTopic =
+    (typeof page.slug === "string" && page.slug.trim()) ||
+    (typeof slug === "string" && slug.trim()) ||
+    headline;
+  const redirectUrl = `/thank-you?topic=${encodeURIComponent(redirectTopic)}`;
+
+  const showWhatsappFooter = Boolean(page.showWhatsappLink && page.whatsappUrl);
+  const whatsappHref = typeof page.whatsappUrl === "string" ? page.whatsappUrl.trim() : "";
 
   return (
     <>
       <Helmet>
-        <title>{page.title} • NorthSide GTA</title>
+        <title>{headline} • NorthSide GTA</title>
         {ogImage && <meta property="og:image" content={ogImage} />}
-        <meta name="description" content={page.intro || page.title} />
+        <meta name="description" content={seoDescription} />
         <meta name="robots" content="noindex,nofollow" />
       </Helmet>
 
-      {/* HERO */}
-      <section style={hero.wrap}>
-        <div style={hero.media}>
-          <img
-            src={heroImageSrc}
-            alt="Curated collection hero"
-            style={hero.image}
-          />
-        </div>
-        <div style={hero.overlay} />
-        <div style={hero.inner}>
-          <h1 style={hero.title}>{page.title}</h1>
-          {page.intro && <p style={hero.sub}>{page.intro}</p>}
-          <p style={hero.trust}>🔒 We’ll email you the private link within 10 seconds. No spam.</p>
-        </div>
-      </section>
-
-      {/* CONTENT */}
-      <main style={content.wrap}>
-        <div style={content.left}>
-          {hasHighlights && (
-            <section style={highlights.section} aria-label="Highlights">
-              <div style={highlights.inner}>
-                <h2 style={highlights.heading}>Highlights</h2>
-                <div style={highlights.list}>
-                  {page.highlights.map((item, idx) => {
-                    const icon =
-                      typeof item?.icon === "string" && item.icon.trim() ? item.icon.trim() : "✨";
-                    const title =
-                      typeof item?.headline === "string" && item.headline.trim()
-                        ? item.headline.trim()
-                        : `Highlight ${idx + 1}`;
-                    const copy =
-                      typeof item?.supporting === "string" && item.supporting.trim()
-                        ? item.supporting.trim()
-                        : "";
-                    const divider = idx !== page.highlights.length - 1 ? highlights.divider : null;
-                    return (
-                      <div key={`${title}-${idx}`} style={{ ...highlights.item, ...divider }}>
-                        <div aria-hidden="true" style={highlights.icon}>{icon}</div>
-                        <div style={highlights.textWrap}>
-                          <p style={highlights.title}>{title}</p>
-                          {copy && <p style={highlights.copy}>{copy}</p>}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            </section>
-          )}
-        </div>
-        <div style={content.right}>
-          <LeadForm slug={page.slug} title={page.title} realmLink={page.realmLink} />
-          <div style={disclosure.box}>
-            <strong>Matthew Mulhall</strong> — Real Estate Agent — HomeLife Optimum Realty — Finally Home Agents
+      <div style={layout.page}>
+        <main style={layout.main}>
+          <div style={layout.headingGroup}>
+            <h1 style={layout.headline}>{headline}</h1>
+            {subheadline && <p style={layout.subheadline}>{subheadline}</p>}
           </div>
-        </div>
-      </main>
+          <div style={layout.formWrap}>
+            <LeadForm
+              slug={(typeof page.slug === "string" && page.slug.trim()) || slug}
+              title={headline}
+              realmLink={page.realmLink}
+              ctaText={ctaText}
+              onSuccessRedirect={redirectUrl}
+            />
+          </div>
+        </main>
+
+        {showWhatsappFooter && whatsappHref && (
+          <footer style={layout.footer}>
+            <a
+              href={whatsappHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={layout.whatsappLink}
+            >
+              Prefer WhatsApp? Message us ↗
+            </a>
+          </footer>
+        )}
+      </div>
     </>
   );
 }
 
-const hero = {
-  wrap: {
-    position: "relative",
-    display: "grid",
-    alignItems: "end",
-    height: "min(65vh, clamp(280px, 55vw, 520px))",
-    overflow: "hidden",
-  },
-  media: { position: "absolute", inset: 0, overflow: "hidden" },
-  image: {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-    objectPosition: "center",
-    filter: "saturate(.95)",
-  },
-  overlay: { position: "absolute", inset: 0, background: "linear-gradient(180deg, rgba(0,0,0,.35), rgba(0,0,0,.55))" },
-  inner: { position: "relative", maxWidth: 1080, margin: "0 auto", padding: "60px 20px" },
-  title: { color: "#fff", fontSize: 36, lineHeight: 1.1, margin: 0 },
-  sub: { color: "rgba(255,255,255,.92)", fontSize: 18, marginTop: 8, maxWidth: 720 },
-  trust: { color: "rgba(255,255,255,.85)", fontSize: 13, marginTop: 14 },
-};
-
-const content = {
-  wrap: {
-    maxWidth: 1080,
-    margin: "32px auto 64px",
-    padding: "0 20px",
-    display: "grid",
-    gridTemplateColumns: "minmax(0, 1fr) 420px",
-    gap: 32,
-  },
-  left: {
+const layout = {
+  page: {
+    minHeight: "100vh",
     display: "flex",
     flexDirection: "column",
-    gap: 32,
+    justifyContent: "space-between",
+    background: "linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%)",
   },
-  right: { position: "relative" },
-};
-
-const highlights = {
-  section: {
-    position: "relative",
-    borderRadius: 28,
-    background: "linear-gradient(145deg, rgba(252,252,253,0.96), rgba(239,243,249,0.94))",
-    boxShadow: "0 18px 45px rgba(15, 23, 42, 0.08)",
-    border: "1px solid rgba(148, 163, 184, 0.12)",
-    overflow: "hidden",
-  },
-  inner: {
-    padding: "32px 32px 20px",
-  },
-  heading: {
-    margin: 0,
-    fontSize: 22,
-    fontWeight: 600,
-    letterSpacing: "-0.01em",
-    color: "#0f172a",
-  },
-  list: {
-    marginTop: 24,
+  main: {
+    flex: "1 1 auto",
     display: "flex",
     flexDirection: "column",
-  },
-  item: {
-    display: "grid",
-    gridTemplateColumns: "40px 1fr",
-    alignItems: "start",
-    gap: 18,
-    padding: "18px 0",
-  },
-  divider: {
-    borderBottom: "1px solid rgba(148, 163, 184, 0.18)",
-  },
-  icon: {
-    fontSize: 28,
-    lineHeight: "32px",
-    display: "flex",
     alignItems: "center",
     justifyContent: "center",
+    padding: "min(12vh, 120px) 20px 60px",
   },
-  textWrap: {
-    display: "flex",
-    flexDirection: "column",
-    gap: 6,
+  headingGroup: {
+    textAlign: "center",
+    maxWidth: 720,
+    marginBottom: 32,
   },
-  title: {
+  headline: {
     margin: 0,
-    fontSize: 18,
-    fontWeight: 600,
-    color: "#111827",
+    fontSize: "clamp(32px, 4vw, 46px)",
+    lineHeight: 1.05,
+    color: "#0f172a",
     letterSpacing: "-0.01em",
   },
-  copy: {
-    margin: 0,
-    fontSize: 15,
+  subheadline: {
+    marginTop: 18,
+    marginBottom: 0,
+    fontSize: 18,
     lineHeight: 1.6,
     color: "#475569",
   },
-};
-
-const disclosure = {
-  box: {
-    marginTop: 12,
+  formWrap: {
+    width: "100%",
+    maxWidth: 420,
+  },
+  footer: {
+    padding: "24px 20px",
+    display: "flex",
+    justifyContent: "center",
+  },
+  whatsappLink: {
     fontSize: 12,
-    opacity: 0.8,
-    background: "#f7f7f7",
-    border: "1px solid #eee",
-    padding: "10px 12px",
-    borderRadius: 8,
+    color: "#0f172a",
+    opacity: 0.65,
+    textDecoration: "none",
   },
 };
 
-// Mobile stack
 if (typeof window !== "undefined") {
-  const mq = window.matchMedia("(max-width: 860px)");
+  const mq = window.matchMedia("(max-width: 640px)");
   if (mq.matches) {
-    content.wrap.gridTemplateColumns = "1fr";
-    content.wrap.gap = 28;
-    content.left.gap = 24;
-    highlights.inner.padding = "28px 24px 18px";
-    highlights.item.gridTemplateColumns = "32px 1fr";
+    layout.main.padding = "80px 18px 48px";
+    layout.headingGroup.marginBottom = 28;
+    layout.headline.fontSize = 30;
+    layout.subheadline.fontSize = 16;
   }
 }

--- a/src/ThankYouPage.js
+++ b/src/ThankYouPage.js
@@ -1,0 +1,189 @@
+// src/ThankYouPage.js
+import React from "react";
+import { useLocation } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
+
+function useTopic() {
+  const location = useLocation();
+  return React.useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const value = params.get("topic") || "";
+    try {
+      return decodeURIComponent(value.replace(/\+/g, "%20"));
+    } catch (err) {
+      return value;
+    }
+  }, [location.search]);
+}
+
+function useCollection(topic) {
+  const [state, setState] = React.useState({ page: null, loading: false });
+
+  React.useEffect(() => {
+    const slug = typeof topic === "string" ? topic.trim().toLowerCase() : "";
+    if (!slug) {
+      setState({ page: null, loading: false });
+      return;
+    }
+
+    let ignore = false;
+    setState((prev) => ({ ...prev, loading: true }));
+    fetch(`/data/collections/${slug}.json`, { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error("Missing JSON");
+        return res.json();
+      })
+      .then((data) => {
+        if (!ignore) setState({ page: data, loading: false });
+      })
+      .catch(() => {
+        if (!ignore) setState({ page: null, loading: false });
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [topic]);
+
+  return state;
+}
+
+const DEFAULT_HEADLINE = "Thanks! Your listings are on the way.";
+
+export default function ThankYouPage() {
+  const topicParam = useTopic();
+  const normalizedSlug = React.useMemo(() => {
+    if (!topicParam) return "";
+    return topicParam.trim().toLowerCase().replace(/[^a-z0-9-]/g, "-");
+  }, [topicParam]);
+  const { page } = useCollection(normalizedSlug);
+
+  const topicLabel =
+    (typeof page?.headline === "string" && page.headline.trim()) ||
+    topicParam ||
+    "this request";
+
+  const whatsappUrl =
+    typeof page?.whatsappUrl === "string" && page.whatsappUrl.trim().length > 0
+      ? page.whatsappUrl.trim()
+      : "";
+
+  const guideUrl =
+    typeof page?.thankYouGuideUrl === "string" && page.thankYouGuideUrl.trim().length > 0
+      ? page.thankYouGuideUrl.trim()
+      : "";
+  const guideLabel =
+    (typeof page?.thankYouGuideLabel === "string" && page.thankYouGuideLabel.trim()) ||
+    "Download the NorthSide GTA Buyer’s Guide";
+
+  return (
+    <div style={styles.page}>
+      <Helmet>
+        <title>Thanks! Your listings are on the way. • NorthSide GTA</title>
+        <meta
+          name="description"
+          content={`We’ve just emailed the full list for ${topicLabel}. Please check your inbox (and spam).`}
+        />
+        <meta name="robots" content="noindex,nofollow" />
+      </Helmet>
+
+      <main style={styles.main}>
+        <header style={styles.header}>
+          <h1 style={styles.headline}>{DEFAULT_HEADLINE}</h1>
+          <p style={styles.subheadline}>
+            We’ve just emailed the full list for {topicLabel}. Please check your inbox (and spam).
+          </p>
+        </header>
+
+        {whatsappUrl && (
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={styles.primaryButton}
+          >
+            Save Us on WhatsApp
+          </a>
+        )}
+
+        {guideUrl && (
+          <a href={guideUrl} style={styles.secondaryLink} target="_blank" rel="noopener noreferrer">
+            {guideLabel}
+          </a>
+        )}
+
+        <p style={styles.homeLinkWrap}>
+          Or keep exploring at {" "}
+          <a href="/" style={styles.homeLink}>
+            northsidegta.ca
+          </a>
+        </p>
+      </main>
+    </div>
+  );
+}
+
+const styles = {
+  page: {
+    minHeight: "100vh",
+    background: "linear-gradient(180deg, #f8fafc 0%, #ffffff 100%)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "80px 20px",
+  },
+  main: {
+    width: "100%",
+    maxWidth: 520,
+    background: "#fff",
+    borderRadius: 24,
+    padding: "48px 40px",
+    boxShadow: "0 30px 80px rgba(15, 23, 42, 0.12)",
+    border: "1px solid rgba(15, 23, 42, 0.06)",
+    textAlign: "center",
+  },
+  header: { marginBottom: 28 },
+  headline: {
+    margin: 0,
+    fontSize: "clamp(28px, 5vw, 40px)",
+    color: "#0f172a",
+    lineHeight: 1.1,
+  },
+  subheadline: {
+    marginTop: 18,
+    marginBottom: 0,
+    fontSize: 16,
+    lineHeight: 1.7,
+    color: "#475569",
+  },
+  primaryButton: {
+    display: "inline-block",
+    marginTop: 12,
+    padding: "14px 24px",
+    borderRadius: 999,
+    background: "#0ea5e9",
+    color: "#fff",
+    fontWeight: 600,
+    textDecoration: "none",
+    boxShadow: "0 12px 30px rgba(14, 165, 233, 0.25)",
+  },
+  secondaryLink: {
+    display: "inline-block",
+    marginTop: 20,
+    fontSize: 15,
+    color: "#0f172a",
+    textDecoration: "none",
+    borderBottom: "1px solid rgba(15, 23, 42, 0.12)",
+    paddingBottom: 2,
+  },
+  homeLinkWrap: {
+    marginTop: 28,
+    fontSize: 14,
+    color: "#64748b",
+  },
+  homeLink: {
+    color: "#0f172a",
+    fontWeight: 600,
+    textDecoration: "none",
+  },
+};

--- a/src/components/LeadForm.jsx
+++ b/src/components/LeadForm.jsx
@@ -1,7 +1,17 @@
 // src/components/LeadForm.jsx
 import React from "react";
 
-export default function LeadForm({ slug, title, realmLink }) {
+const DEFAULT_HELPER =
+  "Once you submit, the full list will be sent instantly by email. We’ll also share our contact info so you can quickly book a showing or ask questions about any property.";
+
+export default function LeadForm({
+  slug,
+  title,
+  realmLink,
+  ctaText = "Send Me the Listings",
+  helperText = DEFAULT_HELPER,
+  onSuccessRedirect,
+}) {
   const [state, setState] = React.useState({
     name: "",
     email: "",
@@ -48,10 +58,9 @@ export default function LeadForm({ slug, title, realmLink }) {
       if (!res.ok) throw new Error(await res.text());
       setStatus({ loading: false, ok: true, err: "" });
 
-      // small delay, then redirect
-      setTimeout(() => {
-        window.location.href = "/"; // send to a branded page if you like
-      }, 2500);
+      if (onSuccessRedirect) {
+        window.location.href = onSuccessRedirect;
+      }
     } catch (err) {
       setStatus({ loading: false, ok: false, err: "Sorry, something went wrong. Please try again." });
     }
@@ -59,16 +68,12 @@ export default function LeadForm({ slug, title, realmLink }) {
 
   return (
     <div style={styles.card}>
-      <h3 style={{ marginBottom: 12 }}>Get the listings by email</h3>
-      <p style={{ marginTop: -4, marginBottom: 16, fontSize: 14, opacity: 0.8 }}>
-        We’ll send the link to your inbox within 10 seconds.
-      </p>
-
       <form onSubmit={onSubmit}>
         <label style={styles.label}>
           Full Name
           <input
             name="name"
+            autoComplete="name"
             value={state.name}
             onChange={onChange}
             placeholder="Jane Doe"
@@ -82,6 +87,7 @@ export default function LeadForm({ slug, title, realmLink }) {
           <input
             name="email"
             type="email"
+            autoComplete="email"
             value={state.email}
             onChange={onChange}
             placeholder="you@email.com"
@@ -94,6 +100,8 @@ export default function LeadForm({ slug, title, realmLink }) {
           Phone
           <input
             name="phone"
+            type="tel"
+            autoComplete="tel"
             value={state.phone}
             onChange={onChange}
             placeholder="(555) 555-5555"
@@ -129,19 +137,17 @@ export default function LeadForm({ slug, title, realmLink }) {
         </label>
 
         <button type="submit" disabled={status.loading} style={styles.cta}>
-          {status.loading ? "Sending…" : "Email me the listings"}
+          {status.loading ? "Sending…" : ctaText}
         </button>
 
         {status.err && <p style={{ color: "#c0392b", marginTop: 10 }}>{status.err}</p>}
-        {status.ok && (
+        {status.ok && !onSuccessRedirect && (
           <p style={{ color: "#2ecc71", marginTop: 10 }}>
-            Success! Check your inbox—the link should arrive within 10 seconds. Redirecting…
+            Success! Check your inbox—the link should arrive within 10 seconds.
           </p>
         )}
 
-        <p style={styles.finePrint}>
-          We’ll never spam. Unsubscribe anytime.
-        </p>
+        {helperText && <p style={styles.helper}>{helperText}</p>}
       </form>
     </div>
   );
@@ -154,6 +160,7 @@ const styles = {
     padding: 20,
     boxShadow: "0 10px 30px rgba(0,0,0,.08)",
     border: "1px solid rgba(0,0,0,.06)",
+    width: "100%",
   },
   label: { display: "block", fontWeight: 600, fontSize: 14, marginBottom: 10 },
   input: {
@@ -177,5 +184,5 @@ const styles = {
     border: "none",
     cursor: "pointer",
   },
-  finePrint: { marginTop: 10, fontSize: 12, opacity: 0.7 },
+  helper: { marginTop: 16, fontSize: 12.5, lineHeight: 1.6, color: "#475569" },
 };


### PR DESCRIPTION
## Summary
- redesign collection landing page to focus on the CMS-configured headline, subheadline, and lead form with optional WhatsApp footer link
- enhance the lead form with configurable CTA text, helper copy, and redirect support for the new thank-you flow
- add a dedicated thank-you page and extend CMS/data models for WhatsApp and buyer guide options

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd66ae217c8324a543378ebab09f6f