### PR TITLE
Ensure EventMap loads Leaflet CSS client-side and compact filters

### DIFF
--- a/src/community/EventFilters.css
+++ b/src/community/EventFilters.css
@@ -1,0 +1,96 @@
+.community-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+@media (min-width: 768px) {
+  .community-filters {
+    padding: 0.75rem 1.5rem;
+  }
+}
+
+.community-filters__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.community-filters__header > * {
+  flex: 1 1 240px;
+}
+
+.community-filters__header button {
+  flex: 0 0 auto;
+}
+
+.community-filters__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.community-filters__fieldset {
+  flex: 1 1 calc(25% - 0.75rem);
+  min-width: 200px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.community-filters__fieldset legend {
+  margin-bottom: 0;
+}
+
+.community-filters__chip-list {
+  gap: 0.5rem;
+}
+
+.community-filters__chip-list button {
+  min-height: 2.25rem;
+  line-height: 1.25;
+}
+
+.community-filters__custom-range {
+  gap: 0.5rem;
+}
+
+.community-filters__custom-range label {
+  flex: 1 1 150px;
+}
+
+.community-filters__custom-range input[type='date'] {
+  min-height: 2.25rem;
+}
+
+.community-filters button,
+.community-filters input[type='search'],
+.community-filters input[type='date'] {
+  font-size: 0.875rem;
+}
+
+@media (max-width: 1200px) {
+  .community-filters__fieldset {
+    flex: 1 1 calc(33.333% - 0.75rem);
+  }
+}
+
+@media (max-width: 900px) {
+  .community-filters__fieldset {
+    flex: 1 1 calc(50% - 0.75rem);
+  }
+}
+
+@media (max-width: 680px) {
+  .community-filters__fieldset {
+    flex: 1 1 100%;
+  }
+}

--- a/src/community/EventFilters.js
+++ b/src/community/EventFilters.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Search, RotateCcw } from 'lucide-react'
 import { CATEGORY_OPTIONS, PRICE_OPTIONS, TOWN_OPTIONS } from './eventUtils'
