### PR TITLE
Fix WhatsApp links for curated landing pages

### DIFF
--- a/public/config.yml
+++ b/public/config.yml
@@ -43,6 +43,10 @@ collections:
       - name: 'whatsappUrl'
         label: 'WhatsApp URL'
         required: false
+        pattern:
+          - '^https://wa\.me/[0-9]+.*$'
+          - 'Enter a link like https://wa.me/16476684646 with the full phone number.'
+        hint: 'Use https://wa.me/<number> optionally followed by ?text=… for a prefilled message.'
       - name: 'thankYouGuideLabel'
         label: 'Buyer’s Guide Label (optional)'
         required: false

--- a/public/data/collections/northside-gta-pool-homes.json
+++ b/public/data/collections/northside-gta-pool-homes.json
@@ -5,7 +5,7 @@
   "slug": "northside-gta-pool-homes",
   "subheadline": "Weeknights that feel like long weekends—poolside by next summer.",
   "headline": "NorthSide GTA — Pool Homes (Current Top Picks)",
-  "whatsappUrl": "Add us on WhatsApp",
+  "whatsappUrl": "https://wa.me/16476684646",
   "ctaText": "Send Me the Pool-Home List",
   "seoDescription": "Be poolside by next summer: get our curated list of NorthSide GTA pool homes delivered instantly—bigger lots, more value, less traffic.\n"
 }

--- a/public/data/collections/northsidegta.json
+++ b/public/data/collections/northsidegta.json
@@ -5,7 +5,7 @@
   "realmLink": "https://northsidegta.ca/buyers",
   "ctaText": "Send Me the Listings",
   "showWhatsappLink": true,
-  "whatsappUrl": "https://wa.me/16471234567",
+  "whatsappUrl": "https://wa.me/16476684646",
   "thankYouGuideLabel": "Download the NorthSide GTA Buyer’s Guide",
   "thankYouGuideUrl": "https://northsidegta.ca/guides/buyers-guide.pdf",
   "seoDescription": "Unlock curated NorthSide GTA homes under $900K. Bigger lots, more value, and listings you can’t find on the public sites.",

--- a/public/data/collections/slugtest.json
+++ b/public/data/collections/slugtest.json
@@ -5,6 +5,6 @@
   "headline": "Headline",
   "slug": "slugtest",
   "realmLink": "https://northsidegta.ca/buyers",
-  "whatsappUrl": "Connect With Us on WhatsApp",
+  "whatsappUrl": "https://wa.me/16476684646",
   "heroImage": "/uploads/northsidegta-map-bg.jpg"
 }


### PR DESCRIPTION
## Summary
- point WhatsApp CTA links in curated collection JSON files to the active NorthSide GTA number
- enforce wa.me URL format in the CMS config to avoid future typos

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d174f331d083249dc053411f9eda53