### PR TITLE
Add share controls and structured event metadata

### DIFF
--- a/docs/qa-event-share.md
+++ b/docs/qa-event-share.md
@@ -1,0 +1,34 @@
+# Event Share QA Checklist
+
+The following real events were used to confirm share controls, metadata, and fallbacks:
+
+1. **Finally Home Agents Golf Tournament**  
+   Slug: `2025-10-04-finally-home-agents-golf-tournament-scramble-at-mill-run`  
+   *Has hero image, onsite location, single-day.*
+2. **Aurora Cultural Centre Fall Exhibition**  
+   Slug: `aurora-cultural-centre-10002644-1758067200-1760572799-auroraculturalcentre.ca-20250916`  
+   *No image (fallback cover used), multi-day date range, onsite.*
+3. **Tourism Now Workshop (Discover Stouffville)**  
+   Slug: `discover-stouffville-https-discoverstouffville.ca-event-tourism-now--20251023`  
+   *Detailed description, includes postal code and organizer metadata.*
+
+## Manual Verification Steps
+
+- Load each `/events/:slug` page and ensure the Share button is visible beside “Add to calendar” on desktop and mobile breakpoints.
+- Trigger the Share button:
+  - On mobile (Web Share API available) verify the native share sheet opens with the correct title and URL.
+  - On desktop verify the canonical URL is copied to the clipboard and the “Link copied” toast appears and dismisses automatically.
+- Use the “Copy link” button in the social section to confirm the clipboard fallback also triggers the toast.
+- Inspect the page `<head>` (or View Source) and verify:
+  - `<title>` follows the `${event.title} | NorthSide GTA` format.
+  - Canonical, Open Graph, and Twitter tags all point to `https://northsidegta.ca/events/:slug` with the event-specific description and image.
+  - JSON-LD script contains `@type: "Event"` with start/end dates, attendance mode, location PostalAddress, and image array.
+- Paste the event URL into Slack or iMessage to confirm the preview uses the event-specific metadata (title, description, and hero/fallback image).
+- Validate the JSON-LD with [Google’s Rich Results Test](https://search.google.com/test/rich-results) for at least one event; ensure it passes as an Event.
+- Confirm each slug appears in `public/sitemap.xml` under `/events/:slug` after running `npm run build` (or `node scripts/generate-sitemap.js`).
+
+## Notes
+
+- The Share toast uses an `aria-live="polite"` region so screen readers announce clipboard success without stealing focus.
+- Fallback Open Graph art is `/Images/hero-desktop.jpg` at the required aspect ratio.
+- Events without explicit province/country default to `ON` and `CA` in structured data.

--- a/scripts/ingest-events.js
+++ b/scripts/ingest-events.js
@@ -413,6 +413,17 @@ function normalizeEvent(item, feed) {
   const subArea =
     subAreaRaw && town && subAreaRaw.toLowerCase() === town.toLowerCase() ? '' : subAreaRaw
 
+  const slugBase = feed.slugPrefix ? `${feed.slugPrefix}-${title}` : title
+  const slugDate = formatDateForSlug(start)
+  const slugParts = [slugDate, feed.slugPrefix ? slugify(feed.slugPrefix) : '', slugify(title), slugify(town)]
+    .filter(Boolean)
+    .join('-')
+  const fallbackSlugParts = [slugify(title), slugify(town), slugDate, slugify(feed.id || '')]
+    .filter(Boolean)
+    .join('-')
+  const slug =
+    slugify(slugParts) || slugify(fallbackSlugParts) || slugify(`${slugBase}-${slugDate}`) || slugify(slugBase)
+
   const sourceInfo = resolveSourceInfo(item, feed, eventUrl)
 
   const badges = mergeUnique(
@@ -641,6 +652,16 @@ function slugify(value) {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 60)
+}
+
+function formatDateForSlug(value) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  const year = date.getUTCFullYear()
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getUTCDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 function cleanText(value) {

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -1153,8 +1153,13 @@ function normalizeEvent(item, feed, now) {
   const sourceId = sourceRef || `${feed.id || slugify(title)}-${start}`
 
   const slugDate = formatDateForSlug(start)
-  const slugBase = `${sourceName.toLowerCase()}:${sourceId}-${slugDate}`
-  const slug = makeFileSafeSlug(slugBase)
+  const slugParts = [slugDate, slugify(title), slugify(town || locationName || feed.town || '')]
+    .filter(Boolean)
+    .join('-')
+  const fallbackSlugParts = [slugify(title), slugify(sourceName), slugDate, slugify(sourceId)]
+    .filter(Boolean)
+    .join('-')
+  const slug = makeFileSafeSlug(slugParts || fallbackSlugParts || `${sourceName}-${sourceId}`)
 
   return {
     id: sourceId,

--- a/src/community/EventCard.js
+++ b/src/community/EventCard.js
@@ -7,6 +7,7 @@ import {
   Share2,
 } from 'lucide-react'
 import { BADGE_LABELS, formatDateRange, generateIcsContent } from './eventUtils'
+import { getCanonicalEventUrl, shareEvent } from './shareUtils'
 
 function PlaceholderImage() {
   return (
@@ -51,9 +52,8 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
       )}`
     : ''
 
-  const shareUrl = event.slug
-    ? `https://northsidegta.ca/community#event-${encodeURIComponent(event.slug)}`
-    : ''
+  const shareUrl = event.slug ? getCanonicalEventUrl(event.slug) : ''
+  const shareText = event.summary || event.title
 
   const [showToast, setShowToast] = React.useState(false)
   const toastTimeoutRef = React.useRef(null)
@@ -63,36 +63,6 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
       if (toastTimeoutRef.current) {
         clearTimeout(toastTimeoutRef.current)
       }
-    }
-  }, [])
-
-  const copyToClipboard = React.useCallback(async (text) => {
-    if (!text) return false
-    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-      try {
-        await navigator.clipboard.writeText(text)
-        return true
-      } catch (error) {
-        console.warn('Clipboard write failed, falling back', error)
-      }
-    }
-
-    if (typeof document === 'undefined') return false
-
-    try {
-      const textarea = document.createElement('textarea')
-      textarea.value = text
-      textarea.style.position = 'fixed'
-      textarea.style.opacity = '0'
-      document.body.appendChild(textarea)
-      textarea.focus()
-      textarea.select()
-      const successful = document.execCommand('copy')
-      document.body.removeChild(textarea)
-      return successful
-    } catch (fallbackError) {
-      console.warn('Unable to copy share URL', fallbackError)
-      return false
     }
   }, [])
 
@@ -106,25 +76,11 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
 
   const handleShare = React.useCallback(async () => {
     if (!shareUrl) return
-    const copied = await copyToClipboard(shareUrl)
-    if (copied) {
+    const result = await shareEvent({ url: shareUrl, title: event.title, text: shareText })
+    if (result.copied) {
       showCopiedToast()
     }
-
-    if (typeof navigator !== 'undefined' && navigator.share) {
-      try {
-        await navigator.share({
-          title: event.title,
-          text: event.summary || event.title,
-          url: shareUrl,
-        })
-      } catch (err) {
-        if (err?.name !== 'AbortError') {
-          console.warn('Share aborted', err)
-        }
-      }
-    }
-  }, [copyToClipboard, event.summary, event.title, shareUrl, showCopiedToast])
+  }, [event.title, shareText, shareUrl, showCopiedToast])
 
   const hasDetailPage = Boolean(event.slug)
   const eventSiteHref = hasDetailPage ? `/events/${encodeURIComponent(event.slug)}` : event.eventUrl
