### PR TITLE
Fix sync summary unchanged tracking

### DIFF
--- a/.github/workflows/daily-events-sync.yml
+++ b/.github/workflows/daily-events-sync.yml
@@ -21,9 +21,23 @@ jobs:
       - run: node scripts/sync-events.mjs
       - name: Commit & push changes
         run: |
+          set -e
           git config user.name "events-sync-bot"
           git config user.email "actions@github.com"
           git add public/data/events || true
-          git diff --cached --quiet && echo "No event changes" && exit 0
-          git commit -m "chore(events-sync): update events"
+
+          if git diff --cached --quiet; then
+            echo "No event changes"
+            exit 0
+          fi
+
+          MSG="chore(events-sync): update events"
+          if [ -f public/data/events/_sync-summary.json ]; then
+            CREATED=$(node -e "console.log(require('./public/data/events/_sync-summary.json').created ?? 0)")
+            UPDATED=$(node -e "console.log(require('./public/data/events/_sync-summary.json').updated ?? 0)")
+            ERRORS=$(node -e "console.log(require('./public/data/events/_sync-summary.json').errors ?? 0)")
+            MSG="chore(events-sync): +${CREATED} new, ${UPDATED} updated, ${ERRORS} errors"
+          fi
+
+          git commit -m "$MSG"
           git push

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ If the GitHub variables are missing, publish/unpublish buttons will be disabled 
 - Preserves `status`, `hidden`, and `archived`; does not delete files.
 - Commits only when changes exist (which triggers a redeploy).
 - To change the time, edit `.github/workflows/daily-events-sync.yml`.
+- When changes occur, the sync writes `public/data/events/_sync-summary.json` so the admin page and commit messages can surface
+  +new/updated counts.
 
 ## Moderating events (zero-config)
 

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -3,6 +3,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { createRequire } from 'module'
+import { DateTime } from 'luxon'
 
 const require = createRequire(import.meta.url)
 const Parser = require('rss-parser')
@@ -14,6 +15,7 @@ const __dirname = path.dirname(__filename)
 const rootDir = path.resolve(__dirname, '..')
 const configPath = path.join(rootDir, 'config', 'event-feeds.json')
 const eventsDir = path.join(rootDir, 'public', 'data', 'events')
+const summaryPath = path.join(eventsDir, '_sync-summary.json')
 
 const DEFAULT_USER_AGENT = 'NorthSideGTA-EventBot/1.0 (+https://www.northsidegta.ca/community)'
 const DEFAULT_PRIORITY = 50
@@ -23,6 +25,7 @@ async function main() {
   const feeds = await loadConfig(configPath)
   if (!feeds.length) {
     console.log('Created: 0, Updated: 0, Unchanged: 0, Errors: 0')
+    console.log('SYNC_SUMMARY created=0 updated=0 unchanged=0 errors=0')
     return
   }
 
@@ -62,7 +65,30 @@ async function main() {
     }
   }
 
