### PR TITLE
Fix Leaflet icons and compact community filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "classnames": "^2.5.1",
         "emailjs-com": "^3.2.0",
         "leaflet": "^1.9.4",
+        "leaflet-defaulticon-compatibility": "^0.1.1",
         "lucide-react": "^0.522.0",
         "node-ical": "^0.21.0",
         "react": "^18.2.0",
@@ -11012,6 +11013,12 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet-defaulticon-compatibility": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/leaflet-defaulticon-compatibility/-/leaflet-defaulticon-compatibility-0.1.2.tgz",
+      "integrity": "sha512-IrKagWxkTwzxUkFIumy/Zmo3ksjuAu3zEadtOuJcKzuXaD76Gwvg2Z1mLyx7y52ykOzM8rAH5ChBs4DnfdGa6Q==",
       "license": "BSD-2-Clause"
     },
     "node_modules/leven": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "classnames": "^2.5.1",
     "emailjs-com": "^3.2.0",
     "leaflet": "^1.9.4",
+    "leaflet-defaulticon-compatibility": "^0.1.1",
     "lucide-react": "^0.522.0",
     "node-ical": "^0.21.0",
     "react": "^18.2.0",

--- a/src/community/EventFilters.js
+++ b/src/community/EventFilters.js
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Search, RotateCcw } from 'lucide-react'
+import { Search } from 'lucide-react'
 import { CATEGORY_OPTIONS, PRICE_OPTIONS, TOWN_OPTIONS } from './eventUtils'
 import './EventFilters.css'
