### PR TITLE
Enable GitHub-triggered events sync

### DIFF
--- a/.github/workflows/events-sync.yml
+++ b/.github/workflows/events-sync.yml
@@ -1,0 +1,45 @@
+name: Daily Events Sync
+
+on:
+  schedule:
+    # 6:00 AM America/Toronto ≈ 10:00 UTC (DST aware enough for our needs)
+    - cron: "0 10 * * *"
+  workflow_dispatch: {}
+  repository_dispatch:
+    types: [sync_now]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with: { node-version: 18 }
+      - name: Install deps
+        run: npm ci || npm i
+      - name: Run sync script
+        run: node scripts/sync-events.mjs
+      - name: Commit & push changes
+        run: |
+          set -e
+          git config user.name "events-sync-bot"
+          git config user.email "actions@github.com"
+          git add public/data/events || true
+          if git diff --cached --quiet; then
+            echo "No event changes"
+            exit 0
+          fi
+          MSG="chore(events-sync): update events"
+          if [ -f public/data/events/_sync-summary.json ]; then
+            CREATED=$(node -e "console.log(require('./public/data/events/_sync-summary.json').created ?? 0)")
+            UPDATED=$(node -e "console.log(require('./public/data/events/_sync-summary.json').updated ?? 0)")
+            ERRORS=$(node -e "console.log(require('./public/data/events/_sync-summary.json').errors ?? 0)")
+            MSG="chore(events-sync): +${CREATED} new, ${UPDATED} updated, ${ERRORS} errors"
+          fi
+          git commit -m "$MSG"
+          git push