-  console.log(`Created: ${summary.created}, Updated: ${summary.updated}, Unchanged: ${summary.unchanged}, Errors: ${summary.errors}`)
+  const totalChanged = summary.created + summary.updated + summary.errors
+
+  if (totalChanged > 0) {
+    const totalAfter = await countEventFiles(eventsDir)
+    const torontoTimestamp = DateTime.fromJSDate(now)
+      .setZone('America/Toronto')
+      .toISO()
+    const payload = {
+      lastChangeAt: torontoTimestamp,
+      created: summary.created,
+      updated: summary.updated,
+      unchanged: summary.unchanged,
+      errors: summary.errors,
+      totalAfter,
+    }
+    await fs.writeFile(summaryPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+  }
+
+  console.log(
+    `Created: ${summary.created}, Updated: ${summary.updated}, Unchanged: ${summary.unchanged}, Errors: ${summary.errors}`
+  )
+  console.log(
+    `SYNC_SUMMARY created=${summary.created} updated=${summary.updated} unchanged=${summary.unchanged} errors=${summary.errors}`
+  )
 }
 
 async function loadConfig(filePath) {
@@ -108,6 +134,21 @@ async function loadExistingEvents(dirPath) {
   }
 
   return { bySlug, bySourceId }
+}
+
+async function countEventFiles(dirPath) {
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true })
+    return entries.filter(
+      (entry) =>
+        entry.isFile() && entry.name.endsWith('.json') && entry.name !== '_sync-summary.json'
+    ).length
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      console.warn('[sync-events] Failed to count event files:', error.message)
+    }
+    return 0
+  }
 }
 
 function getSourceId(event) {
@@ -578,6 +619,7 @@ const KEY_ORDER = [
   'sourcePriority',
   'sourceRef',
   'lastSyncedAt',
+  'firstSeenAt',
   'updatedAt',
 ]
 
@@ -594,18 +636,10 @@ async function mergeEvent(event, existingMaps, now) {
   const hidden = Boolean(preserved.hidden)
   const archived = Boolean(preserved.archived)
   const notes = preserved.notes !== undefined ? preserved.notes : ''
+  const preservedFirstSeen =
+    typeof preserved.firstSeenAt === 'string' && preserved.firstSeenAt ? preserved.firstSeenAt : null
+  const firstSeenAt = preservedFirstSeen || (!isUpdate ? new Date(now).toISOString() : null)
 
-  const merged = {
-    ...preserved,
-    ...event,
-    status,
-    hidden,
-    archived,
-    notes,
-    updatedAt: new Date(now).toISOString(),
-  }
-
-  const ordered = orderKeys(merged)
   const filePath = path.join(eventsDir, `${event.slug}.json`)
 
   let existingContent = ''
@@ -617,17 +651,48 @@ async function mergeEvent(event, existingMaps, now) {
     }
   }
 
+  const baseMerged = {
+    ...preserved,
+    ...event,
+    status,
+    hidden,
+    archived,
+    notes,
+    ...(firstSeenAt ? { firstSeenAt } : {}),
+  }
+
+  const previousComparable = JSON.stringify(orderKeys(stripSyncTimestamps(preserved)))
+  const nextComparable = JSON.stringify(orderKeys(stripSyncTimestamps(baseMerged)))
+
+  if (previousComparable === nextComparable && (isUpdate || existingContent)) {
+    const entryFilePath = existingEntry?.filePath || filePath
+    const entry = existingEntry || { data: preserved, filePath: entryFilePath }
+    bySlug.set(event.slug, entry)
+    if (sourceId) bySourceId.set(sourceId, entry)
+    return 'unchanged'
+  }
+
+  const timestamp = new Date(now).toISOString()
+  const merged = {
+    ...baseMerged,
+    lastSyncedAt: timestamp,
+    updatedAt: timestamp,
+  }
+
+  const ordered = orderKeys(merged)
   const serialized = `${JSON.stringify(ordered, null, 2)}\n`
 
   if (existingContent === serialized) {
-    bySlug.set(event.slug, { data: merged, filePath })
-    if (sourceId) bySourceId.set(sourceId, { data: merged, filePath })
+    const entry = { data: merged, filePath }
+    bySlug.set(event.slug, entry)
+    if (sourceId) bySourceId.set(sourceId, entry)
     return 'unchanged'
   }
 
   await fs.writeFile(filePath, serialized, 'utf8')
-  bySlug.set(event.slug, { data: merged, filePath })
-  if (sourceId) bySourceId.set(sourceId, { data: merged, filePath })
+  const entry = { data: merged, filePath }
+  bySlug.set(event.slug, entry)
+  if (sourceId) bySourceId.set(sourceId, entry)
 
   if (isUpdate || existingContent) return 'updated'
   return 'created'
@@ -648,8 +713,17 @@ function orderKeys(event) {
   return ordered
 }
 
+function stripSyncTimestamps(event) {
+  if (!event || typeof event !== 'object') return {}
+  const clone = { ...event }
+  delete clone.lastSyncedAt
+  delete clone.updatedAt
+  return clone
+}
+
 main().catch((error) => {
   console.error('[sync-events] Fatal error', error)
   console.log('Created: 0, Updated: 0, Unchanged: 0, Errors: 1')
+  console.log('SYNC_SUMMARY created=0 updated=0 unchanged=0 errors=1')
   process.exitCode = 1
 })

--- a/src/community/admin/EventsIndexPage.js
+++ b/src/community/admin/EventsIndexPage.js
@@ -3,6 +3,8 @@ import { DateTime } from 'luxon'
 import { Search, ExternalLink, RefreshCw } from 'lucide-react'
 
 const TORONTO_ZONE = 'America/Toronto'
+const SYNC_SUMMARY_PATH = '/data/events/_sync-summary.json'
+const CMS_SYNC_URL = '/cms#/collections/utilities/entries/sync-now'
 
 const TABS = [
   { key: 'upcoming', label: 'Upcoming' },
@@ -32,6 +34,31 @@ function normalizeStatus(value) {
     return normalized
   }
   return 'draft'
+}
+
+function formatSummaryRelativeTime(value) {
+  if (!value) return ''
+  const dt = DateTime.fromISO(String(value), { zone: TORONTO_ZONE })
+  if (!dt.isValid) return ''
+  const now = DateTime.now().setZone(TORONTO_ZONE)
+  const todayStart = now.startOf('day')
+  const yesterdayStart = todayStart.minus({ days: 1 })
+  const fiveDaysAgo = todayStart.minus({ days: 5 })
+  const timeLabel = dt.toFormat('h:mm a')
+
+  if (dt >= todayStart && dt < todayStart.plus({ days: 1 })) {
+    return `Today ${timeLabel}`
+  }
+
+  if (dt >= yesterdayStart && dt < todayStart) {
+    return `Yesterday ${timeLabel}`
+  }
+
+  if (dt >= fiveDaysAgo) {
+    return `${dt.toFormat('ccc')} ${timeLabel}`
+  }
+
+  return dt.toFormat('MMM d, yyyy h:mm a')
 }
 
 function formatStatusLabel(status) {
@@ -163,6 +190,81 @@ function useEventsData() {
   }, [fetchEvents])
 
   return { events, loading, error, refetch: fetchEvents }
+}
+
+function useSyncSummary() {
+  const [summary, setSummary] = React.useState(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    fetch(SYNC_SUMMARY_PATH, { cache: 'no-store' })
+      .then((response) => {
+        if (response.status === 404) {
+          return null
+        }
+        if (!response.ok) {
+          throw new Error('Failed to load summary')
+        }
+        return response.json()
+      })
+      .then((data) => {
+        if (cancelled) return
+        if (data && typeof data === 'object') {
+          setSummary(data)
+        } else {
+          setSummary(null)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSummary(null)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return summary
+}
+
+function SyncSummaryBanner({ summary }) {
+  if (!summary) return null
+
+  const created = Number(summary.created) || 0
+  const updated = Number(summary.updated) || 0
+  const errors = Number(summary.errors) || 0
+  const relative = formatSummaryRelativeTime(summary.lastChangeAt)
+
+  if (!relative) return null
+
+  const hasChanges = created > 0 || updated > 0
+  const statusText = hasChanges
+    ? `+${created} new, ${updated} updated`
+    : 'no new events'
+  const errorText = errors > 0 ? `, ${errors} errors` : ''
+
+  return (
+    <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900 shadow-sm">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <p className="font-medium">
+          Last change: {relative} — {statusText}
+          {errorText}
+        </p>
+        <a
+          href={CMS_SYNC_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 text-xs font-semibold text-emerald-700 transition hover:text-emerald-900"
+        >
+          Sync now
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+        </a>
+      </div>
+    </div>
+  )
 }
 
 function sortByStartAsc(a, b) {
@@ -361,6 +463,7 @@ function EventTable({
 
 export default function EventsIndexPage() {
   const { events, loading, error, refetch } = useEventsData()
+  const syncSummary = useSyncSummary()
   const [searchTerm, setSearchTerm] = React.useState('')
   const [activeTab, setActiveTab] = React.useState('upcoming')
   const [showHidden, setShowHidden] = React.useState(false)
@@ -495,15 +598,31 @@ export default function EventsIndexPage() {
     <div className="min-h-screen bg-slate-50 pb-12 text-slate-900">
       <header className="border-b border-slate-200 bg-white">
         <div className="mx-auto max-w-6xl px-4 py-10">
-          <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Events Moderation</h1>
-          <p className="mt-2 max-w-3xl text-sm text-slate-600">
-            Review upcoming, past, and archived events without configuring any APIs. Search by title or city, then open entries in
-            Decap CMS to publish, unpublish, hide, or update details.
-          </p>
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <h1 className="text-3xl font-semibold tracking-tight text-slate-900">Events Moderation</h1>
+              <p className="mt-2 max-w-3xl text-sm text-slate-600">
+                Review upcoming, past, and archived events without configuring any APIs. Search by title or city, then open entries in
+                Decap CMS to publish, unpublish, hide, or update details.
+              </p>
+            </div>
+            {!syncSummary && (
+              <a
+                href={CMS_SYNC_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 self-start rounded-full border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 transition hover:border-emerald-300 hover:text-emerald-900"
+              >
+                Sync now
+                <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+              </a>
+            )}
+          </div>
         </div>
       </header>
 
       <main className="mx-auto mt-8 flex max-w-6xl flex-col gap-6 px-4">
+        <SyncSummaryBanner summary={syncSummary} />
         <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="relative w-full md:max-w-md">


### PR DESCRIPTION
## Summary
- avoid rewriting event JSON when only automated timestamps differ so the sync can count unchanged entries correctly
- ensure the sync summary's totalAfter value reflects the actual number of event JSON files on disk

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55511ea108324ad20d292eb8b3bd5