+import './filters.compact.css'
 
 const DATE_RANGES = [
   { value: 'upcoming', label: 'Upcoming' },
@@ -35,160 +36,230 @@ function toggleValue(list, value) {
   return Array.from(set)
 }
 
+const FILTERS_OPEN_STORAGE_KEY = 'communityFiltersOpen'
+
 export default function EventFilters({ filters, onChange, onReset }) {
+  const [isOpen, setIsOpen] = React.useState(() => {
+    if (typeof window === 'undefined') return false
+    const stored = window.sessionStorage.getItem(FILTERS_OPEN_STORAGE_KEY)
+    return stored === 'true'
+  })
   const prefersReducedMotion = usePrefersReducedMotion()
   const interactiveClass = prefersReducedMotion ? '' : 'transition'
+  const searchInputRef = React.useRef(null)
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.sessionStorage.setItem(FILTERS_OPEN_STORAGE_KEY, isOpen ? 'true' : 'false')
+  }, [isOpen])
+
+  const focusSearch = React.useCallback(() => {
+    setIsOpen(true)
+    if (typeof window !== 'undefined') {
+      window.requestAnimationFrame(() => {
+        searchInputRef.current?.focus()
+      })
+    } else {
+      searchInputRef.current?.focus()
+    }
+  }, [])
+
+  const toggleOpen = React.useCallback(() => {
+    setIsOpen((value) => !value)
+  }, [])
+
+  const activeCount = React.useMemo(() => {
+    let count = 0
+    if (filters.search?.trim()) count += 1
+    if (filters.dateRange && filters.dateRange !== 'upcoming') {
+      count += 1
+      if (filters.dateRange === 'custom') {
+        if (filters.customStart) count += 1
+        if (filters.customEnd) count += 1
+      }
+    }
+    count += filters.categories?.length || 0
+    count += filters.towns?.length || 0
+    count += filters.price?.length || 0
+    if (filters.showPast) count += 1
+    return count
+  }, [filters])
 
   const setFilter = (key, value) => {
     onChange({ ...filters, [key]: value })
   }
 
   return (
-    <section
-      className="sticky top-[var(--site-header-h,72px)] z-30 border-b border-slate-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80"
-    >
-      <div className="community-filters mx-auto max-w-6xl">
-        <div className="community-filters__header">
-          <label className="flex w-full items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 shadow-sm focus-within:border-emerald-500 focus-within:ring-2 focus-within:ring-emerald-200">
-            <Search className="h-4 w-4 text-slate-500" aria-hidden="true" />
-            <span className="sr-only">Search events</span>
-            <input
-              type="search"
-              placeholder="Search events"
-              className="w-full border-none bg-transparent text-sm outline-none"
-              value={filters.search}
-              onChange={(event) => setFilter('search', event.target.value)}
-            />
-          </label>
-          <button
-            type="button"
-            onClick={() => onReset?.()}
-            className={`inline-flex items-center gap-1.5 self-start rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:border-slate-300 hover:text-slate-900 ${interactiveClass}`}
-          >
-            <RotateCcw className="h-4 w-4" aria-hidden="true" />
-            Reset
+    <section className="mx-auto max-w-6xl px-4 pt-6 sm:px-6">
+      <div id="community-filters" className="w-full">
+        <div className="filters-toolbar">
+          <button className="btn-icon" type="button" aria-label="Search" onClick={focusSearch}>
+            🔍
           </button>
+          <div className="toolbar-summary">
+            <span className="summary-label">Filters</span>
+            <span className="summary-count" aria-live="polite">
+              ({activeCount})
+            </span>
+          </div>
+          <div className="toolbar-actions">
+            <button
+              className="btn-link"
+              type="button"
+              onClick={toggleOpen}
+              aria-expanded={isOpen}
+              aria-controls="filters-panel"
+            >
+              {isOpen ? 'Collapse' : 'Expand'}
+            </button>
+            <button className="btn-link danger" type="button" onClick={() => onReset?.()}>
+              Reset
+            </button>
+          </div>
         </div>
 
-        <div className="community-filters__grid">
-          <fieldset className="community-filters__fieldset">
-            <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-              Date range
-            </legend>
-            <div className="community-filters__chip-list flex flex-wrap gap-2">
-              {DATE_RANGES.map((option) => (
-                <button
-                  key={option.value}
-                  type="button"
-                  onClick={() => setFilter('dateRange', option.value)}
-                  className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
-                    filters.dateRange === option.value
-                      ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
-                      : 'border-slate-200 text-slate-600 hover:border-slate-300'
-                  }`}
-                >
-                  {option.label}
-                </button>
-              ))}
+        <div
+          id="filters-panel"
+          className={`filters-panel ${isOpen ? 'open' : 'collapsed'}`}
+          aria-hidden={!isOpen}
+        >
+          <div className="community-filters">
+            <div className="community-filters__header">
+              <label className="flex w-full items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 shadow-sm focus-within:border-emerald-500 focus-within:ring-2 focus-within:ring-emerald-200 filters-search">
+                <Search className="h-4 w-4 text-slate-500" aria-hidden="true" />
+                <span className="sr-only">Search events</span>
+                <input
+                  ref={searchInputRef}
+                  type="search"
+                  placeholder="Search events"
+                  className="w-full border-none bg-transparent text-sm outline-none"
+                  value={filters.search}
+                  onChange={(event) => setFilter('search', event.target.value)}
+                />
+              </label>
             </div>
-            {filters.dateRange === 'custom' && (
-              <div className="community-filters__custom-range flex flex-col gap-2 sm:flex-row">
-                <label className="flex flex-col text-xs text-slate-500">
-                  From
+
+            <div className="community-filters__grid">
+              <fieldset className="community-filters__fieldset">
+                <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Date range
+                </legend>
+                <div className="community-filters__chip-list flex flex-wrap gap-2">
+                  {DATE_RANGES.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setFilter('dateRange', option.value)}
+                      className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
+                        filters.dateRange === option.value
+                          ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
+                          : 'border-slate-200 text-slate-600 hover:border-slate-300'
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+                {filters.dateRange === 'custom' && (
+                  <div className="community-filters__custom-range flex flex-col gap-2 sm:flex-row">
+                    <label className="flex flex-col text-xs text-slate-500">
+                      From
+                      <input
+                        type="date"
+                        className="mt-1 rounded-md border border-slate-200 px-3 py-1.5 text-sm"
+                        value={filters.customStart}
+                        onChange={(event) => setFilter('customStart', event.target.value)}
+                      />
+                    </label>
+                    <label className="flex flex-col text-xs text-slate-500">
+                      To
+                      <input
+                        type="date"
+                        className="mt-1 rounded-md border border-slate-200 px-3 py-1.5 text-sm"
+                        value={filters.customEnd}
+                        onChange={(event) => setFilter('customEnd', event.target.value)}
+                      />
+                    </label>
+                  </div>
+                )}
+              </fieldset>
+
+              <fieldset className="community-filters__fieldset">
+                <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Category
+                </legend>
+                <div className="community-filters__chip-list flex flex-wrap gap-2">
+                  {CATEGORY_OPTIONS.map((category) => (
+                    <button
+                      key={category}
+                      type="button"
+                      onClick={() => setFilter('categories', toggleValue(filters.categories, category))}
+                      className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
+                        filters.categories.includes(category)
+                          ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
+                          : 'border-slate-200 text-slate-600 hover:border-slate-300'
+                      }`}
+                    >
+                      {category}
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+
+              <fieldset className="community-filters__fieldset">
+                <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Town / Area
+                </legend>
+                <div className="community-filters__chip-list flex flex-wrap gap-2">
+                  {TOWN_OPTIONS.map((town) => (
+                    <button
+                      key={town}
+                      type="button"
+                      onClick={() => setFilter('towns', toggleValue(filters.towns, town))}
+                      className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
+                        filters.towns.includes(town)
+                          ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
+                          : 'border-slate-200 text-slate-600 hover:border-slate-300'
+                      }`}
+                    >
+                      {town}
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+
+              <fieldset className="community-filters__fieldset">
+                <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Price
+                </legend>
+                <div className="community-filters__chip-list flex flex-wrap gap-2">
+                  {PRICE_OPTIONS.map((price) => (
+                    <button
+                      key={price}
+                      type="button"
+                      onClick={() => setFilter('price', toggleValue(filters.price, price))}
+                      className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
+                        filters.price.includes(price)
+                          ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
+                          : 'border-slate-200 text-slate-600 hover:border-slate-300'
+                      }`}
+                    >
+                      {price}
+                    </button>
+                  ))}
+                </div>
+                <label className="mt-2 flex items-center gap-2 text-xs text-slate-600">
                   <input
