### PR TITLE
Enhance curated landing social metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "resend": "^6.0.3"
       },
       "devDependencies": {
-        "@tailwindcss/aspect-ratio": "^0.4.2"
+        "@tailwindcss/aspect-ratio": "^0.4.2",
+        "node-html-parser": "^7.0.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -11464,6 +11465,93 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.0.1.tgz",
+      "integrity": "sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "postbuild": "cp build/index.html build/404.html"
+    "postbuild": "node scripts/generate-curated-html.js && cp build/index.html build/404.html",
+    "generate:curated": "node scripts/generate-curated-html.js"
   },
   "dependencies": {
     "classmates": "^1.0.1",
@@ -34,6 +35,7 @@
     ]
   },
   "devDependencies": {
-    "@tailwindcss/aspect-ratio": "^0.4.2"
+    "@tailwindcss/aspect-ratio": "^0.4.2",
+    "node-html-parser": "^7.0.1"
   }
 }

--- a/scripts/generate-curated-html.js
+++ b/scripts/generate-curated-html.js
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("node-html-parser");
+
+const DEFAULT_SUBHEADLINE =
+  "Bigger lots, more value, and less traffic — get the listings now.";
+const DEFAULT_ORIGIN = process.env.SITE_ORIGIN || "https://northsidegta.ca";
+const DEFAULT_HERO = "/Images/northside-map.svg";
+
+const rootDir = path.resolve(__dirname, "..");
+const publicDir = path.join(rootDir, "public");
+const dataDir = path.join(publicDir, "data", "collections");
+const buildDir = path.join(rootDir, "build");
+const hasBuildTemplate = fs.existsSync(path.join(buildDir, "index.html"));
+const templatePath = hasBuildTemplate
+  ? path.join(buildDir, "index.html")
+  : path.join(publicDir, "index.html");
+const outputRoot = hasBuildTemplate
+  ? path.join(buildDir, "collections")
+  : path.join(publicDir, "collections");
+
+if (!fs.existsSync(dataDir)) {
+  console.warn(
+    `[generate-curated-html] Skipping — collections directory not found at ${path.relative(
+      rootDir,
+      dataDir
+    )}`
+  );
+  process.exit(0);
+}
+
+if (!fs.existsSync(templatePath)) {
+  console.warn(
+    `[generate-curated-html] Skipping — template not found at ${path.relative(
+      rootDir,
+      templatePath
+    )}`
+  );
+  process.exit(0);
+}
+
+const baseHtml = fs.readFileSync(templatePath, "utf8");
+const doctypeMatch = baseHtml.match(/<!DOCTYPE html[^>]*>/i);
+const doctype = doctypeMatch ? doctypeMatch[0] : "<!DOCTYPE html>";
+const templateOrigin = deriveOrigin(baseHtml) || DEFAULT_ORIGIN;
+const siteOrigin = templateOrigin || DEFAULT_ORIGIN;
+
+if (fs.existsSync(outputRoot)) {
+  fs.rmSync(outputRoot, { recursive: true, force: true });
+}
+fs.mkdirSync(outputRoot, { recursive: true });
+
+const files = fs
+  .readdirSync(dataDir)
+  .filter(name => name.toLowerCase().endsWith(".json"))
+  .sort();
+
+let created = 0;
+const failures = [];
+
+for (const file of files) {
+  const filePath = path.join(dataDir, file);
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    failures.push({ file, reason: `Invalid JSON (${error.message})` });
+    continue;
+  }
+
+  const fallbackSlug = file.replace(/\.json$/i, "");
+  const slug = sanitizeSlug(fallbackSlug, fallbackSlug);
+
+  if (!slug) {
+    failures.push({ file, reason: "Missing slug" });
+    continue;
+  }
+
+  const meta = computeMeta(raw, slug, siteOrigin);
+  const html = buildHtml(baseHtml, doctype, meta);
+
+  const targetDir = path.join(outputRoot, slug);
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(path.join(targetDir, "index.html"), html, "utf8");
+  created += 1;
+}
+
+if (created) {
+  console.log(
+    `[generate-curated-html] Created ${created} curated page${
+      created === 1 ? "" : "s"
+    } using ${path.relative(rootDir, templatePath)} → ${path.relative(
+      rootDir,
+      outputRoot
+    )}`
+  );
+}
+
+if (failures.length) {
+  failures.forEach(failure => {
+    console.warn(
+      `[generate-curated-html] Skipped ${failure.file}: ${failure.reason}`
+    );
+  });
+  process.exitCode = 1;
+}
+
+function deriveOrigin(html) {
+  try {
+    const doc = parse(html);
+    const canonical = doc.querySelector('link[rel="canonical"]');
+    if (canonical) {
+      const href = canonical.getAttribute("href");
+      if (href) {
+        return new URL(href).origin;
+      }
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
+function sanitizeSlug(value, fallback) {
+  const raw = cleanString(value) || cleanString(fallback);
+  if (!raw) return "";
+  return raw.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9/_-]/g, "-");
+}
+
+function computeMeta(data, slug, origin) {
+  const legacyTitle = cleanString(data.title) || cleanString(data.legacyTitle);
+  const headline = cleanString(data.headline) || legacyTitle || "Curated Listings";
+  const subheadline = cleanString(data.subheadline) || DEFAULT_SUBHEADLINE;
+  const seoDescription = collapseWhitespace(
+    cleanString(data.seoDescription) || subheadline
+  );
+  const heroImageValue = cleanString(data.heroImage) || DEFAULT_HERO;
+  const slugTextSource = cleanString(data.slug) || slug;
+  const heroAltBase =
+    headline || slugTextSource.replace(/[-_]+/g, " ").trim() || "NorthSide GTA";
+
+  const canonicalUrl = buildUrl(origin, `/collections/${encodeSlug(slug)}`);
+  const ogImage = absoluteUrl(origin, heroImageValue);
+  const pageTitle = `${headline} • NorthSide GTA`;
+  const heroAltText = `${heroAltBase} hero image`;
+  const twitterCard = ogImage ? "summary_large_image" : "summary";
+
+  return {
+    slug,
+    headline,
+    pageTitle,
+    seoDescription,
+    canonicalUrl,
+    ogImage,
+    heroAltText,
+    twitterCard,
+  };
+}
+
+function buildHtml(template, doctypeValue, meta) {
+  const doc = parse(template, { comment: true });
+  const head = doc.querySelector("head");
+  if (!head) {
+    throw new Error("Template is missing <head>");
+  }
+
+  head.querySelectorAll("title").forEach(node => node.remove());
+  head
+    .querySelectorAll("meta")
+    .forEach(node => {
+      const name = (node.getAttribute("name") || "").toLowerCase();
+      const property = (node.getAttribute("property") || "").toLowerCase();
+      if (
+        name === "description" ||
+        name === "keywords" ||
+        name === "robots" ||
+        name.startsWith("twitter:") ||
+        property.startsWith("og:")
+      ) {
+        node.remove();
+      }
+    });
+  head
+    .querySelectorAll('link[rel="canonical"]')
+    .forEach(node => node.remove());
+
+  append(head, `<title>${escapeHtml(meta.pageTitle)}</title>`);
+  append(
+    head,
+    `<meta name="description" content="${escapeAttribute(meta.seoDescription)}" />`
+  );
+  append(head, `<meta name="robots" content="noindex,nofollow" />`);
+  append(
+    head,
+    `<link rel="canonical" href="${escapeAttribute(meta.canonicalUrl)}" />`
+  );
+  append(
+    head,
+    `<meta property="og:title" content="${escapeAttribute(meta.pageTitle)}" />`
+  );
+  append(
+    head,
+    `<meta property="og:description" content="${escapeAttribute(meta.seoDescription)}" />`
+  );
+  append(
+    head,
+    `<meta property="og:url" content="${escapeAttribute(meta.canonicalUrl)}" />`
+  );
+  append(head, `<meta property="og:type" content="website" />`);
+  if (meta.ogImage) {
+    append(
+      head,
+      `<meta property="og:image" content="${escapeAttribute(meta.ogImage)}" />`
+    );
+    append(
+      head,
+      `<meta property="og:image:alt" content="${escapeAttribute(meta.heroAltText)}" />`
+    );
+  }
+  append(
+    head,
+    `<meta name="twitter:card" content="${escapeAttribute(meta.twitterCard)}" />`
+  );
+  append(
+    head,
+    `<meta name="twitter:title" content="${escapeAttribute(meta.pageTitle)}" />`
+  );
+  append(
+    head,
+    `<meta name="twitter:description" content="${escapeAttribute(meta.seoDescription)}" />`
+  );
+  append(
+    head,
+    `<meta name="twitter:url" content="${escapeAttribute(meta.canonicalUrl)}" />`
+  );
+  if (meta.ogImage) {
+    append(
+      head,
+      `<meta name="twitter:image" content="${escapeAttribute(meta.ogImage)}" />`
+    );
+    append(
+      head,
+      `<meta name="twitter:image:alt" content="${escapeAttribute(meta.heroAltText)}" />`
+    );
+  }
+
+  let html = doc.toString();
+  if (!/^<!DOCTYPE html/i.test(html)) {
+    html = `${doctypeValue}\n${html}`;
+  }
+  return html;
+}
+
+function cleanString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function collapseWhitespace(value) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function encodeSlug(slug) {
+  return slug
+    .split("/")
+    .map(segment => encodeURIComponent(segment))
+    .join("/");
+}
+
+function buildUrl(origin, targetPath) {
+  if (!origin) {
+    return targetPath;
+  }
+  const normalizedOrigin = origin.endsWith("/") ? origin : `${origin}/`;
+  const normalizedPath = targetPath.startsWith("/")
+    ? targetPath.slice(1)
+    : targetPath;
+  try {
+    return new URL(normalizedPath, normalizedOrigin).toString();
+  } catch (error) {
+    return `${normalizedOrigin}${normalizedPath}`;
+  }
+}
+
+function absoluteUrl(origin, value) {
+  if (!value) return "";
+  if (/^https?:\/\//i.test(value)) {
+    return value;
+  }
+  const normalized = value.startsWith("/") ? value : `/${value}`;
+  return buildUrl(origin, normalized);
+}
+
+function append(node, html) {
+  node.insertAdjacentHTML("beforeend", `\n    ${html}`);
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value).replace(/"/g, "&quot;");
+}

--- a/src/CuratedPage.js
+++ b/src/CuratedPage.js
@@ -31,8 +31,18 @@ export default function CuratedPage() {
 
   const heroImage = typeof page.heroImage === "string" ? page.heroImage.trim() : page.heroImage;
   const heroImageSrc = heroImage ? heroImage : HERO_BACKGROUND;
-  const site = typeof window !== "undefined" ? window.location.origin : "";
-  const ogImage = heroImageSrc.startsWith("/") ? `${site}${heroImageSrc}` : heroImageSrc;
+  const defaultOrigin = "https://northsidegta.ca";
+  const site =
+    typeof window !== "undefined" && window.location
+      ? window.location.origin
+      : defaultOrigin;
+  const absoluteUrl = path => {
+    if (!path) return "";
+    if (/^https?:\/\//i.test(path)) return path;
+    const normalized = path.startsWith("/") ? path : `/${path}`;
+    return `${site.replace(/\/$/, "")}${normalized}`;
+  };
+  const ogImage = absoluteUrl(heroImageSrc);
 
   const legacyTitle =
     (typeof page.title === "string" && page.title.trim()) ||
@@ -58,17 +68,35 @@ export default function CuratedPage() {
   const showWhatsappFooter = Boolean(page.showWhatsappLink && page.whatsappUrl);
   const whatsappHref = typeof page.whatsappUrl === "string" ? page.whatsappUrl.trim() : "";
 
-  const slugText =
-    typeof slug === "string" ? slug.replace(/[-_]+/g, " ").trim() : "";
+  const slugValue = typeof slug === "string" ? slug.trim() : "";
+  const slugText = slugValue ? slugValue.replace(/[-_]+/g, " ").trim() : "";
   const heroAltText = `${headline || slugText || "NorthSide GTA"} hero image`;
+  const canonicalUrl =
+    typeof window !== "undefined" && window.location
+      ? window.location.href
+      : absoluteUrl(`/collections/${encodeURIComponent(slugValue)}`);
+  const pageTitle = `${headline} • NorthSide GTA`;
+  const twitterCardType = ogImage ? "summary_large_image" : "summary";
 
   return (
     <>
       <Helmet>
-        <title>{headline} • NorthSide GTA</title>
-        {ogImage && <meta property="og:image" content={ogImage} />}
+        <title>{pageTitle}</title>
         <meta name="description" content={seoDescription} />
         <meta name="robots" content="noindex,nofollow" />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={seoDescription} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:type" content="website" />
+        {ogImage && <meta property="og:image" content={ogImage} />}
+        {ogImage && <meta property="og:image:alt" content={heroAltText} />}
+        <meta name="twitter:card" content={twitterCardType} />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={seoDescription} />
+        <meta name="twitter:url" content={canonicalUrl} />
+        {ogImage && <meta name="twitter:image" content={ogImage} />}
+        {ogImage && <meta name="twitter:image:alt" content={heroAltText} />}
       </Helmet>
 
       <div style={layout.page}>


### PR DESCRIPTION
## Summary
- expand the curated landing Helmet configuration to emit canonical, Open Graph, and Twitter tags derived from each collection's data
- add a Node build script that renders per-collection HTML files with the customized metadata and hook it into the postbuild step
- include node-html-parser as a dev dependency and expose an npm script for regenerating the curated HTML on demand

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda79cfe9083249ff1c2aeeb7292d6