### PR TITLE
Reposition map hero ticker under map card

### DIFF
--- a/public/Images/northsidegta-logo.svg
+++ b/public/Images/northsidegta-logo.svg
@@ -1,0 +1,42 @@
+<svg width="128" height="40" viewBox="0 0 128 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="128" height="40" rx="12" fill="#064E3B" />
+  <rect x="6" y="6" width="28" height="28" rx="9" fill="url(#paint0_linear_1_1)" />
+  <path
+    d="M20.4 25.6L17.08 21.16C16.92 20.96 16.78 20.74 16.66 20.52L14.4 16.64C13.78 15.56 14.54 14.2 15.76 14.2H20.74C21.18 14.2 21.6 14.44 21.82 14.82L23.54 17.8C23.78 18.2 23.78 18.72 23.52 19.12L22.48 20.76C22.32 21 22.32 21.32 22.5 21.56L24.12 23.68C24.72 24.48 24.16 25.6 23.18 25.6H20.4Z"
+    fill="white"
+    opacity="0.95"
+  />
+  <path
+    d="M18.28 26.2H21.72C22.16 26.2 22.58 26.44 22.8 26.82L23.64 28.2C24.12 29 23.54 30 22.6 30H17.56C16.34 30 15.58 28.64 16.2 27.56L17.4 25.48C17.58 25.16 18.04 25.18 18.2 25.5L18.52 26.14C18.6 26.22 18.66 26.2 18.74 26.2H18.28Z"
+    fill="#ECFDF5"
+    opacity="0.95"
+  />
+  <text
+    x="42"
+    y="19"
+    fill="#ECFDF5"
+    font-family="'Blinker', 'Arial', 'sans-serif'"
+    font-size="13"
+    font-weight="700"
+    letter-spacing="0.18em"
+  >
+    NORTHSIDE
+  </text>
+  <text
+    x="42"
+    y="29"
+    fill="#6EE7B7"
+    font-family="'Blinker', 'Arial', 'sans-serif'"
+    font-size="11"
+    font-weight="600"
+    letter-spacing="0.42em"
+  >
+    GTA
+  </text>
+  <defs>
+    <linearGradient id="paint0_linear_1_1" x1="6" y1="6" x2="34" y2="34" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#059669" />
+      <stop offset="1" stop-color="#047857" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/MapHero.js
+++ b/src/MapHero.js
@@ -274,9 +274,9 @@ function ComparisonBar({ className = "" }) {
   const cur = items[i];
 
   return (
-    <div className={`pointer-events-none ${className}`}>
+    <div className={`pointer-events-none w-full ${className}`}>
       <div
-        className="pointer-events-auto relative mx-auto w-[min(92vw,520px)] overflow-hidden rounded-2xl border border-emerald-400/60 shadow-[0_22px_48px_-24px_rgba(16,185,129,0.85)] backdrop-blur-md"
+        className="pointer-events-auto relative w-full overflow-hidden rounded-2xl border border-emerald-400/60 shadow-[0_22px_48px_-24px_rgba(16,185,129,0.85)] backdrop-blur-md"
         style={{
           background:
             "linear-gradient(140deg, rgba(7,16,21,0.88) 0%, rgba(6,56,41,0.92) 45%, rgba(6,78,59,0.9) 100%)",
@@ -328,9 +328,14 @@ function ComparisonBar({ className = "" }) {
                   NorthSide GTA
                 </span>
               </div>
-              <span className="flex h-8 w-8 items-center justify-center rounded-full border border-emerald-300/60 bg-emerald-500/40 text-[11px] font-bold uppercase tracking-[0.24em] text-emerald-50 shadow-[inset_0_0_14px_rgba(16,185,129,0.55)]">
-                NSG
-              </span>
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-emerald-300/60 bg-emerald-500/30 p-1 shadow-[inset_0_0_14px_rgba(16,185,129,0.45)]">
+                <img
+                  src="/Images/northsidegta-logo.svg"
+                  alt="NorthSide GTA logo"
+                  className="h-full w-auto"
+                  loading="lazy"
+                />
+              </div>
             </div>
           </div>
 
@@ -418,7 +423,6 @@ export default function MapHero() {
             className="relative rounded-xl overflow-hidden"
             onMouseLeave={() => canHover && setHoverId(null)}
           >
-            <ComparisonBar className="absolute left-1/2 top-3 z-20 w-[min(94vw,520px)] -translate-x-1/2 md:top-5 lg:top-8" />
             {/* Keep natural aspect ratio so pin percentages line up EXACTLY */}
             <img
               src="/Images/northside-map.svg?v=2"
@@ -501,6 +505,8 @@ export default function MapHero() {
               </div>
             )}
           </div>
+
+          <ComparisonBar className="mt-4 lg:mt-5" />
 
           {/* MOBILE: panel below the map when a pin is tapped */}
           {!canHover && activeTown && (


### PR DESCRIPTION
## Summary
- move the MapHero live matchup ticker below the map inside the rounded card with responsive spacing
- update ticker styling so the comparison bar stretches to the card width without overlaying the map
- swap the NSG text badge for the official NorthSide GTA SVG logo with broadcast-style framing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d14c94b4a4832483d3e5315a2b7da7