### PR TITLE
Validate Formspree endpoint before posting lead payload

### DIFF
--- a/api/send-lead.js
+++ b/api/send-lead.js
@@ -156,43 +156,50 @@ export default async function handler(req, res) {
     }
 
     if (FORMSPREE_ENDPOINT) {
-      const payload = {
-        name,
-        email,
-        phone,
-        slug,
-        title,
-        casl,
-        notRepresented,
-        realmLink,
-      }
-
-      try {
-        const fsRes = await fetch(FORMSPREE_ENDPOINT, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-          body: JSON.stringify(payload),
-        })
-
-        if (!fsRes.ok) {
-          let bodyText = ''
-          try {
-            bodyText = await fsRes.text()
-          } catch (err) {
-            console.error('Formspree response read error:', err)
-          }
-          console.error(
-            'Formspree error:',
-            fsRes.status,
-            fsRes.statusText,
-            bodyText
-          )
+      if (!isHttpUrl(FORMSPREE_ENDPOINT)) {
+        console.warn(
+          'Formspree endpoint ignored (must be http/https):',
+          FORMSPREE_ENDPOINT
+        )
+      } else {
+        const payload = {
+          name,
+          email,
+          phone,
+          slug,
+          title,
+          casl,
+          notRepresented,
+          realmLink,
         }
-      } catch (err) {
-        console.error('Formspree request failed:', err)
+
+        try {
+          const fsRes = await fetch(FORMSPREE_ENDPOINT, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+            },
+            body: JSON.stringify(payload),
+          })
+
+          if (!fsRes.ok) {
+            let bodyText = ''
+            try {
+              bodyText = await fsRes.text()
+            } catch (err) {
+              console.error('Formspree response read error:', err)
+            }
+            console.error(
+              'Formspree error:',
+              fsRes.status,
+              fsRes.statusText,
+              bodyText
+            )
+          }
+        } catch (err) {
+          console.error('Formspree request failed:', err)
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure the Formspree endpoint is an http(s) URL before attempting to post
- skip the Formspree request and log a warning when the endpoint is invalid while keeping existing error logging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd862a8ab88324be29175a305d9e09