### PR TITLE
Events: CMS-based Hide/Unhide + Archive (no env changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,10 @@ Publishing, unpublishing, and hard-delete fallbacks use the GitHub Content API. 
 
 If the GitHub variables are missing, publish/unpublish buttons will be disabled and hard deletes are unavailable.
 
+## Managing event visibility
+
+- **Hide from public lists & sitemap**: In Decap CMS, open the event entry and toggle the new **Hide from public lists & sitemap** checkbox, then publish. Hidden events stay accessible directly at `/community/events/<slug>` but disappear from the main listings and sitemap.
+- **Move to Archive page**: In the same CMS form, toggle **Move to Archive page** and publish to remove the event from live listings and surface it on `/events/archive`. Archived items always bypass the main list and sitemap, and show an archive badge in the admin UI.
+
 
 

--- a/api/events.js
+++ b/api/events.js
@@ -76,6 +76,7 @@ export default function handler(req, res) {
 
   const filtered = events
     .filter((event) => withinStatuses(event, statusFilter))
+    .filter((event) => !event?.hidden)
     .sort((a, b) => {
       const aDate = new Date(a.startDate || 0).getTime()
       const bDate = new Date(b.startDate || 0).getTime()

--- a/config/site.json
+++ b/config/site.json
@@ -1,0 +1,4 @@
+{
+  "siteOrigin": "https://northsidegta.ca",
+  "includeEventsArchiveInSitemap": true
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "postbuild": "node scripts/generate-curated-html.js && cp build/index.html build/404.html",
+    "postbuild": "node scripts/generate-curated-html.js && node scripts/generate-sitemap.js && cp build/index.html build/404.html",
     "generate:curated": "node scripts/generate-curated-html.js",
     "ingest:events": "node scripts/ingest-events.js"
   },

--- a/public/cms/config.yml
+++ b/public/cms/config.yml
@@ -85,7 +85,7 @@ collections:
     extension: 'json'
     format: 'json'
     # Note: Decap does not support setting a default sort; editors must use the Sort menu.
-    summary: "{{title}} — {{startDate | date('ddd, MMM D h:mm a')}} — {{town}}{{locationName ? (', ' + locationName) : ''}} — Status: {{status | upper}}"
+    summary: "{{title}} — {{startDate | date('ddd, MMM D h:mm a')}} — {{town}}{{locationName ? (', ' + locationName) : ''}} — Status: {{status | upper}}{{hidden ? ' • HIDDEN' : ''}}{{archived ? ' • ARCHIVED' : ''}}"
     sortable_fields: ['startDate', 'status', 'commit_date', 'town', 'category', 'featured']
     view_filters:
       - label: Published
@@ -94,6 +94,18 @@ collections:
       - label: Unpublished
         field: status
         pattern: '^(draft|pending|archived)$'
+      - label: Hidden
+        field: hidden
+        pattern: '^true$'
+      - label: Not Hidden
+        field: hidden
+        pattern: '^(false|)$'
+      - label: Archived
+        field: archived
+        pattern: '^true$'
+      - label: Not Archived
+        field: archived
+        pattern: '^(false|)$'
     view_groups:
       - label: Month
         field: startDate
@@ -190,6 +202,16 @@ collections:
         hint: 'Optional external calendar link. Leave blank to auto-generate.'
       - name: 'featured'
         label: 'Featured This Week'
+        widget: 'boolean'
+        required: false
+        default: false
+      - name: 'hidden'
+        label: 'Hide from public lists & sitemap'
+        widget: 'boolean'
+        required: false
+        default: false
+      - name: 'archived'
+        label: 'Move to Archive page'
         widget: 'boolean'
         required: false
         default: false

--- a/public/config.yml
+++ b/public/config.yml
@@ -77,8 +77,28 @@ collections:
     slug: '{{slug}}'
     extension: 'json'
     format: 'json'
-    summary: '{{title}} — {{startDate}} — {{town}}'
-    sortable_fields: ['startDate', 'status', 'town', 'category', 'featured']
+    # Note: Decap does not support setting a default sort; editors must use the Sort menu.
+    summary: "{{title}} — {{startDate | date('ddd, MMM D h:mm a')}} — {{town}}{{locationName ? (', ' + locationName) : ''}} — Status: {{status | upper}}{{hidden ? ' • HIDDEN' : ''}}{{archived ? ' • ARCHIVED' : ''}}"
+    sortable_fields: ['startDate', 'status', 'commit_date', 'town', 'category', 'featured']
+    view_filters:
+      - label: Published
+        field: status
+        pattern: '^published$'
+      - label: Unpublished
+        field: status
+        pattern: '^(draft|pending|archived)$'
+      - label: Hidden
+        field: hidden
+        pattern: '^true$'
+      - label: Not Hidden
+        field: hidden
+        pattern: '^(false|)$'
+      - label: Archived
+        field: archived
+        pattern: '^true$'
+      - label: Not Archived
+        field: archived
+        pattern: '^(false|)$'
     fields:
       - { name: 'title', label: 'Title' }
       - name: 'slug'
@@ -171,6 +191,16 @@ collections:
         hint: 'Optional external calendar link. Leave blank to auto-generate.'
       - name: 'featured'
         label: 'Featured This Week'
+        widget: 'boolean'
+        required: false
+        default: false
+      - name: 'hidden'
+        label: 'Hide from public lists & sitemap'
+        widget: 'boolean'
+        required: false
+        default: false
+      - name: 'archived'
+        label: 'Move to Archive page'
         widget: 'boolean'
         required: false
         default: false

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
-  <!-- Core pages -->
   <url>
     <loc>https://northsidegta.ca/</loc>
     <changefreq>weekly</changefreq>
@@ -37,8 +36,21 @@
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
-
-  <!-- Town pages -->
+  <url>
+    <loc>https://northsidegta.ca/community</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/archive</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
   <url>
     <loc>https://northsidegta.ca/georgina</loc>
     <changefreq>monthly</changefreq>
@@ -73,6 +85,88 @@
     <loc>https://northsidegta.ca/scugog</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/golfunder2m</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/landontest</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/northside-gta-pool-homes</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/northsidegta</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/slugtest</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/test-collection</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/test2</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/test3</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/community/events/aurora-cultural-centre-cooo</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-09-23T17:24:17.531Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/community/events/aurora-cultural-centre-pa-day-ages-4-to-7-september-26</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-09-23T17:24:17.530Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/community/events/aurora-cultural-centre-printmaking-trace-monotypes</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-09-23T17:24:17.530Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/community/events/aurora-farmers-market</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-05-01T14:00:00.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/community/events/newmarket-night-market</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-05-04T19:15:00.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/community/events/uxbridge-trails-challenge</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-04-22T12:45:00.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/community/events/york-region-echoes-of-bond-lake-the-lost-hotel</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-09-23T17:24:57.390Z</lastmod>
   </url>
 
 </urlset>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+const rootDir = path.resolve(__dirname, '..')
+const publicDir = path.join(rootDir, 'public')
+const buildDir = path.join(rootDir, 'build')
+const eventsDir = path.join(publicDir, 'data', 'events')
+const collectionsDir = path.join(publicDir, 'data', 'collections')
+const townsPath = path.join(rootDir, 'src', 'towns.json')
+const siteConfigPath = path.join(rootDir, 'config', 'site.json')
+
+function loadJson(filePath, fallback) {
+  if (!fs.existsSync(filePath)) return fallback
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8')
+    return JSON.parse(raw)
+  } catch (error) {
+    console.warn(`[generate-sitemap] Failed to parse ${path.relative(rootDir, filePath)}: ${error.message}`)
+    return fallback
+  }
+}
+
+function loadCollections(dirPath) {
+  if (!fs.existsSync(dirPath)) return []
+  const entries = []
+  const files = fs.readdirSync(dirPath).filter((name) => name.endsWith('.json'))
+  for (const file of files) {
+    const fullPath = path.join(dirPath, file)
+    try {
+      const data = JSON.parse(fs.readFileSync(fullPath, 'utf8'))
+      const slug = typeof data.slug === 'string' && data.slug.trim() ? data.slug.trim() : file.replace(/\.json$/i, '')
+      if (slug) {
+        entries.push(slug)
+      }
+    } catch (error) {
+      console.warn(`[generate-sitemap] Skipping collection ${file}: ${error.message}`)
+    }
+  }
+  return entries
+}
+
+function loadEvents(dirPath) {
+  if (!fs.existsSync(dirPath)) return []
+  const files = fs.readdirSync(dirPath).filter((name) => name.endsWith('.json'))
+  const events = []
+  for (const file of files) {
+    const fullPath = path.join(dirPath, file)
+    try {
+      const event = JSON.parse(fs.readFileSync(fullPath, 'utf8'))
+      if (!event.slug) {
+        event.slug = file.replace(/\.json$/i, '')
+      }
+      events.push(event)
+    } catch (error) {
+      console.warn(`[generate-sitemap] Skipping event ${file}: ${error.message}`)
+    }
+  }
+  return events
+}
+
+function buildAbsoluteUrl(origin, relativePath) {
+  const normalizedPath = relativePath.startsWith('/') ? relativePath : `/${relativePath}`
+  return `${origin.replace(/\/$/, '')}${normalizedPath}`
+}
+
+function sanitizeDate(value) {
+  if (!value) return ''
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return ''
+  return parsed.toISOString()
+}
+
+function writeFileIfPossible(targetPath, contents) {
+  try {
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+    fs.writeFileSync(targetPath, contents, 'utf8')
+    return true
+  } catch (error) {
+    console.warn(`[generate-sitemap] Failed to write ${path.relative(rootDir, targetPath)}: ${error.message}`)
+    return false
+  }
+}
+
+function main() {
+  const siteConfig = loadJson(siteConfigPath, {}) || {}
+  const origin =
+    (typeof siteConfig.siteOrigin === 'string' && siteConfig.siteOrigin.trim()) ||
+    (typeof process.env.SITE_ORIGIN === 'string' && process.env.SITE_ORIGIN.trim()) ||
+    'https://northsidegta.ca'
+  const includeArchive = siteConfig.includeEventsArchiveInSitemap !== false
+
+  const staticRoutes = [
+    { path: '/', changefreq: 'weekly', priority: '1.0' },
+    { path: '/buyers', changefreq: 'weekly', priority: '0.9' },
+    { path: '/sellers', changefreq: 'weekly', priority: '0.9' },
+    { path: '/homeanalysis', changefreq: 'monthly', priority: '0.7' },
+    { path: '/vip', changefreq: 'monthly', priority: '0.6' },
+    { path: '/about', changefreq: 'yearly', priority: '0.5' },
+    { path: '/contact', changefreq: 'yearly', priority: '0.5' },
+    { path: '/community', changefreq: 'daily', priority: '0.8' },
+    { path: '/collections', changefreq: 'monthly', priority: '0.6' },
+  ]
+
+  if (includeArchive) {
+    staticRoutes.push({ path: '/events/archive', changefreq: 'weekly', priority: '0.5' })
+  }
+
+  const towns = loadJson(townsPath, []) || []
+  towns
+    .map((town) => (typeof town === 'object' ? town.slug : null))
+    .filter((slug) => typeof slug === 'string' && slug.trim())
+    .forEach((slug) => {
+      staticRoutes.push({ path: `/${slug.trim()}`, changefreq: 'monthly', priority: '0.7' })
+    })
+
+  const collections = loadCollections(collectionsDir)
+  collections.forEach((slug) => {
+    staticRoutes.push({ path: `/collections/${slug}`, changefreq: 'monthly', priority: '0.6' })
+  })
+
+  const events = loadEvents(eventsDir)
+  const eventEntries = events
+    .filter((event) => {
+      if (!event || typeof event.slug !== 'string' || !event.slug.trim()) return false
+      const status = typeof event.status === 'string' ? event.status.trim().toLowerCase() : ''
+      const hidden = Boolean(event.hidden)
+      const archived = Boolean(event.archived) || status === 'archived'
+      const publishable = status === 'published' || archived
+      return publishable && !hidden
+    })
+    .map((event) => ({
+      path: `/community/events/${event.slug.trim()}`,
+      changefreq: 'monthly',
+      priority: '0.4',
+      lastmod: sanitizeDate(event.updatedAt || event.endDate || event.startDate),
+    }))
+
+  const entries = [...staticRoutes, ...eventEntries]
+
+  const seen = new Set()
+  const urlElements = entries
+    .filter((entry) => {
+      if (!entry || typeof entry.path !== 'string') return false
+      const key = entry.path
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    .map((entry) => {
+      const parts = [
+        '  <url>',
+        `    <loc>${buildAbsoluteUrl(origin, entry.path)}</loc>`,
+      ]
+      if (entry.changefreq) parts.push(`    <changefreq>${entry.changefreq}</changefreq>`)
+      if (entry.priority) parts.push(`    <priority>${entry.priority}</priority>`)
+      if (entry.lastmod) parts.push(`    <lastmod>${entry.lastmod}</lastmod>`)
+      parts.push('  </url>')
+      return parts.join('\n')
+    })
+
+  const sitemap = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    '',
+    ...urlElements,
+    '',
+    '</urlset>',
+    '',
+  ].join('\n')
+
+  const publicTarget = path.join(publicDir, 'sitemap.xml')
+  const buildTarget = path.join(buildDir, 'sitemap.xml')
+
+  const wrotePublic = writeFileIfPossible(publicTarget, sitemap)
+  let wroteBuild = false
+  if (fs.existsSync(buildDir)) {
+    wroteBuild = writeFileIfPossible(buildTarget, sitemap)
+  }
+
+  if (wrotePublic || wroteBuild) {
+    console.log(
+      `[generate-sitemap] Updated sitemap with ${urlElements.length} entries → ${path.relative(rootDir, publicTarget)}`
+    )
+  } else {
+    process.exitCode = 1
+  }
+}
+
+main()

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,8 @@ import HomeAnalysisPage from "./HomeAnalysisPage";
 import TownPage         from "./TownPage";
 import ThankYouPage     from "./ThankYouPage";
 import EventsIndexPage  from "./community/admin/EventsIndexPage";
+import EventsArchivePage from "./community/EventsArchivePage";
+import EventDetailPage  from "./community/EventDetailPage";
 
 // Load the town slugs right here (no helper to avoid any cyclic import)
 import towns from "./towns.json";
@@ -54,6 +56,9 @@ function App() {
         <Route path="/buyers"       element={<BuyersPage />} />
         <Route path="/sellers"      element={<SellersPage />} />
         <Route path="/community"    element={<CommunityPage />} />
+        <Route path="/community/events/archive" element={<EventsArchivePage />} />
+        <Route path="/community/events/:slug" element={<EventDetailPage />} />
+        <Route path="/events/archive" element={<EventsArchivePage />} />
         <Route path="/community/events-admin" element={<EventsIndexPage />} />
         <Route path="/contact"      element={<ContactPage />} />
         <Route path="/vip"          element={<VipPage />} />

--- a/src/CommunityPage.js
+++ b/src/CommunityPage.js
@@ -68,14 +68,22 @@ export default function CommunityPage() {
 
   const events = React.useMemo(() => hydrateEvents(rawEvents), [rawEvents])
 
-  const featuredEvents = React.useMemo(
-    () => events.filter((event) => event.featured && event.status === 'published').slice(0, 6),
+  const visibleEvents = React.useMemo(
+    () => events.filter((event) => !event.hidden && !event.archived),
     [events]
   )
 
+  const featuredEvents = React.useMemo(
+    () =>
+      visibleEvents
+        .filter((event) => event.featured && event.status === 'published')
+        .slice(0, 6),
+    [visibleEvents]
+  )
+
   const { events: filteredEvents, rangeStart, rangeEnd } = React.useMemo(
-    () => filterEvents(events, filters),
-    [events, filters]
+    () => filterEvents(visibleEvents, filters),
+    [visibleEvents, filters]
   )
 
   const structuredData = React.useMemo(() => getStructuredData(filteredEvents), [filteredEvents])

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -5,6 +5,15 @@ export default function Footer() {
   return (
     <footer className="text-center text-sm text-gray-500 py-6">
       © 2025 NorthSide GTA | Finally Home Agents
+      {' '}
+      <span aria-hidden="true">•</span>
+      {' '}
+      <a
+        href="/events/archive"
+        className="font-medium text-emerald-600 hover:text-emerald-700"
+      >
+        Past Events Archive
+      </a>
     </footer>
   );
 }

--- a/src/community/EventDetailPage.js
+++ b/src/community/EventDetailPage.js
@@ -1,0 +1,411 @@
+import React from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
+import { ArrowLeft, CalendarPlus, ExternalLink, MapPin } from 'lucide-react'
+import Navigation from '../Navigation'
+import Footer from '../Footer'
+import { sanitizeEvent, formatDateRange, generateIcsContent } from './eventUtils'
+
+function splitParagraphs(text) {
+  return text
+    .split(/\n{2,}/)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+}
+
+function buildEventSchema(event, origin) {
+  if (!event) return null
+  const baseOrigin = typeof origin === 'string' && origin ? origin : 'https://www.northsidegta.ca'
+  const canonical = `${baseOrigin.replace(/\/$/, '')}/community/events/${encodeURIComponent(event.slug)}`
+  const start = event.startDateObj || (event.startDate ? new Date(event.startDate) : null)
+  const end = event.endDateObj || start
+  const image = event.image && /^https?:\/\//i.test(event.image)
+    ? event.image
+    : event.image
+      ? `${baseOrigin.replace(/\/$/, '')}${event.image.startsWith('/') ? event.image : `/${event.image}`}`
+      : undefined
+
+  const location = {
+    '@type': 'Place',
+    name: event.locationName || event.town || 'NorthSide GTA',
+  }
+
+  if (event.address) {
+    location.address = event.address
+  } else if (event.town) {
+    location.address = `${event.town}, Ontario`
+  }
+
+  if (event.hasLocation) {
+    location.geo = {
+      '@type': 'GeoCoordinates',
+      latitude: event.lat,
+      longitude: event.lng,
+    }
+  }
+
+  const offers = {
+    '@type': 'Offer',
+    availability: 'https://schema.org/InStock',
+    url: event.eventUrl || canonical,
+  }
+
+  if (event.priceType === 'Free') {
+    offers.price = 0
+    offers.priceCurrency = 'CAD'
+  }
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: event.title,
+    startDate: start ? new Date(start).toISOString() : event.startDate,
+    endDate: end ? new Date(end).toISOString() : event.endDate || event.startDate,
+    eventStatus: 'https://schema.org/EventScheduled',
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    description: (event.summary || event.description || '').replace(/\s+/g, ' ').trim(),
+    location,
+    offers,
+    url: event.eventUrl || canonical,
+  }
+
+  if (image) {
+    schema.image = [image]
+  }
+
+  if (event.organizerName) {
+    schema.organizer = {
+      '@type': 'Organization',
+      name: event.organizerName,
+      url: event.organizerUrl || event.eventUrl || canonical,
+    }
+  }
+
+  return JSON.stringify(schema, null, 2)
+}
+
+export default function EventDetailPage() {
+  const { slug: routeSlug } = useParams()
+  const slug = routeSlug ? decodeURIComponent(routeSlug) : ''
+  const [event, setEvent] = React.useState(null)
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState('')
+
+  React.useEffect(() => {
+    if (!slug) {
+      setError('not-found')
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError('')
+
+    fetch(`/data/events/${encodeURIComponent(slug)}.json`, { cache: 'no-store' })
+      .then((response) => {
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error('not-found')
+          }
+          throw new Error('failed')
+        }
+        return response.json()
+      })
+      .then((payload) => {
+        if (cancelled) return
+        const sanitized = sanitizeEvent(payload)
+        if (!sanitized) {
+          setError('not-found')
+        } else {
+          setEvent(sanitized)
+        }
+        setLoading(false)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(err.message === 'not-found' ? 'not-found' : 'failed')
+        setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [slug])
+
+  const occurrence = React.useMemo(() => {
+    if (!event) return null
+    const start = event.startDateObj || (event.startDate ? new Date(event.startDate) : null)
+    const end = event.endDateObj || start
+    if (!start) return null
+    return { start, end }
+  }, [event])
+
+  const dateLabel = occurrence ? formatDateRange(occurrence, event?.allDay) : ''
+
+  const descriptionParagraphs = React.useMemo(() => splitParagraphs(event?.description || ''), [event])
+
+  const summaryParagraphs = React.useMemo(
+    () => (event?.summary ? splitParagraphs(event.summary) : []),
+    [event]
+  )
+
+  const townParts = []
+  if (event?.subArea) townParts.push(event.subArea)
+  if (event?.town) townParts.push(event.town)
+  const townLabel = townParts.join(', ')
+
+  const mapEmbedSrc = React.useMemo(() => {
+    if (!event) return ''
+    if (typeof event.lat === 'number' && typeof event.lng === 'number') {
+      return `https://www.google.com/maps?q=${event.lat},${event.lng}&z=14&output=embed`
+    }
+    if (event.address) {
+      return `https://www.google.com/maps?q=${encodeURIComponent(event.address)}&z=13&output=embed`
+    }
+    return ''
+  }, [event])
+
+  const mapLink = React.useMemo(() => {
+    if (!event) return ''
+    if (event.address) {
+      const label = `${event.locationName || ''} ${event.address}`.trim()
+      return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(label)}`
+    }
+    return ''
+  }, [event])
+
+  const schema = React.useMemo(() => buildEventSchema(event), [event])
+
+  const pageTitle = event ? `${event.title} • NorthSide GTA Events` : 'Event Details • NorthSide GTA'
+  const pageDescription =
+    event?.summary ||
+    (event?.description ? event.description.replace(/\s+/g, ' ').trim().slice(0, 160) : '') ||
+    'Explore community events across the NorthSide GTA.'
+  const canonicalUrl = event
+    ? `https://www.northsidegta.ca/community/events/${encodeURIComponent(event.slug)}`
+    : 'https://www.northsidegta.ca/community/events'
+
+  const handleAddToCalendar = React.useCallback(() => {
+    if (!event) return
+    if (event.icsUrl) {
+      window.open(event.icsUrl, '_blank', 'noopener')
+      return
+    }
+    const ics = generateIcsContent(event, occurrence)
+    if (!ics) return
+    const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `${event.slug || 'northside-event'}.ics`
+    anchor.rel = 'noopener'
+    document.body.appendChild(anchor)
+    anchor.click()
+    document.body.removeChild(anchor)
+    URL.revokeObjectURL(url)
+  }, [event, occurrence])
+
+  return (
+    <>
+      <Helmet>
+        <title>{pageTitle}</title>
+        <meta name="description" content={pageDescription} />
+        <link rel="canonical" href={canonicalUrl} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDescription} />
+        {event?.image && <meta property="og:image" content={event.image} />}
+        {event?.hidden && <meta name="robots" content="noindex" />}
+        {schema && <script type="application/ld+json">{schema}</script>}
+      </Helmet>
+
+      <Navigation />
+
+      <main className="bg-slate-50">
+        <section className="border-b border-slate-200 bg-white">
+          <div className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-10">
+            <div className="flex items-center gap-3 text-sm text-slate-600">
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              <Link to="/community" className="font-semibold text-slate-700 hover:text-slate-900">
+                Back to events
+              </Link>
+            </div>
+            {loading && (
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-6 text-sm text-slate-600">
+                Loading event details…
+              </div>
+            )}
+            {!loading && error === 'not-found' && (
+              <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-5 py-6 text-sm text-slate-600">
+                We couldn’t find this event. It may have been removed or renamed.
+              </div>
+            )}
+            {!loading && error === 'failed' && (
+              <div className="rounded-2xl border border-dashed border-amber-300 bg-amber-50 px-5 py-6 text-sm text-amber-700">
+                The event details are unavailable right now. Please try again in a moment.
+              </div>
+            )}
+            {!loading && !error && event && (
+              <article className="space-y-8">
+                {event.image && (
+                  <img
+                    src={event.image}
+                    alt={`${event.title} hero`}
+                    className="h-72 w-full rounded-3xl object-cover"
+                    loading="lazy"
+                  />
+                )}
+                <div className="space-y-5">
+                  <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-slate-500">
+                    {townLabel && <span>{townLabel}</span>}
+                    {townLabel && event.category && (
+                      <span className="h-1 w-1 rounded-full bg-slate-300" aria-hidden="true" />
+                    )}
+                    {event.category && <span>{event.category}</span>}
+                  </div>
+                  <h1 className="text-3xl font-semibold tracking-tight text-slate-900">{event.title}</h1>
+                  <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+                    {event.status === 'published' ? (
+                      <span className="inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">
+                        Published
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                        {event.status.charAt(0).toUpperCase() + event.status.slice(1)}
+                      </span>
+                    )}
+                    {event.hidden && (
+                      <span className="inline-flex items-center rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-700">
+                        Hidden from listings
+                      </span>
+                    )}
+                    {event.archived && (
+                      <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-700">
+                        Archived
+                      </span>
+                    )}
+                  </div>
+                  {dateLabel && <p className="text-base text-slate-700">{dateLabel}</p>}
+                  {event.locationName && (
+                    <p className="flex items-center gap-2 text-sm text-slate-600">
+                      <MapPin className="h-4 w-4" aria-hidden="true" />
+                      <span>
+                        {event.locationName}
+                        {event.address ? ` · ${event.address}` : ''}
+                        {!event.address && townLabel ? ` · ${townLabel}` : ''}
+                      </span>
+                    </p>
+                  )}
+                  {event.priceNote && <p className="text-xs text-slate-500">{event.priceNote}</p>}
+                  {summaryParagraphs.length > 0 && (
+                    <div className="space-y-3 text-sm text-slate-600">
+                      {summaryParagraphs.map((paragraph, index) => (
+                        <p key={index}>{paragraph}</p>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {descriptionParagraphs.length > 0 && (
+                  <section className="space-y-4 text-base leading-relaxed text-slate-700">
+                    {descriptionParagraphs.map((paragraph, index) => (
+                      <p key={index}>{paragraph}</p>
+                    ))}
+                  </section>
+                )}
+
+                <div className="flex flex-wrap gap-3 text-sm font-medium">
+                  {event.eventUrl && (
+                    <a
+                      href={event.eventUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                    >
+                      Event site
+                      <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                    </a>
+                  )}
+                  <button
+                    type="button"
+                    onClick={handleAddToCalendar}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                  >
+                    Add to calendar
+                    <CalendarPlus className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                  {mapLink && (
+                    <a
+                      href={mapLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                    >
+                      Map & directions
+                      <MapPin className="h-4 w-4" aria-hidden="true" />
+                    </a>
+                  )}
+                </div>
+
+                {mapEmbedSrc && (
+                  <div className="overflow-hidden rounded-3xl border border-slate-200">
+                    <iframe
+                      title="Map preview"
+                      src={mapEmbedSrc}
+                      width="100%"
+                      height="320"
+                      style={{ border: 0 }}
+                      allowFullScreen
+                      loading="lazy"
+                    />
+                  </div>
+                )}
+
+                {(event.organizerName || event.organizerUrl || event.sourceName || event.sourceUrl) && (
+                  <div className="space-y-2 rounded-3xl border border-slate-200 bg-white px-6 py-5 text-sm text-slate-600 shadow-sm">
+                    {event.organizerName && (
+                      <p>
+                        Organizer:{' '}
+                        {event.organizerUrl ? (
+                          <a
+                            href={event.organizerUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-medium text-slate-700 hover:text-slate-900"
+                          >
+                            {event.organizerName}
+                          </a>
+                        ) : (
+                          <span className="font-medium text-slate-700">{event.organizerName}</span>
+                        )}
+                      </p>
+                    )}
+                    {(event.sourceName || event.sourceUrl) && (
+                      <p className="text-xs text-slate-500">
+                        Source:{' '}
+                        {event.sourceUrl ? (
+                          <a
+                            href={event.sourceUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-medium text-slate-600 hover:text-slate-900"
+                          >
+                            {event.sourceName || event.sourceUrl}
+                          </a>
+                        ) : (
+                          <span className="font-medium text-slate-600">{event.sourceName}</span>
+                        )}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </article>
+            )}
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  )
+}

--- a/src/community/EventsArchivePage.js
+++ b/src/community/EventsArchivePage.js
@@ -1,0 +1,212 @@
+import React from 'react'
+import { Helmet } from 'react-helmet-async'
+import { DateTime } from 'luxon'
+import { CalendarDays, ExternalLink, MapPin } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import Navigation from '../Navigation'
+import Footer from '../Footer'
+import { hydrateEvents, formatDateRange } from './eventUtils'
+
+const TORONTO_ZONE = 'America/Toronto'
+
+function getArchiveCandidates(events) {
+  const todayStart = DateTime.now().setZone(TORONTO_ZONE).startOf('day')
+
+  return events
+    .map((event) => {
+      if (!event || event.hidden) return null
+      const archivedFlag = Boolean(event.archived)
+      const endDate = event.endDateObj || event.startDateObj
+      const endDateTime = endDate ? DateTime.fromJSDate(endDate).setZone(TORONTO_ZONE) : null
+      const isPast = endDateTime ? endDateTime < todayStart : false
+      if (!archivedFlag && !isPast) return null
+
+      const sortValue = endDateTime ? endDateTime.toMillis() : 0
+      return {
+        ...event,
+        archiveType: archivedFlag ? 'archived' : 'past',
+        _sortValue: sortValue,
+      }
+    })
+    .filter(Boolean)
+    .sort((a, b) => b._sortValue - a._sortValue)
+    .map(({ _sortValue, ...event }) => event)
+}
+
+function buildDateLabel(event) {
+  const occurrence = {
+    start: event.startDateObj || (event.startDate ? new Date(event.startDate) : null),
+    end: event.endDateObj || event.startDateObj || (event.startDate ? new Date(event.startDate) : null),
+  }
+  if (!occurrence.start) return ''
+  return formatDateRange(occurrence, event.allDay)
+}
+
+function ArchiveEventCard({ event }) {
+  const dateLabel = buildDateLabel(event)
+  const townParts = []
+  if (event.subArea) townParts.push(event.subArea)
+  if (event.town) townParts.push(event.town)
+  const townLabel = townParts.join(', ')
+
+  return (
+    <article className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-slate-500">
+          {townLabel && <span>{townLabel}</span>}
+          {townLabel && event.category && (
+            <span className="h-1 w-1 rounded-full bg-slate-300" aria-hidden="true" />
+          )}
+          {event.category && <span>{event.category}</span>}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-xl font-semibold text-slate-900">
+            <Link to={`/community/events/${event.slug}`} className="hover:text-emerald-700">
+              {event.title}
+            </Link>
+          </h3>
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+              event.archiveType === 'archived'
+                ? 'border border-slate-300 bg-slate-100 text-slate-700'
+                : 'border border-emerald-200 bg-emerald-50 text-emerald-700'
+            }`}
+          >
+            {event.archiveType === 'archived' ? 'Archived' : 'Past Event'}
+          </span>
+        </div>
+        {dateLabel && (
+          <p className="flex items-center gap-2 text-sm text-slate-600">
+            <CalendarDays className="h-4 w-4" aria-hidden="true" />
+            <span>{dateLabel}</span>
+          </p>
+        )}
+        {event.locationName && (
+          <p className="flex items-center gap-2 text-sm text-slate-600">
+            <MapPin className="h-4 w-4" aria-hidden="true" />
+            <span>
+              {event.locationName}
+              {event.address ? ` · ${event.address}` : ''}
+              {!event.address && townLabel ? ` · ${townLabel}` : ''}
+            </span>
+          </p>
+        )}
+        {event.summary && <p className="text-sm leading-relaxed text-slate-600">{event.summary}</p>}
+      </div>
+
+      <div className="mt-auto flex flex-wrap gap-3 text-sm font-medium">
+        <Link
+          to={`/community/events/${event.slug}`}
+          className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+        >
+          View details
+        </Link>
+        {event.eventUrl && (
+          <a
+            href={event.eventUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+          >
+            Event site
+            <ExternalLink className="h-4 w-4" aria-hidden="true" />
+          </a>
+        )}
+      </div>
+    </article>
+  )
+}
+
+export default function EventsArchivePage() {
+  const [rawEvents, setRawEvents] = React.useState([])
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState('')
+
+  React.useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError('')
+
+    fetch('/api/events?status=all', { cache: 'no-store' })
+      .then((response) => {
+        if (!response.ok) throw new Error('failed')
+        return response.json()
+      })
+      .then((payload) => {
+        if (cancelled) return
+        setRawEvents(Array.isArray(payload.events) ? payload.events : [])
+        setLoading(false)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        console.error('[events-archive] failed to load events', err)
+        setError('failed')
+        setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const events = React.useMemo(() => hydrateEvents(rawEvents), [rawEvents])
+  const archiveEvents = React.useMemo(() => getArchiveCandidates(events), [events])
+
+  const pageDescription =
+    'Browse the archive of past community events across Aurora, Uxbridge, Georgina, Stouffville, East Gwillimbury, Newmarket and Scugog.'
+
+  return (
+    <>
+      <Helmet>
+        <title>Past Events Archive • NorthSide GTA</title>
+        <meta name="description" content={pageDescription} />
+        <link rel="canonical" href="https://www.northsidegta.ca/events/archive" />
+        <meta property="og:title" content="Past Events Archive" />
+        <meta property="og:description" content={pageDescription} />
+      </Helmet>
+
+      <Navigation />
+
+      <main className="bg-slate-50">
+        <section className="bg-slate-900 py-16 text-white">
+          <div className="mx-auto max-w-4xl space-y-4 px-4 text-center">
+            <h1 className="text-4xl font-semibold tracking-tight">Past Events Archive</h1>
+            <p className="text-base text-slate-200">
+              Catch up on recently wrapped and archived happenings across the NorthSide GTA.
+            </p>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-5xl space-y-8 px-4 py-12">
+          {loading && (
+            <div className="rounded-3xl border border-slate-200 bg-white px-6 py-12 text-center text-sm text-slate-600 shadow-sm">
+              Loading the archive…
+            </div>
+          )}
+
+          {!loading && error && (
+            <div className="rounded-3xl border border-dashed border-amber-300 bg-amber-50 px-6 py-12 text-center text-sm text-amber-700">
+              We couldn’t load the archive right now. Please try again soon.
+            </div>
+          )}
+
+          {!loading && !error && archiveEvents.length === 0 && (
+            <div className="rounded-3xl border border-slate-200 bg-white px-6 py-12 text-center text-sm text-slate-600 shadow-sm">
+              Recently published events will appear here once they wrap up.
+            </div>
+          )}
+
+          {!loading && !error && archiveEvents.length > 0 && (
+            <div className="grid gap-6 md:grid-cols-2">
+              {archiveEvents.map((event) => (
+                <ArchiveEventCard key={event.slug} event={event} />
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  )
+}

--- a/src/community/admin/EventsIndexPage.js
+++ b/src/community/admin/EventsIndexPage.js
@@ -36,6 +36,9 @@ const timeFormatter = new Intl.DateTimeFormat('en-CA', {
   hour12: true,
 })
 
+const CMS_HIDE_TOOLTIP = 'In CMS: toggle "Hide from public lists & sitemap" → Publish'
+const CMS_ARCHIVE_TOOLTIP = 'In CMS: toggle "Move to Archive page" → Publish'
+
 function cleanString(value) {
   return typeof value === 'string' ? value.trim() : ''
 }
@@ -169,6 +172,8 @@ function normalizeEvent(raw) {
   const status = rawStatus ? rawStatus.toLowerCase() : 'draft'
   const statusLabel = formatStatusLabel(rawStatus || status)
   const isPublished = status === 'published'
+  const hidden = Boolean(raw.hidden)
+  const archived = Boolean(raw.archived) || status === 'archived'
   const start = parseDate(raw.startDate || raw.start)
   const end = parseDate(raw.endDate || raw.end)
   const city = cleanString(raw.city) || cleanString(raw.town) || cleanString(raw?.location?.city)
@@ -203,6 +208,8 @@ function normalizeEvent(raw) {
     status,
     statusLabel,
     isPublished,
+    hidden,
+    archived,
     raw,
   }
 }
@@ -537,6 +544,20 @@ function CardsView({
                         {event.statusLabel}
                       </span>
                     </div>
+                    {(event.hidden || event.archived) && (
+                      <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold">
+                        {event.hidden && (
+                          <span className="inline-flex items-center rounded-full bg-rose-100 px-2 py-0.5 text-rose-700">
+                            Hidden
+                          </span>
+                        )}
+                        {event.archived && (
+                          <span className="inline-flex items-center rounded-full bg-slate-200 px-2 py-0.5 text-slate-700">
+                            Archived
+                          </span>
+                        )}
+                      </div>
+                    )}
                     {event.isDeleted && (
                       <span className="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-0.5 text-xs font-semibold text-rose-700">
                         Deleted
@@ -554,31 +575,53 @@ function CardsView({
                     </div>
                   </dl>
                   <div className="mt-auto flex flex-wrap items-center justify-between gap-3 text-sm">
-                    <div className="flex flex-wrap items-center gap-2">
+                    <div className="flex flex-col gap-1">
                       {cmsUrl ? (
-                        <a
-                          href={cmsUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-2 font-semibold text-slate-700 hover:text-slate-900"
-                        >
-                          Open in CMS
-                          <ExternalLink className="h-4 w-4" aria-hidden="true" />
-                        </a>
+                        <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                          <a
+                            href={cmsUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-2 font-semibold text-slate-700 hover:text-slate-900"
+                          >
+                            Open in CMS
+                            <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                          </a>
+                          <a
+                            href={cmsUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title={CMS_HIDE_TOOLTIP}
+                            className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 underline-offset-2 hover:text-slate-900 hover:underline"
+                          >
+                            Toggle Hide in CMS
+                          </a>
+                          <a
+                            href={cmsUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title={CMS_ARCHIVE_TOOLTIP}
+                            className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 underline-offset-2 hover:text-slate-900 hover:underline"
+                          >
+                            {event.archived ? 'Update Archive in CMS' : 'Move to Archive in CMS'}
+                          </a>
+                        </div>
                       ) : null}
-                      {event.url ? (
-                        <a
-                          href={event.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-2 font-semibold text-emerald-700 hover:text-emerald-900"
-                        >
-                          Public link
-                          <ExternalLink className="h-4 w-4" aria-hidden="true" />
-                        </a>
-                      ) : (
-                        <span className="text-slate-400">No public link</span>
-                      )}
+                      <div className="flex flex-wrap items-center gap-2">
+                        {event.url ? (
+                          <a
+                            href={event.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-2 font-semibold text-emerald-700 hover:text-emerald-900"
+                          >
+                            Public link
+                            <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                          </a>
+                        ) : (
+                          <span className="text-slate-400">No public link</span>
+                        )}
+                      </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
                       {!event.isDeleted && (
@@ -746,16 +789,46 @@ function TableView({
                     </div>
                     <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
                       {cmsUrl ? (
-                        <a
-                          href={cmsUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-slate-500 hover:text-emerald-700 hover:underline"
-                        >
-                          Open in CMS
-                          <ExternalLink className="h-3 w-3" aria-hidden="true" />
-                        </a>
+                        <>
+                          <a
+                            href={cmsUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 font-medium text-slate-600 hover:text-emerald-700 hover:underline"
+                          >
+                            Open in CMS
+                            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                          </a>
+                          <a
+                            href={cmsUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title={CMS_HIDE_TOOLTIP}
+                            className="inline-flex items-center gap-1 text-[11px] font-medium text-slate-500 underline-offset-2 hover:text-slate-900 hover:underline"
+                          >
+                            Toggle Hide in CMS
+                          </a>
+                          <a
+                            href={cmsUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title={CMS_ARCHIVE_TOOLTIP}
+                            className="inline-flex items-center gap-1 text-[11px] font-medium text-slate-500 underline-offset-2 hover:text-slate-900 hover:underline"
+                          >
+                            {event.archived ? 'Update Archive in CMS' : 'Move to Archive in CMS'}
+                          </a>
+                        </>
                       ) : null}
+                      {event.hidden && (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-0.5 text-[11px] font-semibold text-rose-700">
+                          Hidden
+                        </span>
+                      )}
+                      {event.archived && (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-semibold text-slate-700">
+                          Archived
+                        </span>
+                      )}
                       {event.isDeleted && (
                         <span className="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-0.5 text-[11px] font-semibold text-rose-700">
                           Deleted

--- a/src/community/eventUtils.js
+++ b/src/community/eventUtils.js
@@ -75,6 +75,11 @@ export function sanitizeEvent(raw) {
     ? raw.qaTags.map((tag) => String(tag).trim()).filter(Boolean)
     : []
 
+  const status = normalizeStatus(raw.status)
+  const hidden = Boolean(raw.hidden)
+  const archivedFlag = Boolean(raw.archived)
+  const archived = archivedFlag || status === 'archived'
+
   return {
     ...raw,
     title: String(raw.title || '').trim(),
@@ -101,7 +106,9 @@ export function sanitizeEvent(raw) {
     organizerUrl: typeof raw.organizerUrl === 'string' ? raw.organizerUrl.trim() : '',
     icsUrl: typeof raw.icsUrl === 'string' ? raw.icsUrl.trim() : '',
     featured: Boolean(raw.featured),
-    status: normalizeStatus(raw.status),
+    status,
+    hidden,
+    archived,
     source: normalizeSource(raw.source),
     sourceName,
     sourceUrl,


### PR DESCRIPTION
## Summary
- add Decap CMS fields for hide/archive with improved events list filters and summary metadata
- surface hidden and archived metadata throughout the public site, including filtered event listings, detail pages, and the new past-events archive
- enhance the events admin with badges plus CMS deep links, refresh the sitemap generation tooling, and document the hide/archive workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d43ccae9ec8324b52e5b7e927eb900