+import './EventFilters.css'
 
 const DATE_RANGES = [
   { value: 'upcoming', label: 'Upcoming' },
@@ -44,11 +45,11 @@ export default function EventFilters({ filters, onChange, onReset }) {
 
   return (
     <section
-      className="sticky top-[72px] z-30 border-b border-slate-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80"
+      className="sticky top-[var(--site-header-h,72px)] z-30 border-b border-slate-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80"
     >
-      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-6">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <label className="flex w-full items-center gap-3 rounded-full border border-slate-200 bg-white px-4 py-2 shadow-sm focus-within:border-emerald-500 focus-within:ring-2 focus-within:ring-emerald-200">
+      <div className="community-filters mx-auto max-w-6xl">
+        <div className="community-filters__header">
+          <label className="flex w-full items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 shadow-sm focus-within:border-emerald-500 focus-within:ring-2 focus-within:ring-emerald-200">
             <Search className="h-4 w-4 text-slate-500" aria-hidden="true" />
             <span className="sr-only">Search events</span>
             <input
@@ -62,25 +63,25 @@ export default function EventFilters({ filters, onChange, onReset }) {
           <button
             type="button"
             onClick={() => onReset?.()}
-            className={`inline-flex items-center gap-2 self-start rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300 hover:text-slate-900 ${interactiveClass}`}
+            className={`inline-flex items-center gap-1.5 self-start rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:border-slate-300 hover:text-slate-900 ${interactiveClass}`}
           >
             <RotateCcw className="h-4 w-4" aria-hidden="true" />
             Reset
           </button>
         </div>
 
-        <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
-          <fieldset className="space-y-3">
+        <div className="community-filters__grid">
+          <fieldset className="community-filters__fieldset">
             <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
               Date range
             </legend>
-            <div className="flex flex-wrap gap-2">
+            <div className="community-filters__chip-list flex flex-wrap gap-2">
               {DATE_RANGES.map((option) => (
                 <button
                   key={option.value}
                   type="button"
                   onClick={() => setFilter('dateRange', option.value)}
-                  className={`inline-flex items-center rounded-full border px-4 py-1.5 text-xs font-medium ${interactiveClass} ${
+                  className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
                     filters.dateRange === option.value
                       ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
                       : 'border-slate-200 text-slate-600 hover:border-slate-300'
@@ -91,12 +92,12 @@ export default function EventFilters({ filters, onChange, onReset }) {
               ))}
             </div>
             {filters.dateRange === 'custom' && (
-              <div className="flex flex-col gap-3 sm:flex-row">
+              <div className="community-filters__custom-range flex flex-col gap-2 sm:flex-row">
                 <label className="flex flex-col text-xs text-slate-500">
                   From
                   <input
                     type="date"
-                    className="mt-1 rounded-md border border-slate-200 px-3 py-2 text-sm"
+                    className="mt-1 rounded-md border border-slate-200 px-3 py-1.5 text-sm"
                     value={filters.customStart}
                     onChange={(event) => setFilter('customStart', event.target.value)}
                   />
@@ -105,7 +106,7 @@ export default function EventFilters({ filters, onChange, onReset }) {
                   To
                   <input
                     type="date"
-                    className="mt-1 rounded-md border border-slate-200 px-3 py-2 text-sm"
+                    className="mt-1 rounded-md border border-slate-200 px-3 py-1.5 text-sm"
                     value={filters.customEnd}
                     onChange={(event) => setFilter('customEnd', event.target.value)}
                   />
@@ -114,17 +115,17 @@ export default function EventFilters({ filters, onChange, onReset }) {
             )}
           </fieldset>
 
-          <fieldset className="space-y-3">
+          <fieldset className="community-filters__fieldset">
             <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
               Category
             </legend>
-            <div className="flex flex-wrap gap-2">
+            <div className="community-filters__chip-list flex flex-wrap gap-2">
               {CATEGORY_OPTIONS.map((category) => (
                 <button
                   key={category}
                   type="button"
                   onClick={() => setFilter('categories', toggleValue(filters.categories, category))}
-                  className={`inline-flex items-center rounded-full border px-4 py-1.5 text-xs font-medium ${interactiveClass} ${
+                  className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
                     filters.categories.includes(category)
                       ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
                       : 'border-slate-200 text-slate-600 hover:border-slate-300'
@@ -136,17 +137,17 @@ export default function EventFilters({ filters, onChange, onReset }) {
             </div>
           </fieldset>
 
-          <fieldset className="space-y-3">
+          <fieldset className="community-filters__fieldset">
             <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
               Town / Area
             </legend>
-            <div className="flex flex-wrap gap-2">
+            <div className="community-filters__chip-list flex flex-wrap gap-2">
               {TOWN_OPTIONS.map((town) => (
                 <button
                   key={town}
                   type="button"
                   onClick={() => setFilter('towns', toggleValue(filters.towns, town))}
-                  className={`inline-flex items-center rounded-full border px-4 py-1.5 text-xs font-medium ${interactiveClass} ${
+                  className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
                     filters.towns.includes(town)
                       ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
                       : 'border-slate-200 text-slate-600 hover:border-slate-300'
@@ -158,17 +159,17 @@ export default function EventFilters({ filters, onChange, onReset }) {
             </div>
           </fieldset>
 
-          <fieldset className="space-y-3">
+          <fieldset className="community-filters__fieldset">
             <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
               Price
             </legend>
-            <div className="flex flex-wrap gap-2">
+            <div className="community-filters__chip-list flex flex-wrap gap-2">
               {PRICE_OPTIONS.map((price) => (
                 <button
                   key={price}
                   type="button"
                   onClick={() => setFilter('price', toggleValue(filters.price, price))}
-                  className={`inline-flex items-center rounded-full border px-4 py-1.5 text-xs font-medium ${interactiveClass} ${
+                  className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
                     filters.price.includes(price)
                       ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
                       : 'border-slate-200 text-slate-600 hover:border-slate-300'

--- a/src/community/EventMap.js
+++ b/src/community/EventMap.js
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet'
 import L from 'leaflet'


### PR DESCRIPTION
## Summary
- mark the community EventMap component as a client component so Leaflet assets load only in the browser
- tighten the Community page filter controls with new scoped styles that reduce padding, align items, and wrap responsively under the header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1dd152cb883249100aba28f041055