--- a/api/sync-now.js
+++ b/api/sync-now.js
@@ -1,0 +1,68 @@
+// /api/sync-now.js
+const OWNER = process.env.GITHUB_REPO_OWNER || process.env.VERCEL_GIT_REPO_OWNER
+const REPO = process.env.GITHUB_REPO_NAME || process.env.VERCEL_GIT_REPO_SLUG
+const WORKFLOW_FILE = 'events-sync.yml'
+
+async function trigger() {
+  const token = process.env.GH_TOKEN
+  if (!token || !OWNER || !REPO) {
+    return { ok: false, status: 500, body: { error: 'Missing GH_TOKEN/owner/repo' } }
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  }
+
+  try {
+    const wf = await fetch(
+      `https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_FILE}/dispatches`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ ref: 'main' }),
+      }
+    )
+
+    const rd = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/dispatches`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ event_type: 'sync_now' }),
+    })
+
+    const ok =
+      wf.status === 204 ||
+      wf.status === 201 ||
+      wf.status === 202 ||
+      rd.status === 204 ||
+      rd.status === 201 ||
+      rd.status === 202
+
+    return {
+      ok,
+      status: ok ? 200 : 502,
+      body: { workflowStatus: wf.status, repoDispatchStatus: rd.status },
+    }
+  } catch (error) {
+    console.error('[sync-now] failed to trigger GitHub workflow', error)
+    return { ok: false, status: 502, body: { error: 'Failed to trigger sync' } }
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ error: 'Method Not Allowed' })
+    return
+  }
+
+  if (req.headers['x-sync-secret'] !== process.env.SYNC_SECRET) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return
+  }
+
+  const result = await trigger()
+  res.status(result.status).json(result.body)
+}

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -68,14 +68,17 @@ async function main() {
   const totalChanged = summary.created + summary.updated + summary.errors
 
   if (totalChanged > 0) {
-    const totalAfter = await countEventFiles(eventsDir)
-
-    const torontoTimestamp = DateTime.fromJSDate(now)
-      .setZone('America/Toronto')
-      .toISO()
+    const totalAfter = await fs
+      .readdir(eventsDir)
+      .then((list) =>
+        list.filter((name) => name.endsWith('.json') && name !== '_sync-summary.json').length
+      )
+      .catch(() => 0)
 
     const payload = {
-      lastChangeAt: torontoTimestamp,
+      lastChangeAt: DateTime.fromJSDate(now)
+        .setZone('America/Toronto')
+        .toISO(),
       created: summary.created,
       updated: summary.updated,
       unchanged: summary.unchanged,
@@ -137,21 +140,6 @@ async function loadExistingEvents(dirPath) {
   }
 
   return { bySlug, bySourceId }
-}
-
-async function countEventFiles(dirPath) {
-  try {
-    const entries = await fs.readdir(dirPath, { withFileTypes: true })
-    return entries.filter(
-      (entry) =>
-        entry.isFile() && entry.name.endsWith('.json') && entry.name !== '_sync-summary.json'
-    ).length
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      console.warn('[sync-events] Failed to count event files:', error.message)
-    }
-    return 0
-  }
 }
 
 function getSourceId(event) {

--- a/src/community/admin/EventsIndexPage.js
+++ b/src/community/admin/EventsIndexPage.js
@@ -4,7 +4,6 @@ import { Search, ExternalLink, RefreshCw } from 'lucide-react'
 
 const TORONTO_ZONE = 'America/Toronto'
 const SYNC_SUMMARY_PATH = '/data/events/_sync-summary.json'
-const CMS_SYNC_URL = '/cms#/collections/utilities/entries/sync-now'
 
 const TABS = [
   { key: 'upcoming', label: 'Upcoming' },
@@ -230,7 +229,7 @@ function useSyncSummary() {
   return summary
 }
 
-function SyncSummaryBanner({ summary }) {
+function SyncSummaryBanner({ summary, onSync, syncing }) {
   if (!summary) return null
 
   const created = Number(summary.created) || 0
@@ -253,15 +252,19 @@ function SyncSummaryBanner({ summary }) {
           Last change: {relative} — {statusText}
           {errorText}
         </p>
-        <a
-          href={CMS_SYNC_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 text-xs font-semibold text-emerald-700 transition hover:text-emerald-900"
+        <button
+          type="button"
+          onClick={onSync}
+          disabled={syncing}
+          className={`inline-flex items-center gap-2 text-xs font-semibold transition ${
+            syncing
+              ? 'cursor-not-allowed text-emerald-500'
+              : 'text-emerald-700 hover:text-emerald-900'
+          }`}
         >
-          Sync now
-          <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-        </a>
+          <RefreshCw className={`h-3.5 w-3.5 ${syncing ? 'animate-spin' : ''}`} aria-hidden="true" />
+          {syncing ? 'Syncing…' : 'Sync now'}
+        </button>
       </div>
     </div>
   )
@@ -468,6 +471,30 @@ export default function EventsIndexPage() {
   const [activeTab, setActiveTab] = React.useState('upcoming')
   const [showHidden, setShowHidden] = React.useState(false)
   const { selectedIds, toggle, clear, setAll } = useSelectedSet()
+  const [syncing, setSyncing] = React.useState(false)
+
+  const handleSyncNow = React.useCallback(async () => {
+    if (syncing) return
+    setSyncing(true)
+    try {
+      const response = await fetch('/api/sync-now', {
+        method: 'POST',
+        headers: { 'x-sync-secret': process.env.NEXT_PUBLIC_SYNC_SECRET || '' },
+      })
+      if (response.ok) {
+        alert('Sync started! Check GitHub → Actions.')
+      } else {
+        const debugText = await response.text().catch(() => '')
+        console.error('[events-admin] sync failed', response.status, debugText)
+        alert('Sync failed. See console.')
+      }
+    } catch (error) {
+      console.error('[events-admin] sync failed', error)
+      alert('Sync failed. See console.')
+    } finally {
+      setSyncing(false)
+    }
+  }, [syncing])
 
   const normalizedSearch = searchTerm.trim().toLowerCase()
 
@@ -607,22 +634,26 @@ export default function EventsIndexPage() {
               </p>
             </div>
             {!syncSummary && (
-              <a
-                href={CMS_SYNC_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 self-start rounded-full border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 transition hover:border-emerald-300 hover:text-emerald-900"
+              <button
+                type="button"
+                onClick={handleSyncNow}
+                disabled={syncing}
+                className={`inline-flex items-center gap-2 self-start rounded-full border px-4 py-2 text-sm font-semibold transition ${
+                  syncing
+                    ? 'cursor-not-allowed border-emerald-100 bg-emerald-50 text-emerald-400'
+                    : 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:border-emerald-300 hover:text-emerald-900'
+                }`}
               >
-                Sync now
-                <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-              </a>
+                <RefreshCw className={`h-3.5 w-3.5 ${syncing ? 'animate-spin' : ''}`} aria-hidden="true" />
+                {syncing ? 'Syncing…' : 'Sync now'}
+              </button>
             )}
           </div>
         </div>
       </header>
 
       <main className="mx-auto mt-8 flex max-w-6xl flex-col gap-6 px-4">
-        <SyncSummaryBanner summary={syncSummary} />
+        <SyncSummaryBanner summary={syncSummary} onSync={handleSyncNow} syncing={syncing} />
         <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="relative w-full md:max-w-md">


### PR DESCRIPTION
## Summary
- add a daily GitHub Actions workflow to run the events sync script and commit results
- expose a serverless API endpoint that triggers the workflow and wire the admin “Sync now” button to it
- ensure the sync summary reads the latest event count directly from disk when writing metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab79efd888324b39d2a912593ee40