### PR TITLE
chore(ci): expose sync secrets for manual runs

### DIFF
--- a/.github/workflows/events-sync.yml
+++ b/.github/workflows/events-sync.yml
@@ -14,6 +14,13 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      SYNC_SECRET: ${{ secrets.SYNC_SECRET }}
+      NEXT_PUBLIC_SYNC_SECRET: ${{ secrets.NEXT_PUBLIC_SYNC_SECRET }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GITHUB_REPO: ${{ secrets.GITHUB_REPO }}
+      GITHUB_REPO_OWNER: ${{ secrets.GITHUB_REPO_OWNER }}
+      GITHUB_REPO_NAME: ${{ secrets.GITHUB_REPO_NAME }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- expose the sync-related secrets as job environment variables so manual workflow_dispatch runs receive the same configuration as repository dispatch triggers

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dad46989408324b9739fcb8701bf1e