@@ -258,7 +214,8 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
             <button
               type="button"
               onClick={handleShare}
-              className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+              className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+              aria-label={`Share ${event.title}`}
             >
               Share
               <Share2 className="h-4 w-4" aria-hidden="true" />

--- a/src/community/EventDetailPage.js
+++ b/src/community/EventDetailPage.js
@@ -16,16 +16,16 @@ import {
 import Navigation from '../Navigation'
 import Footer from '../Footer'
 import { sanitizeEvent, formatDateRange, generateIcsContent } from './eventUtils'
+import {
+  copyTextToClipboard,
+  getCanonicalEventUrl,
+  getSiteOrigin,
+  shareEvent,
+  toAbsoluteUrl,
+} from './shareUtils'
 
 const SITE_ORIGIN = 'https://northsidegta.ca'
 const FALLBACK_IMAGE = '/Images/hero-desktop.jpg'
-
-function getSiteOrigin(defaultOrigin = SITE_ORIGIN) {
-  if (typeof window !== 'undefined' && window.location?.origin) {
-    return window.location.origin
-  }
-  return defaultOrigin
-}
 
 function normalizeWhitespace(text) {
   if (typeof text !== 'string') return ''
@@ -54,18 +54,10 @@ function splitParagraphs(text) {
     .filter(Boolean)
 }
 
-function toAbsoluteUrl(path, origin = SITE_ORIGIN) {
-  if (!path) return ''
-  if (/^https?:\/\//i.test(path)) return path
-  const base = typeof origin === 'string' && origin ? origin.replace(/\/$/, '') : SITE_ORIGIN
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`
-  return `${base}${normalizedPath}`
-}
-
 function buildEventSchema(event, origin = SITE_ORIGIN, descriptionOverride = '') {
   if (!event) return null
   const baseOrigin = typeof origin === 'string' && origin ? origin : SITE_ORIGIN
-  const canonical = `${baseOrigin.replace(/\/$/, '')}/events/${encodeURIComponent(event.slug)}`
+  const canonical = getCanonicalEventUrl(event.slug, baseOrigin)
   const start = event.startDateObj || (event.startDate ? new Date(event.startDate) : null)
   const end = event.endDateObj || start
   const image = event.image
@@ -78,10 +70,15 @@ function buildEventSchema(event, origin = SITE_ORIGIN, descriptionOverride = '')
     name: event.locationName || event.town || 'NorthSide GTA',
   }
 
-  if (event.address) {
-    location.address = event.address
-  } else if (event.town) {
-    location.address = `${event.town}, Ontario`
+  if (event.address || event.town || event.postalCode) {
+    location.address = {
+      '@type': 'PostalAddress',
+      streetAddress: event.address || '',
+      addressLocality: event.town || event.subArea || 'NorthSide GTA',
+      addressRegion: event.addressRegion || 'ON',
+      postalCode: event.postalCode || '',
+      addressCountry: event.addressCountry || 'CA',
+    }
   }
 
   if (event.hasLocation) {
@@ -103,6 +100,10 @@ function buildEventSchema(event, origin = SITE_ORIGIN, descriptionOverride = '')
     offers.priceCurrency = 'CAD'
   }
 
+  const attendanceMode = event.hasLocation || event.address || event.locationName
+    ? 'https://schema.org/OfflineEventAttendanceMode'
+    : 'https://schema.org/OnlineEventAttendanceMode'
+
   const schema = {
     '@context': 'https://schema.org',
     '@type': 'Event',
@@ -110,7 +111,7 @@ function buildEventSchema(event, origin = SITE_ORIGIN, descriptionOverride = '')
     startDate: start ? new Date(start).toISOString() : event.startDate,
     endDate: end ? new Date(end).toISOString() : event.endDate || event.startDate,
     eventStatus: 'https://schema.org/EventScheduled',
-    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    eventAttendanceMode: attendanceMode,
     description,
     location,
     offers,
@@ -130,36 +131,6 @@ function buildEventSchema(event, origin = SITE_ORIGIN, descriptionOverride = '')
   }
 
   return JSON.stringify(schema, null, 2)
-}
-
-async function copyTextToClipboard(text) {
-  if (!text) return false
-  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(text)
-      return true
-    } catch (error) {
-      console.warn('Clipboard write failed, falling back', error)
-    }
-  }
-
-  if (typeof document === 'undefined') return false
-
-  try {
-    const textarea = document.createElement('textarea')
-    textarea.value = text
-    textarea.style.position = 'fixed'
-    textarea.style.opacity = '0'
-    document.body.appendChild(textarea)
-    textarea.focus()
-    textarea.select()
-    const successful = document.execCommand('copy')
-    document.body.removeChild(textarea)
-    return successful
-  } catch (error) {
-    console.warn('Unable to copy share URL', error)
-    return false
-  }
 }
 
 export default function EventDetailPage() {
@@ -275,18 +246,16 @@ export default function EventDetailPage() {
     return ''
   }, [event])
 
-  const truncatedDescription = event ? truncateText(eventDescription || '', 200) : ''
+  const truncatedDescription = event ? truncateText(eventDescription || '', 160) : ''
   const schema = React.useMemo(
     () => buildEventSchema(event, normalizedOrigin, truncatedDescription || eventDescription),
     [event, eventDescription, normalizedOrigin, truncatedDescription],
   )
 
-  const pageTitle = event ? `${event.title} • NorthSide GTA Events` : 'Event Details • NorthSide GTA'
+  const pageTitle = event ? `${event.title} | NorthSide GTA` : 'Event Details | NorthSide GTA'
   const defaultDescription = 'Explore community events across the NorthSide GTA.'
   const pageDescription = truncatedDescription || eventDescription || defaultDescription
-  const canonicalUrl = event
-    ? `${normalizedOrigin}/events/${encodeURIComponent(event.slug)}`
-    : `${normalizedOrigin}/events`
+  const canonicalUrl = event ? getCanonicalEventUrl(event.slug, normalizedOrigin) : `${normalizedOrigin}/events`
   const ogImage = event?.image
     ? toAbsoluteUrl(event.image, normalizedOrigin)
     : toAbsoluteUrl(FALLBACK_IMAGE, normalizedOrigin)
@@ -294,6 +263,7 @@ export default function EventDetailPage() {
   const shareTitle = event ? event.title : 'NorthSide GTA Event'
   const shareText = event ? pageDescription : 'Check out this NorthSide GTA event.'
   const emailBody = shareText ? `${shareText}\n\n${shareUrl}` : shareUrl
+  const publishedTime = event?.startDate ? new Date(event.startDate).toISOString() : ''
 
   const handleAddToCalendar = React.useCallback(() => {
     if (!event) return
@@ -326,23 +296,9 @@ export default function EventDetailPage() {
   }, [])
 
   const handleShare = React.useCallback(async () => {
-    const copied = await copyTextToClipboard(shareUrl)
-    if (copied) {
+    const result = await shareEvent({ url: shareUrl, title: shareTitle, text: shareText })
+    if (result.copied) {
       showShareToast()
-    }
-
-    if (typeof navigator !== 'undefined' && navigator.share) {
-      try {
-        await navigator.share({
-          title: shareTitle,
-          text: shareText,
-          url: shareUrl,
-        })
-      } catch (error) {
-        if (error?.name !== 'AbortError') {
-          console.warn('Share aborted', error)
-        }
-      }
     }
   }, [shareText, shareTitle, shareUrl, showShareToast])
 
@@ -384,10 +340,13 @@ export default function EventDetailPage() {
         <meta property="og:url" content={canonicalUrl} />
         {ogImage && <meta property="og:image" content={ogImage} />}
         {ogImage && <meta property="og:image:alt" content={shareTitle} />}
+        <meta property="og:site_name" content="NorthSide GTA" />
+        {publishedTime && <meta property="article:published_time" content={publishedTime} />}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={shareTitle} />
         <meta name="twitter:description" content={pageDescription} />
         {ogImage && <meta name="twitter:image" content={ogImage} />}
+        {ogImage && <meta name="twitter:image:alt" content={shareTitle} />}
         {event?.hidden && <meta name="robots" content="noindex" />}
         {schema && <script type="application/ld+json">{schema}</script>}
       </Helmet>
@@ -468,7 +427,7 @@ export default function EventDetailPage() {
                             href={href}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                            className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
                           >
                             <Icon className="h-4 w-4" aria-hidden="true" />
                             {label}
@@ -477,7 +436,8 @@ export default function EventDetailPage() {
                         <button
                           type="button"
                           onClick={handleShare}
-                          className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                          className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+                          aria-label="Share this event"
                         >
                           Share
                           <Share2 className="h-4 w-4" aria-hidden="true" />
@@ -488,7 +448,7 @@ export default function EventDetailPage() {
                             const copied = await copyTextToClipboard(shareUrl)
                             if (copied) showShareToast()
                           }}
-                          className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                          className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
                         >
                           Copy link
                           <Copy className="h-4 w-4" aria-hidden="true" />
@@ -512,7 +472,7 @@ export default function EventDetailPage() {
                       href={event.eventUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                      className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
                     >
                       Event site
                       <ExternalLink className="h-4 w-4" aria-hidden="true" />
@@ -521,17 +481,26 @@ export default function EventDetailPage() {
                   <button
                     type="button"
                     onClick={handleAddToCalendar}
-                    className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
                   >
                     Add to calendar
                     <CalendarPlus className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleShare}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+                    aria-label="Share this event"
+                  >
+                    Share
+                    <Share2 className="h-4 w-4" aria-hidden="true" />
                   </button>
                   {mapLink && (
                     <a
                       href={mapLink}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                      className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
                     >
                       Map & directions
                       <MapPin className="h-4 w-4" aria-hidden="true" />

--- a/src/community/EventModal.js
+++ b/src/community/EventModal.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { X, MapPin, ExternalLink, CalendarPlus } from 'lucide-react'
+import { X, MapPin, ExternalLink, CalendarPlus, Share2 } from 'lucide-react'
 import { BADGE_LABELS, formatDateRange, generateIcsContent } from './eventUtils'
+import { getCanonicalEventUrl, shareEvent } from './shareUtils'
 
 function getModalRoot() {
   if (typeof document === 'undefined') return null
@@ -31,6 +32,8 @@ export default function EventModal({ event, onClose }) {
   const townLabel = townParts.join(', ') || 'NorthSide GTA'
   const sourceLabel = event?.sourceName || event?.sourceDomain || 'Source'
   const sourceTypeLabel = event?.source === 'feed' ? 'Feed' : 'Manual'
+  const [shareToastVisible, setShareToastVisible] = React.useState(false)
+  const shareToastTimeoutRef = React.useRef(null)
 
   React.useEffect(() => {
     if (typeof document === 'undefined') return undefined
@@ -49,6 +52,14 @@ export default function EventModal({ event, onClose }) {
       document.removeEventListener('keydown', handleKeydown)
     }
   }, [onClose])
+
+  React.useEffect(() => {
+    return () => {
+      if (shareToastTimeoutRef.current) {
+        clearTimeout(shareToastTimeoutRef.current)
+      }
+    }
+  }, [])
 
   if (!modalRoot || !event) return null
 
@@ -85,6 +96,24 @@ export default function EventModal({ event, onClose }) {
     : ''
 
   const descriptionParagraphs = splitParagraphs(event.description || event.summary || '')
+  const shareUrl = event.slug ? getCanonicalEventUrl(event.slug) : event.eventUrl || ''
+  const shareText = event.summary || event.title
+
+  const showShareToast = React.useCallback(() => {
+    setShareToastVisible(true)
+    if (shareToastTimeoutRef.current) {
+      clearTimeout(shareToastTimeoutRef.current)
+    }
+    shareToastTimeoutRef.current = setTimeout(() => setShareToastVisible(false), 2000)
+  }, [])
+
+  const handleShare = React.useCallback(async () => {
+    if (!shareUrl) return
+    const result = await shareEvent({ url: shareUrl, title: event.title, text: shareText })
+    if (result.copied) {
+      showShareToast()
+    }
+  }, [event.title, shareText, shareUrl, showShareToast])
 
   const modal = (
     <div
@@ -94,6 +123,9 @@ export default function EventModal({ event, onClose }) {
       aria-labelledby="event-modal-title"
     >
       <div className="relative w-full max-w-3xl rounded-3xl bg-white shadow-2xl">
+        <div className="sr-only" role="status" aria-live="polite">
+          {shareToastVisible ? 'Link copied to clipboard' : ''}
+        </div>
         <button
           type="button"
           onClick={onClose}
@@ -102,6 +134,12 @@ export default function EventModal({ event, onClose }) {
         >
           <X className="h-5 w-5" aria-hidden="true" />
         </button>
+
+        {shareToastVisible && (
+          <div className="pointer-events-none absolute left-1/2 top-6 -translate-x-1/2 rounded-full bg-emerald-600/90 px-4 py-2 text-xs font-medium text-white shadow-lg">
+            Link copied
+          </div>
+        )}
 
         {event.image && (
           <img
@@ -165,36 +203,47 @@ export default function EventModal({ event, onClose }) {
           )}
 
           <div className="flex flex-wrap gap-3 text-sm font-medium">
-            {event.eventUrl && (
-              <a
-                href={event.eventUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-slate-700 hover:border-slate-300 hover:text-slate-900"
-              >
-                Event site
-                <ExternalLink className="h-4 w-4" aria-hidden="true" />
-              </a>
-            )}
+          {event.eventUrl && (
+            <a
+              href={event.eventUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-slate-700 hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+            >
+              Event site
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={handleAddToCalendar}
+            className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-slate-700 hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+          >
+            Add to calendar
+            <CalendarPlus className="h-4 w-4" aria-hidden="true" />
+          </button>
+          {shareUrl && (
             <button
               type="button"
-              onClick={handleAddToCalendar}
-              className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-slate-700 hover:border-slate-300 hover:text-slate-900"
+              onClick={handleShare}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-slate-700 hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+              aria-label={`Share ${event.title}`}
             >
-              Add to calendar
-              <CalendarPlus className="h-4 w-4" aria-hidden="true" />
+              Share
+              <Share2 className="h-4 w-4" aria-hidden="true" />
             </button>
-            {mapLink && (
-              <a
-                href={mapLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-slate-700 hover:border-slate-300 hover:text-slate-900"
-              >
-                Map & directions
-                <MapPin className="h-4 w-4" aria-hidden="true" />
-              </a>
-            )}
+          )}
+          {mapLink && (
+            <a
+              href={mapLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-slate-700 hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+            >
+              Map & directions
+              <MapPin className="h-4 w-4" aria-hidden="true" />
+            </a>
+          )}
           </div>
 
           {mapEmbedSrc && (

--- a/src/community/eventUtils.js
+++ b/src/community/eventUtils.js
@@ -11,6 +11,40 @@ function slugify(value) {
     .trim()
 }
 
+function formatDateForSlug(value) {
+  if (!value) return ''
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return ''
+  const year = parsed.getFullYear()
+  const month = `${parsed.getMonth() + 1}`.padStart(2, '0')
+  const day = `${parsed.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function buildEventSlug(raw = {}) {
+  if (raw && typeof raw.slug === 'string' && raw.slug.trim()) {
+    return raw.slug.trim()
+  }
+
+  const datePart = formatDateForSlug(raw.startDate || raw.start || raw.begin)
+  const titlePart = slugify(raw.title || raw.name || '')
+  const townPart = slugify(raw.town || raw.locationName || '')
+  const primary = [datePart, titlePart, townPart].filter(Boolean).join('-')
+
+  const fallback = [
+    titlePart,
+    slugify(raw.sourceName || ''),
+    slugify(raw.sourceRef || ''),
+    slugify(raw.id || ''),
+  ]
+    .filter(Boolean)
+    .join('-')
+
+  const urlFallback = slugify(raw.eventUrl || raw.url || '')
+
+  return slugify(primary) || slugify(fallback) || urlFallback || ''
+}
+
 export const CATEGORY_OPTIONS = [
   'Family',
   'Festivals',
@@ -72,8 +106,7 @@ export function sanitizeEvent(raw) {
   const endDateObj = parseDate(raw.endDate) || startDateObj
   const durationMs = getDuration(startDateObj, endDateObj)
 
-  const initialSlug = typeof raw.slug === 'string' ? raw.slug.trim() : ''
-  const slug = initialSlug || slugify(raw.title)
+  const slug = buildEventSlug(raw)
 
   const description = typeof raw.description === 'string' ? raw.description : ''
   const summary = typeof raw.summary === 'string' ? raw.summary : ''
@@ -81,6 +114,17 @@ export function sanitizeEvent(raw) {
   const address = typeof raw.address === 'string' ? raw.address : ''
   const town = typeof raw.town === 'string' ? raw.town : ''
   const subArea = typeof raw.subArea === 'string' ? raw.subArea : ''
+  const addressRegion =
+    typeof raw.addressRegion === 'string' && raw.addressRegion.trim()
+      ? raw.addressRegion.trim()
+      : typeof raw.province === 'string' && raw.province.trim()
+        ? raw.province.trim()
+        : ''
+  const addressCountry =
+    typeof raw.addressCountry === 'string' && raw.addressCountry.trim()
+      ? raw.addressCountry.trim()
+      : ''
+  const postalCode = typeof raw.postalCode === 'string' ? raw.postalCode.trim() : ''
   const sourceName = typeof raw.sourceName === 'string' ? raw.sourceName.trim() : ''
   const sourceUrl = typeof raw.sourceUrl === 'string' ? raw.sourceUrl.trim() : ''
   const sourceDomain = typeof raw.sourceDomain === 'string' ? raw.sourceDomain.trim() : ''
@@ -112,6 +156,9 @@ export function sanitizeEvent(raw) {
     description,
     locationName,
     address,
+    addressRegion,
+    addressCountry,
+    postalCode,
     priceType: normalizePriceType(raw.priceType),
     priceNote: typeof raw.priceNote === 'string' ? raw.priceNote.trim() : '',
     badges: Array.isArray(raw.badges) ? raw.badges.filter((badge) => BADGE_LABELS[badge]) : [],

--- a/src/community/shareUtils.js
+++ b/src/community/shareUtils.js
@@ -1,0 +1,111 @@
+export const DEFAULT_SITE_ORIGIN = 'https://northsidegta.ca'
+
+export function getSiteOrigin(fallback = DEFAULT_SITE_ORIGIN) {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin
+  }
+  return fallback
+}
+
+export function toAbsoluteUrl(path, origin = DEFAULT_SITE_ORIGIN) {
+  if (!path) return ''
+  if (/^https?:\/\//i.test(path)) return path
+  const normalizedOrigin = (origin || DEFAULT_SITE_ORIGIN).replace(/\/$/, '')
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${normalizedOrigin}${normalizedPath}`
+}
+
+export function formatDateForSlug(value) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function slugify(value) {
+  if (!value) return ''
+  return String(value)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .trim()
+}
+
+export function buildEventSlug(raw = {}) {
+  if (raw && typeof raw.slug === 'string' && raw.slug.trim()) {
+    return raw.slug.trim()
+  }
+
+  const titleSlug = slugify(raw.title)
+  const townSlug = slugify(raw.town || raw.locationName || '')
+  const dateSlug = formatDateForSlug(raw.startDate || raw.start || raw.begin)
+  const baseParts = [dateSlug, titleSlug, townSlug].filter(Boolean)
+
+  const base = baseParts.length > 0 ? baseParts.join('-') : titleSlug
+  const fallback = raw.eventUrl || raw.sourceRef || raw.sourceName || raw.id || ''
+  const candidate = slugify(base) || slugify(fallback) || ''
+  return candidate
+}
+
+export async function copyTextToClipboard(text) {
+  if (!text) return false
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch (error) {
+      console.warn('Clipboard write failed, falling back', error)
+    }
+  }
+
+  if (typeof document === 'undefined') return false
+
+  try {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.style.position = 'fixed'
+    textarea.style.opacity = '0'
+    document.body.appendChild(textarea)
+    textarea.focus()
+    textarea.select()
+    const successful = document.execCommand('copy')
+    document.body.removeChild(textarea)
+    return successful
+  } catch (error) {
+    console.warn('Unable to copy share URL', error)
+    return false
+  }
+}
+
+export async function shareEvent({ url, title, text }) {
+  if (!url) {
+    return { usedNative: false, copied: false, aborted: false }
+  }
+
+  if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+    try {
+      await navigator.share({ title, text, url })
+      return { usedNative: true, copied: false, aborted: false }
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        return { usedNative: true, copied: false, aborted: true }
+      }
+      console.warn('Native share failed, falling back', error)
+    }
+  }
+
+  const copied = await copyTextToClipboard(url)
+  return { usedNative: false, copied, aborted: false }
+}
+
+export function getCanonicalEventUrl(slug, origin = getSiteOrigin()) {
+  if (!slug) return ''
+  const safeSlug = encodeURIComponent(slug)
+  const normalizedOrigin = (origin || DEFAULT_SITE_ORIGIN).replace(/\/$/, '')
+  return `${normalizedOrigin}/events/${safeSlug}`
+}


### PR DESCRIPTION
## Summary
- add reusable share utilities and surface share buttons alongside calendar actions on event detail, card, and modal views with accessible clipboard fallbacks
- emit event-specific SEO metadata (canonical, Open Graph, Twitter, JSON-LD) from the detail page and document QA coverage for multiple event scenarios
- harden event slug generation for ingest/sync scripts to use date, title, and town for stable sitemap URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e1cacd34208324b3d18e5e23a9aa14