-                    type="date"
-                    className="mt-1 rounded-md border border-slate-200 px-3 py-1.5 text-sm"
-                    value={filters.customStart}
-                    onChange={(event) => setFilter('customStart', event.target.value)}
+                    type="checkbox"
+                    checked={filters.showPast}
+                    onChange={(event) => setFilter('showPast', event.target.checked)}
+                    className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
                   />
+                  Show past events
                 </label>
-                <label className="flex flex-col text-xs text-slate-500">
-                  To
-                  <input
-                    type="date"
-                    className="mt-1 rounded-md border border-slate-200 px-3 py-1.5 text-sm"
-                    value={filters.customEnd}
-                    onChange={(event) => setFilter('customEnd', event.target.value)}
-                  />
-                </label>
-              </div>
-            )}
-          </fieldset>
-
-          <fieldset className="community-filters__fieldset">
-            <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-              Category
-            </legend>
-            <div className="community-filters__chip-list flex flex-wrap gap-2">
-              {CATEGORY_OPTIONS.map((category) => (
-                <button
-                  key={category}
-                  type="button"
-                  onClick={() => setFilter('categories', toggleValue(filters.categories, category))}
-                  className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
-                    filters.categories.includes(category)
-                      ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
-                      : 'border-slate-200 text-slate-600 hover:border-slate-300'
-                  }`}
-                >
-                  {category}
-                </button>
-              ))}
+              </fieldset>
             </div>
-          </fieldset>
-
-          <fieldset className="community-filters__fieldset">
-            <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-              Town / Area
-            </legend>
-            <div className="community-filters__chip-list flex flex-wrap gap-2">
-              {TOWN_OPTIONS.map((town) => (
-                <button
-                  key={town}
-                  type="button"
-                  onClick={() => setFilter('towns', toggleValue(filters.towns, town))}
-                  className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
-                    filters.towns.includes(town)
-                      ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
-                      : 'border-slate-200 text-slate-600 hover:border-slate-300'
-                  }`}
-                >
-                  {town}
-                </button>
-              ))}
-            </div>
-          </fieldset>
-
-          <fieldset className="community-filters__fieldset">
-            <legend className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-              Price
-            </legend>
-            <div className="community-filters__chip-list flex flex-wrap gap-2">
-              {PRICE_OPTIONS.map((price) => (
-                <button
-                  key={price}
-                  type="button"
-                  onClick={() => setFilter('price', toggleValue(filters.price, price))}
-                  className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium ${interactiveClass} ${
-                    filters.price.includes(price)
-                      ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
-                      : 'border-slate-200 text-slate-600 hover:border-slate-300'
-                  }`}
-                >
-                  {price}
-                </button>
-              ))}
-            </div>
-            <label className="mt-2 flex items-center gap-2 text-xs text-slate-600">
-              <input
-                type="checkbox"
-                checked={filters.showPast}
-                onChange={(event) => setFilter('showPast', event.target.checked)}
-                className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
-              />
-              Show past events
-            </label>
-          </fieldset>
+          </div>
         </div>
       </div>
     </section>

--- a/src/community/EventMap.js
+++ b/src/community/EventMap.js
@@ -4,16 +4,9 @@ import React from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
-import markerIcon from 'leaflet/dist/images/marker-icon.png'
-import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
-import markerShadow from 'leaflet/dist/images/marker-shadow.png'
+import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css'
+import 'leaflet-defaulticon-compatibility'
 import { formatDateRange } from './eventUtils'
-
-L.Icon.Default.mergeOptions({
-  iconUrl: markerIcon,
-  iconRetinaUrl: markerIcon2x,
-  shadowUrl: markerShadow,
-})
 
 const TILE_LAYER = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
 const ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/src/community/filters.compact.css
+++ b/src/community/filters.compact.css
@@ -1,0 +1,151 @@
+/* Always-visible, tiny toolbar (one line) */
+#community-filters {
+  width: 100%;
+  margin-bottom: 12px;
+}
+#community-filters .community-filters {
+  display: block;
+}
+#community-filters .community-filters__header {
+  margin-bottom: 12px;
+}
+.filters-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  height: 48px;
+  border: 1px solid #e6e6e6;
+  border-radius: 10px;
+  background: #fff;
+}
+.filters-toolbar .btn-icon {
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+.filters-toolbar .toolbar-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+.filters-toolbar .summary-label {
+  font-weight: 600;
+}
+.filters-toolbar .summary-count {
+  color: #64748b;
+}
+.filters-toolbar .toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.filters-toolbar .btn-link {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 14px;
+  color: #0f766e;
+  cursor: pointer;
+}
+.filters-toolbar .btn-link.danger {
+  color: #b91c1c;
+}
+
+/* Panel hidden by default; opens below toolbar */
+.filters-panel {
+  display: none;
+  border: 1px solid #f0f0f0;
+  border-radius: 12px;
+  background: #fff;
+  padding: 10px 12px;
+  margin-top: 8px;
+}
+.filters-panel.open {
+  display: block;
+}
+
+/* Compact chips/controls inside the panel */
+#community-filters input,
+#community-filters select,
+#community-filters button {
+  max-width: 180px;
+}
+.community-filters__chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.community-filters__chip-list button {
+  height: 32px;
+  padding: 4px 10px;
+  font-size: 14px;
+  border-radius: 18px;
+}
+.community-filters__fieldset legend {
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  margin: 10px 0 6px;
+  text-transform: uppercase;
+  color: #637081;
+}
+
+/* Non-sticky & constrained on mobile */
+@media (max-width: 767px) {
+  #community-filters {
+    position: static !important;
+    top: auto !important;
+  }
+  .filters-panel {
+    max-height: 60vh;
+    overflow: auto;
+  }
+  .community-filters__chip-list {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 6px;
+  }
+  .community-filters__chip-list::-webkit-scrollbar {
+    display: none;
+  }
+  .community-filters__chip-list button {
+    height: 28px;
+    padding: 2px 8px;
+    font-size: 13px;
+  }
+}
+
+/* Desktop/tablet expanded: compact grid and cap height if parent makes it sticky */
+@media (min-width: 768px) {
+  .filters-panel {
+    display: none;
+  }
+  .filters-panel.open {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px 12px;
+  }
+  .filters-panel.open .community-filters {
+    display: contents;
+  }
+  .filters-panel.open .community-filters__header {
+    grid-column: 1 / -1;
+  }
+  .filters-panel.open .community-filters__grid {
+    display: contents;
+  }
+  .is-sticky .filters-panel {
+    max-height: 220px;
+    overflow: auto;
+  }
+}
+
+/* Allow the search input to grow full width */
+.filters-search input {
+  max-width: none;
+}


### PR DESCRIPTION
## Summary
- add the leaflet-defaulticon-compatibility package so default markers build correctly
- update EventMap imports to rely on the compatibility assets instead of manual icon overrides
- redesign the community filters with a compact toolbar, collapsible panel, and supporting styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1f23c2c708324876ce5f11b402519