### PR TITLE
Add sharing support and per-event pages

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -102,6 +102,16 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://northsidegta.ca/collections/northside-gta-under-800k</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/northside-gta-under-900k</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://northsidegta.ca/collections/northsidegta</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
@@ -127,43 +137,61 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://northsidegta.ca/community/events/aurora-cultural-centre-cooo</loc>
+    <loc>https://northsidegta.ca/events/aurora-cultural-centre-10002603-1759518000-1759527000-auroraculturalcentre.ca-20251003</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-10-03T19:53:43.428Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/aurora-cultural-centre-10002683-1759968000-1760054399-auroraculturalcentre.ca-20251008</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-10-03T19:53:43.428Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/aurora-cultural-centre-cooo</loc>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
     <lastmod>2025-09-23T17:24:17.531Z</lastmod>
   </url>
   <url>
-    <loc>https://northsidegta.ca/community/events/aurora-cultural-centre-pa-day-ages-4-to-7-september-26</loc>
+    <loc>https://northsidegta.ca/events/aurora-cultural-centre-pa-day-ages-4-to-7-september-26</loc>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
     <lastmod>2025-09-23T17:24:17.530Z</lastmod>
   </url>
   <url>
-    <loc>https://northsidegta.ca/community/events/aurora-cultural-centre-printmaking-trace-monotypes</loc>
+    <loc>https://northsidegta.ca/events/aurora-cultural-centre-printmaking-trace-monotypes</loc>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
     <lastmod>2025-09-23T17:24:17.530Z</lastmod>
   </url>
   <url>
-    <loc>https://northsidegta.ca/community/events/aurora-farmers-market</loc>
+    <loc>https://northsidegta.ca/events/aurora-farmers-market</loc>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
     <lastmod>2025-05-01T14:00:00.000Z</lastmod>
   </url>
   <url>
-    <loc>https://northsidegta.ca/community/events/newmarket-night-market</loc>
+    <loc>https://northsidegta.ca/events/experience-york-region-10014157-1759582800-1759593600-www.experienceyorkregion.com-20251003</loc>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
-    <lastmod>2025-05-04T19:15:00.000Z</lastmod>
+    <lastmod>2025-10-04T10:14:53.999Z</lastmod>
   </url>
   <url>
-    <loc>https://northsidegta.ca/community/events/uxbridge-trails-challenge</loc>
+    <loc>https://northsidegta.ca/events/experience-york-region-10014244-1759582800-1759593600-www.experienceyorkregion.com-20251004</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-10-04T10:14:53.999Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/uxbridge-trails-challenge</loc>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
     <lastmod>2025-04-22T12:45:00.000Z</lastmod>
   </url>
   <url>
