### PR TITLE
Add Formspree forwarding for leads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# NorthSide GTA Site
+
+## Environment variables
+
+- `RESEND_API_KEY` – API key used to send confirmation emails through Resend.
+- `FROM_EMAIL` – Optional custom "from" address for Resend emails.
+- `AGENT_EMAIL` – Optional BCC recipient for incoming leads.
+- `SIGNATURE_IMG_URL` – Optional URL for a signature image embedded in the lead email.
+- `FORMSPREE_ENDPOINT` – Optional Formspree endpoint that receives a copy of each lead submission. If unset, Formspree forwarding is skipped. Configure this to match your Formspree form URL (for example `https://formspree.io/f/xyzdokjk`).
+

--- a/api/send-lead.js
+++ b/api/send-lead.js
@@ -6,6 +6,7 @@ const resend = new Resend(process.env.RESEND_API_KEY)
 // --- Config -------------------------------------------------
 const ORIGIN = 'https://northsidegta.ca' // your site; add preview origin if needed
 const FROM_DEFAULT = 'NorthSide GTA <no-reply@northsidegta.ca>' // must be a verified domain in Resend
+const FORMSPREE_ENDPOINT = (process.env.FORMSPREE_ENDPOINT ?? '').trim()
 
 // --- Utils --------------------------------------------------
 function escapeHtml(str = '') {
@@ -152,6 +153,47 @@ export default async function handler(req, res) {
     if (r?.error) {
       console.error('Resend error:', r.error)
       return res.status(502).json({ ok: false, error: 'Email sending failed.' })
+    }
+
+    if (FORMSPREE_ENDPOINT) {
+      const payload = {
+        name,
+        email,
+        phone,
+        slug,
+        title,
+        casl,
+        notRepresented,
+        realmLink,
+      }
+
+      try {
+        const fsRes = await fetch(FORMSPREE_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify(payload),
+        })
+
+        if (!fsRes.ok) {
+          let bodyText = ''
+          try {
+            bodyText = await fsRes.text()
+          } catch (err) {
+            console.error('Formspree response read error:', err)
+          }
+          console.error(
+            'Formspree error:',
+            fsRes.status,
+            fsRes.statusText,
+            bodyText
+          )
+        }
+      } catch (err) {
+        console.error('Formspree request failed:', err)
+      }
     }
 
     return res.status(200).json({ ok: true })


### PR DESCRIPTION
## Summary
- add optional Formspree forwarding to the send-lead API after successful Resend sends
- log Formspree failures without blocking the response and include lead metadata in the payload
- document the FORMSPREE_ENDPOINT environment variable alongside existing email settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd76d3ca1c8324a3e239fae2d51558