-    <loc>https://northsidegta.ca/community/events/york-region-echoes-of-bond-lake-the-lost-hotel</loc>
+    <loc>https://northsidegta.ca/events/york-region-echoes-of-bond-lake-the-lost-hotel</loc>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
     <lastmod>2025-09-23T17:24:57.390Z</lastmod>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -131,7 +131,7 @@ function main() {
       return publishable && !hidden
     })
     .map((event) => ({
-      path: `/community/events/${event.slug.trim()}`,
+      path: `/events/${event.slug.trim()}`,
       changefreq: 'monthly',
       priority: '0.4',
       lastmod: sanitizeDate(event.updatedAt || event.endDate || event.startDate),

--- a/src/App.js
+++ b/src/App.js
@@ -59,6 +59,7 @@ function App() {
         <Route path="/community"    element={<CommunityPage />} />
         <Route path="/community/events/archive" element={<EventsArchivePage />} />
         <Route path="/community/events/:slug" element={<EventDetailPage />} />
+        <Route path="/events/:slug" element={<EventDetailPage />} />
         <Route path="/community/submit-event" element={<SubmitEventPage />} />
         <Route path="/events/archive" element={<EventsArchivePage />} />
         <Route path="/community/events-admin" element={<EventsIndexPage />} />

--- a/src/CommunityPage.js
+++ b/src/CommunityPage.js
@@ -41,6 +41,9 @@ export default function CommunityPage() {
   const [filters, setFilters] = React.useState(buildFiltersDefaults)
   const [view, setView] = usePersistedView('list')
   const [selectedEvent, setSelectedEvent] = React.useState(null)
+  const [highlightedSlug, setHighlightedSlug] = React.useState('')
+  const [deepLinkSlug, setDeepLinkSlug] = React.useState('')
+  const deepLinkResetRef = React.useRef({ slug: '', attempted: false })
 
   React.useEffect(() => {
     let cancelled = false
@@ -90,6 +93,69 @@ export default function CommunityPage() {
 
   const pageDescription =
     'Always-updated guide to NorthSide GTA events across Aurora, Uxbridge, Georgina, Stouffville, East Gwillimbury, Newmarket and Scugog.'
+
+  const parseHashSlug = React.useCallback(() => {
+    if (typeof window === 'undefined') return ''
+    const { hash } = window.location
+    if (!hash) return ''
+    const cleaned = hash.replace(/^#/, '')
+    if (!cleaned.startsWith('event-')) return ''
+    return decodeURIComponent(cleaned.replace('event-', ''))
+  }, [])
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    const handleHashChange = () => {
+      const slug = parseHashSlug()
+      setDeepLinkSlug(slug)
+    }
+    handleHashChange()
+    window.addEventListener('hashchange', handleHashChange)
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange)
+    }
+  }, [parseHashSlug])
+
+  React.useEffect(() => {
+    if (!deepLinkSlug) return
+    const targetEvent = events.find((event) => event.slug === deepLinkSlug)
+    if (!targetEvent) return
+
+    if (deepLinkResetRef.current.slug !== deepLinkSlug) {
+      deepLinkResetRef.current = { slug: deepLinkSlug, attempted: false }
+    }
+
+    setView('list')
+
+    const tracker = deepLinkResetRef.current
+
+    if (!filteredEvents.some((event) => event.slug === deepLinkSlug)) {
+      if (!tracker.attempted) {
+        tracker.attempted = true
+        setFilters(buildFiltersDefaults())
+      }
+      return
+    }
+
+    setHighlightedSlug(deepLinkSlug)
+    setSelectedEvent(targetEvent)
+
+    if (typeof window !== 'undefined') {
+      window.requestAnimationFrame(() => {
+        const element = document.getElementById(`event-${deepLinkSlug}`)
+        if (element && typeof element.scrollIntoView === 'function') {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        }
+      })
+    }
+  }, [deepLinkSlug, events, filteredEvents, setFilters, setView])
+
+  React.useEffect(() => {
+    if (!highlightedSlug) return undefined
+    if (typeof window === 'undefined') return undefined
+    const timeout = window.setTimeout(() => setHighlightedSlug(''), 6000)
+    return () => window.clearTimeout(timeout)
+  }, [highlightedSlug])
 
   const handleResetFilters = () => {
     setFilters(buildFiltersDefaults())
@@ -212,7 +278,12 @@ export default function CommunityPage() {
                   </div>
                   <div className="grid gap-6 md:grid-cols-2">
                     {featuredEvents.map((event) => (
-                      <EventCard key={event.slug} event={event} onSelect={setSelectedEvent} />
+                      <EventCard
+                        key={event.slug}
+                        event={event}
+                        onSelect={setSelectedEvent}
+                        highlighted={highlightedSlug === event.slug}
+                      />
                     ))}
                   </div>
                 </section>
@@ -222,7 +293,12 @@ export default function CommunityPage() {
                 <section className="space-y-6">
                   <div className="grid gap-6 lg:grid-cols-2">
                     {filteredEvents.map((event) => (
-                      <EventCard key={event.slug} event={event} onSelect={setSelectedEvent} />
+                      <EventCard
+                        key={event.slug}
+                        event={event}
+                        onSelect={setSelectedEvent}
+                        highlighted={highlightedSlug === event.slug}
+                      />
                     ))}
                   </div>
                   {!filteredEvents.length && emptyState}

--- a/src/community/EventCard.js
+++ b/src/community/EventCard.js
@@ -4,6 +4,7 @@ import {
   ExternalLink,
   MapPin,
   ArrowRight,
+  Share2,
 } from 'lucide-react'
 import { BADGE_LABELS, formatDateRange, generateIcsContent } from './eventUtils'
 
@@ -15,7 +16,7 @@ function PlaceholderImage() {
   )
 }
 
-export default function EventCard({ event, onSelect }) {
+export default function EventCard({ event, onSelect, highlighted = false }) {
   const occurrence = event.nextOccurrence || event.occurrences?.[0]
   const dateLabel = formatDateRange(occurrence, event.allDay)
   const isFree = event.priceType === 'Free'
@@ -50,10 +51,99 @@ export default function EventCard({ event, onSelect }) {
       )}`
     : ''
 
+  const shareUrl = event.slug
+    ? `https://northsidegta.ca/community#event-${encodeURIComponent(event.slug)}`
+    : ''
+
+  const [showToast, setShowToast] = React.useState(false)
+  const toastTimeoutRef = React.useRef(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (toastTimeoutRef.current) {
+        clearTimeout(toastTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const copyToClipboard = React.useCallback(async (text) => {
+    if (!text) return false
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text)
+        return true
+      } catch (error) {
+        console.warn('Clipboard write failed, falling back', error)
+      }
+    }
+
+    if (typeof document === 'undefined') return false
+
+    try {
+      const textarea = document.createElement('textarea')
+      textarea.value = text
+      textarea.style.position = 'fixed'
+      textarea.style.opacity = '0'
+      document.body.appendChild(textarea)
+      textarea.focus()
+      textarea.select()
+      const successful = document.execCommand('copy')
+      document.body.removeChild(textarea)
+      return successful
+    } catch (fallbackError) {
+      console.warn('Unable to copy share URL', fallbackError)
+      return false
+    }
+  }, [])
+
+  const showCopiedToast = React.useCallback(() => {
+    setShowToast(true)
+    if (toastTimeoutRef.current) {
+      clearTimeout(toastTimeoutRef.current)
+    }
+    toastTimeoutRef.current = setTimeout(() => setShowToast(false), 2000)
+  }, [])
+
+  const handleShare = React.useCallback(async () => {
+    if (!shareUrl) return
+    const copied = await copyToClipboard(shareUrl)
+    if (copied) {
+      showCopiedToast()
+    }
+
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      try {
+        await navigator.share({
+          title: event.title,
+          text: event.summary || event.title,
+          url: shareUrl,
+        })
+      } catch (err) {
+        if (err?.name !== 'AbortError') {
+          console.warn('Share aborted', err)
+        }
+      }
+    }
+  }, [copyToClipboard, event.summary, event.title, shareUrl, showCopiedToast])
+
+  const hasDetailPage = Boolean(event.slug)
+  const eventSiteHref = hasDetailPage ? `/events/${encodeURIComponent(event.slug)}` : event.eventUrl
+  const eventSiteIsExternal = Boolean(event.eventUrl && !hasDetailPage)
+  const EventSiteIcon = eventSiteIsExternal ? ExternalLink : ArrowRight
+  const eventSiteLinkProps = eventSiteIsExternal
+    ? { target: '_blank', rel: 'noopener noreferrer' }
+    : {}
+
   return (
     <article
-      className="group relative flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-shadow duration-200 hover:shadow-xl focus-within:shadow-xl"
+      id={event.slug ? `event-${event.slug}` : undefined}
+      className={`group relative flex flex-col overflow-hidden rounded-2xl border bg-white shadow-sm transition-shadow duration-200 hover:shadow-xl focus-within:shadow-xl ${
+        highlighted ? 'border-emerald-300 ring-2 ring-emerald-200' : 'border-slate-200'
+      }`}
     >
+      <div className="sr-only" role="status" aria-live="polite">
+        {showToast ? 'Link copied to clipboard' : ''}
+      </div>
       <div className="flex flex-col gap-5 p-6">
         {event.image ? (
           <img
@@ -132,15 +222,14 @@ export default function EventCard({ event, onSelect }) {
         )}
 
         <div className="flex flex-wrap gap-3 text-sm font-medium">
-          {event.eventUrl && (
+          {eventSiteHref && (
             <a
-              href={event.eventUrl}
-              target="_blank"
-              rel="noopener noreferrer"
+              href={eventSiteHref}
+              {...eventSiteLinkProps}
               className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
             >
               Event site
-              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+              <EventSiteIcon className="h-4 w-4" aria-hidden="true" />
             </a>
           )}
 
@@ -164,8 +253,25 @@ export default function EventCard({ event, onSelect }) {
               <MapPin className="h-4 w-4" aria-hidden="true" />
             </a>
           )}
+
+          {shareUrl && (
+            <button
+              type="button"
+              onClick={handleShare}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+            >
+              Share
+              <Share2 className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
         </div>
       </div>
+
+      {showToast && (
+        <div className="pointer-events-none absolute inset-x-6 top-6 rounded-xl bg-emerald-600/90 px-4 py-2 text-center text-xs font-medium text-white shadow-lg">
+          Link copied
+        </div>
+      )}
 
       <div className="border-t border-slate-200 bg-slate-50 px-6 py-4">
         <button

--- a/src/community/EventDetailPage.js
+++ b/src/community/EventDetailPage.js
@@ -1,10 +1,24 @@
 import React from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
-import { ArrowLeft, CalendarPlus, ExternalLink, MapPin } from 'lucide-react'
+import {
+  ArrowLeft,
+  CalendarPlus,
+  ExternalLink,
+  MapPin,
+  Share2,
+  Copy,
+  Facebook,
+  Twitter,
+  Linkedin,
+  Mail,
+} from 'lucide-react'
 import Navigation from '../Navigation'
 import Footer from '../Footer'
 import { sanitizeEvent, formatDateRange, generateIcsContent } from './eventUtils'
+
+const SITE_ORIGIN = 'https://northsidegta.ca'
+const FALLBACK_IMAGE = '/Images/hero-desktop.jpg'
 
 function splitParagraphs(text) {
   return text
@@ -13,17 +27,21 @@ function splitParagraphs(text) {
     .filter(Boolean)
 }
 
-function buildEventSchema(event, origin) {
+function toAbsoluteUrl(path, origin = SITE_ORIGIN) {
+  if (!path) return ''
+  if (/^https?:\/\//i.test(path)) return path
+  const base = typeof origin === 'string' && origin ? origin.replace(/\/$/, '') : SITE_ORIGIN
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${base}${normalizedPath}`
+}
+
+function buildEventSchema(event, origin = SITE_ORIGIN) {
   if (!event) return null
-  const baseOrigin = typeof origin === 'string' && origin ? origin : 'https://www.northsidegta.ca'
-  const canonical = `${baseOrigin.replace(/\/$/, '')}/community/events/${encodeURIComponent(event.slug)}`
+  const baseOrigin = typeof origin === 'string' && origin ? origin : SITE_ORIGIN
+  const canonical = `${baseOrigin.replace(/\/$/, '')}/events/${encodeURIComponent(event.slug)}`
   const start = event.startDateObj || (event.startDate ? new Date(event.startDate) : null)
   const end = event.endDateObj || start
-  const image = event.image && /^https?:\/\//i.test(event.image)
-    ? event.image
-    : event.image
-      ? `${baseOrigin.replace(/\/$/, '')}${event.image.startsWith('/') ? event.image : `/${event.image}`}`
-      : undefined
+  const image = event.image ? toAbsoluteUrl(event.image, baseOrigin) : undefined
 
   const location = {
     '@type': 'Place',
@@ -84,12 +102,44 @@ function buildEventSchema(event, origin) {
   return JSON.stringify(schema, null, 2)
 }
 
+async function copyTextToClipboard(text) {
+  if (!text) return false
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch (error) {
+      console.warn('Clipboard write failed, falling back', error)
+    }
+  }
+
+  if (typeof document === 'undefined') return false
+
+  try {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.style.position = 'fixed'
+    textarea.style.opacity = '0'
+    document.body.appendChild(textarea)
+    textarea.focus()
+    textarea.select()
+    const successful = document.execCommand('copy')
+    document.body.removeChild(textarea)
+    return successful
+  } catch (error) {
+    console.warn('Unable to copy share URL', error)
+    return false
+  }
+}
+
 export default function EventDetailPage() {
   const { slug: routeSlug } = useParams()
   const slug = routeSlug ? decodeURIComponent(routeSlug) : ''
   const [event, setEvent] = React.useState(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState('')
+  const [shareToastVisible, setShareToastVisible] = React.useState(false)
+  const toastTimeoutRef = React.useRef(null)
 
   React.useEffect(() => {
     if (!slug) {
@@ -133,6 +183,14 @@ export default function EventDetailPage() {
     }
   }, [slug])
 
+  React.useEffect(() => {
+    return () => {
+      if (toastTimeoutRef.current && typeof window !== 'undefined') {
+        window.clearTimeout(toastTimeoutRef.current)
+      }
+    }
+  }, [])
+
   const occurrence = React.useMemo(() => {
     if (!event) return null
     const start = event.startDateObj || (event.startDate ? new Date(event.startDate) : null)
@@ -144,7 +202,6 @@ export default function EventDetailPage() {
   const dateLabel = occurrence ? formatDateRange(occurrence, event?.allDay) : ''
 
   const descriptionParagraphs = React.useMemo(() => splitParagraphs(event?.description || ''), [event])
-
   const summaryParagraphs = React.useMemo(
     () => (event?.summary ? splitParagraphs(event.summary) : []),
     [event]
@@ -183,8 +240,12 @@ export default function EventDetailPage() {
     (event?.description ? event.description.replace(/\s+/g, ' ').trim().slice(0, 160) : '') ||
     'Explore community events across the NorthSide GTA.'
   const canonicalUrl = event
-    ? `https://www.northsidegta.ca/community/events/${encodeURIComponent(event.slug)}`
-    : 'https://www.northsidegta.ca/community/events'
+    ? `${SITE_ORIGIN}/events/${encodeURIComponent(event.slug)}`
+    : `${SITE_ORIGIN}/events`
+  const ogImage = event?.image ? toAbsoluteUrl(event.image) : toAbsoluteUrl(FALLBACK_IMAGE)
+  const shareUrl = canonicalUrl
+  const shareTitle = event ? event.title : 'NorthSide GTA Event'
+  const shareText = event?.summary || 'Check out this NorthSide GTA event.'
 
   const handleAddToCalendar = React.useCallback(() => {
     if (!event) return
@@ -206,15 +267,79 @@ export default function EventDetailPage() {
     URL.revokeObjectURL(url)
   }, [event, occurrence])
 
+  const showShareToast = React.useCallback(() => {
+    setShareToastVisible(true)
+    if (toastTimeoutRef.current && typeof window !== 'undefined') {
+      window.clearTimeout(toastTimeoutRef.current)
+    }
+    if (typeof window !== 'undefined') {
+      toastTimeoutRef.current = window.setTimeout(() => setShareToastVisible(false), 2000)
+    }
+  }, [])
+
+  const handleShare = React.useCallback(async () => {
+    const copied = await copyTextToClipboard(shareUrl)
+    if (copied) {
+      showShareToast()
+    }
+
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      try {
+        await navigator.share({
+          title: shareTitle,
+          text: shareText,
+          url: shareUrl,
+        })
+      } catch (error) {
+        if (error?.name !== 'AbortError') {
+          console.warn('Share aborted', error)
+        }
+      }
+    }
+  }, [shareText, shareTitle, shareUrl, showShareToast])
+
+  const shareLinks = React.useMemo(() => {
+    if (!shareUrl || !event) return []
+    return [
+      {
+        href: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`,
+        label: 'Facebook',
+        icon: Facebook,
+      },
+      {
+        href: `https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(shareTitle)}`,
+        label: 'X (Twitter)',
+        icon: Twitter,
+      },
+      {
+        href: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`,
+        label: 'LinkedIn',
+        icon: Linkedin,
+      },
+      {
+        href: `mailto:?subject=${encodeURIComponent(shareTitle)}&body=${encodeURIComponent(shareUrl)}`,
+        label: 'Email',
+        icon: Mail,
+      },
+    ]
+  }, [event, shareTitle, shareUrl])
+
   return (
     <>
       <Helmet>
         <title>{pageTitle}</title>
         <meta name="description" content={pageDescription} />
         <link rel="canonical" href={canonicalUrl} />
-        <meta property="og:title" content={pageTitle} />
+        <meta property="og:title" content={shareTitle} />
         <meta property="og:description" content={pageDescription} />
-        {event?.image && <meta property="og:image" content={event.image} />}
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={canonicalUrl} />
+        {ogImage && <meta property="og:image" content={ogImage} />}
+        {ogImage && <meta property="og:image:alt" content={shareTitle} />}
+        <meta name="twitter:card" content={ogImage ? 'summary_large_image' : 'summary'} />
+        <meta name="twitter:title" content={shareTitle} />
+        <meta name="twitter:description" content={pageDescription} />
+        {ogImage && <meta name="twitter:image" content={ogImage} />}
         {event?.hidden && <meta name="robots" content="noindex" />}
         {schema && <script type="application/ld+json">{schema}</script>}
       </Helmet>
@@ -264,27 +389,6 @@ export default function EventDetailPage() {
                     {event.category && <span>{event.category}</span>}
                   </div>
                   <h1 className="text-3xl font-semibold tracking-tight text-slate-900">{event.title}</h1>
-                  <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
-                    {event.status === 'published' ? (
-                      <span className="inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">
-                        Published
-                      </span>
-                    ) : (
-                      <span className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
-                        {event.status.charAt(0).toUpperCase() + event.status.slice(1)}
-                      </span>
-                    )}
-                    {event.hidden && (
-                      <span className="inline-flex items-center rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-700">
-                        Hidden from listings
-                      </span>
-                    )}
-                    {event.archived && (
-                      <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-1 text-xs font-semibold text-slate-700">
-                        Archived
-                      </span>
-                    )}
-                  </div>
                   {dateLabel && <p className="text-base text-slate-700">{dateLabel}</p>}
                   {event.locationName && (
                     <p className="flex items-center gap-2 text-sm text-slate-600">
@@ -302,6 +406,46 @@ export default function EventDetailPage() {
                       {summaryParagraphs.map((paragraph, index) => (
                         <p key={index}>{paragraph}</p>
                       ))}
+                    </div>
+                  )}
+                  {shareLinks.length > 0 && (
+                    <div className="space-y-3 pt-2">
+                      <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Share this event
+                      </div>
+                      <div className="flex flex-wrap gap-3 text-sm font-medium">
+                        {shareLinks.map(({ href, label, icon: Icon }) => (
+                          <a
+                            key={label}
+                            href={href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                          >
+                            <Icon className="h-4 w-4" aria-hidden="true" />
+                            {label}
+                          </a>
+                        ))}
+                        <button
+                          type="button"
+                          onClick={handleShare}
+                          className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                        >
+                          Share
+                          <Share2 className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={async () => {
+                            const copied = await copyTextToClipboard(shareUrl)
+                            if (copied) showShareToast()
+                          }}
+                          className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                        >
+                          Copy link
+                          <Copy className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                      </div>
                     </div>
                   )}
                 </div>
@@ -406,6 +550,16 @@ export default function EventDetailPage() {
       </main>
 
       <Footer />
+
+      <div className="sr-only" role="status" aria-live="polite">
+        {shareToastVisible ? 'Link copied to clipboard' : ''}
+      </div>
+
+      {shareToastVisible && (
+        <div className="fixed inset-x-4 bottom-6 z-50 mx-auto max-w-sm rounded-full bg-emerald-600 px-4 py-2 text-center text-xs font-semibold text-white shadow-lg">
+          Link copied
+        </div>
+      )}
     </>
   )
 }

--- a/src/community/EventsArchivePage.js
+++ b/src/community/EventsArchivePage.js
@@ -61,7 +61,7 @@ function ArchiveEventCard({ event }) {
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <h3 className="text-xl font-semibold text-slate-900">
-            <Link to={`/community/events/${event.slug}`} className="hover:text-emerald-700">
+            <Link to={`/events/${event.slug}`} className="hover:text-emerald-700">
               {event.title}
             </Link>
           </h3>
@@ -96,7 +96,7 @@ function ArchiveEventCard({ event }) {
 
       <div className="mt-auto flex flex-wrap gap-3 text-sm font-medium">
         <Link
-          to={`/community/events/${event.slug}`}
+          to={`/events/${event.slug}`}
           className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
         >
           View details

--- a/src/community/eventUtils.js
+++ b/src/community/eventUtils.js
@@ -1,5 +1,16 @@
 import { RRule } from 'rrule'
 
+function slugify(value) {
+  if (!value) return ''
+  return String(value)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .trim()
+}
+
 export const CATEGORY_OPTIONS = [
   'Family',
   'Festivals',
@@ -61,6 +72,9 @@ export function sanitizeEvent(raw) {
   const endDateObj = parseDate(raw.endDate) || startDateObj
   const durationMs = getDuration(startDateObj, endDateObj)
 
+  const initialSlug = typeof raw.slug === 'string' ? raw.slug.trim() : ''
+  const slug = initialSlug || slugify(raw.title)
+
   const description = typeof raw.description === 'string' ? raw.description : ''
   const summary = typeof raw.summary === 'string' ? raw.summary : ''
   const locationName = typeof raw.locationName === 'string' ? raw.locationName : ''
@@ -83,7 +97,7 @@ export function sanitizeEvent(raw) {
   return {
     ...raw,
     title: String(raw.title || '').trim(),
-    slug: String(raw.slug || '').trim(),
+    slug,
     category: String(raw.category || ''),
     town,
     subArea,
@@ -436,7 +450,7 @@ function buildEventSchema(event, origin) {
   const start = occurrence?.start || event.startDateObj
   const end = occurrence?.end || event.endDateObj || occurrence?.start
   const image = absoluteUrl(origin, event.image)
-  const url = absoluteUrl(origin, `/community/events/${encodeURIComponent(event.slug)}`)
+  const url = absoluteUrl(origin, `/events/${encodeURIComponent(event.slug)}`)
   const eventUrl = event.eventUrl || url
 
   const location = {
@@ -491,7 +505,7 @@ function getWindowOrigin() {
   if (typeof window !== 'undefined' && window.location?.origin) {
     return window.location.origin
   }
-  return 'https://www.northsidegta.ca'
+  return 'https://northsidegta.ca'
 }
 
 function absoluteUrl(origin, value) {


### PR DESCRIPTION
## Summary
- enable hash-based deep links on the community page, add share buttons, and highlight linked cards
- create public `/events/:slug` pages with social sharing metadata and buttons
- generate missing slugs, update sitemap generation, and link archive cards to the new per-event route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e10cdc7f5483249683a59b87cd8aa5