### PR TITLE
feat(events): support per-day schedules

### DIFF
--- a/lib/events/ics.js
+++ b/lib/events/ics.js
@@ -1,0 +1,439 @@
+const { DateTime } = require('luxon')
+
+const DEFAULT_TIMEZONE = 'America/Toronto'
+const RRULE_LOOKAHEAD_MONTHS = 6
+const RRULE_MAX_OCCURRENCES = 120
+const MAX_SCHEDULE_DAYS = 120
+
+function expandIcsEvents(entries, feed = {}, now = new Date()) {
+  if (!Array.isArray(entries) || !entries.length) return []
+
+  const groups = new Map()
+
+  for (const entry of entries) {
+    if (!entry || entry.type !== 'VEVENT') continue
+    const key = buildGroupKey(entry)
+    if (!groups.has(key)) {
+      groups.set(key, { base: entry, events: [] })
+    }
+    const group = groups.get(key)
+    group.events.push(entry)
+    if (!group.base || shouldPreferEntry(entry, group.base)) {
+      group.base = entry
+    }
+  }
+
+  const results = []
+  for (const group of groups.values()) {
+    const aggregated = aggregateGroup(group, feed, now)
+    if (aggregated) {
+      results.push(aggregated)
+    }
+  }
+
+  return results
+}
+
+function aggregateGroup(group, feed, now) {
+  const base = group?.base
+  if (!base) return null
+
+  const timezone = inferTimezone(base, feed)
+  const allEvents = Array.isArray(group.events) && group.events.length ? group.events : [base]
+
+  let occurrences = []
+  for (const event of allEvents) {
+    occurrences.push(...convertEventToOccurrences(event, timezone))
+  }
+
+  if (base.rrule) {
+    occurrences.push(...expandRruleOccurrences(base, timezone, now))
+  }
+
+  if (!occurrences.length) {
+    occurrences = deriveOccurrencesFromSingleSpan(base, timezone)
+  }
+
+  const deduped = dedupeOccurrences(occurrences)
+  if (!deduped.length) {
+    return normalizeLegacy(base)
+  }
+
+  deduped.sort((a, b) => a.start.toMillis() - b.start.toMillis())
+
+  const schedule = []
+  let earliest = null
+  let latest = null
+
+  for (const occurrence of deduped) {
+    if (!occurrence?.start || !occurrence?.end || !occurrence.start.isValid || !occurrence.end.isValid) {
+      continue
+    }
+    const isoDate = occurrence.start.toISODate()
+    if (!isoDate) continue
+
+    if (!earliest || occurrence.start < earliest) {
+      earliest = occurrence.start
+    }
+    if (!latest || occurrence.end > latest) {
+      latest = occurrence.end
+    }
+
+    if (occurrence.allDay) {
+      schedule.push({
+        date: isoDate,
+        start_time: '',
+        end_time: '',
+        all_day: true,
+      })
+    } else {
+      schedule.push({
+        date: isoDate,
+        start_time: occurrence.start.toFormat('HH:mm'),
+        end_time: occurrence.end.toFormat('HH:mm'),
+        all_day: false,
+      })
+    }
+  }
+
+  if (!schedule.length) {
+    return normalizeLegacy(base)
+  }
+
+  const normalized = {
+    ...base,
+    start: earliest ? earliest.toISO() : base.start,
+    end: latest ? latest.toISO() : base.end,
+    use_daily_schedule: true,
+    daily_schedule: schedule,
+  }
+
+  const rruleString = extractRruleString(base)
+  if (rruleString) {
+    normalized.rrule = rruleString
+  }
+
+  if (!normalized.summary && base.summary) {
+    normalized.summary = base.summary
+  }
+  if (!normalized.description && base.description) {
+    normalized.description = base.description
+  }
+  if (!normalized.url && base.url) {
+    normalized.url = base.url
+  }
+
+  return normalized
+}
+
+function normalizeLegacy(base) {
+  const rruleString = extractRruleString(base)
+  const normalized = { ...base }
+  if (rruleString) {
+    normalized.rrule = rruleString
+  }
+  return normalized
+}
+
+function extractRruleString(event) {
+  if (!event?.rrule || typeof event.rrule.toString !== 'function') return ''
+  const raw = event.rrule.toString()
+  if (typeof raw !== 'string') return ''
+  const line = raw
+    .split(/\n+/)
+    .map((entry) => entry.trim())
+    .find((entry) => /^RRULE:/i.test(entry))
+  if (!line) return ''
+  return line.replace(/^RRULE:/i, '')
+}
+
+function buildGroupKey(event) {
+  if (event?.uid) return `uid:${event.uid}`
+  const summary = (event?.summary || '').toLowerCase()
+  const location = (event?.location || '').toLowerCase()
+  const startKey = event?.start instanceof Date ? event.start.toISOString() : ''
+  return `fallback:${summary}|${location}|${startKey}`
+}
+
+function shouldPreferEntry(candidate, current) {
+  const candidateStart = candidate?.start instanceof Date ? candidate.start.getTime() : NaN
+  const currentStart = current?.start instanceof Date ? current.start.getTime() : NaN
+  if (!Number.isFinite(candidateStart)) return false
+  if (!Number.isFinite(currentStart)) return true
+  return candidateStart < currentStart
+}
+
+function inferTimezone(event, feed) {
+  const candidates = [
+    event?.rrule?.options?.tzid,
+    event?.tz,
+    event?.start?.tz,
+    event?.end?.tz,
+  ]
+
+  for (const value of candidates) {
+    if (typeof value === 'string' && value && !isUtcLike(value)) {
+      return value
+    }
+  }
+
+  if (typeof feed?.timezone === 'string' && feed.timezone) {
+    return feed.timezone
+  }
+
+  return DEFAULT_TIMEZONE
+}
+
+function isUtcLike(value) {
+  const normalized = String(value || '').trim().toUpperCase()
+  return normalized === 'UTC' || normalized === 'ETC/UTC' || normalized === 'GMT'
+}
+
+function convertEventToOccurrences(event, timezone) {
+  if (!event) return []
+  const allDay = isAllDayEvent(event)
+  const start = toDateTime(event.start, timezone, { allDay })
+  const end = toDateTime(event.end, timezone, { isEnd: true, allDay })
+  return buildOccurrencesFromRange(start, end, allDay)
+}
+
+function expandRruleOccurrences(event, timezone, now) {
+  const rule = event?.rrule
+  if (!rule) return []
+
+  const baseAllDay = isAllDayEvent(event)
+  const durationMs = computeDurationMs(event, timezone, baseAllDay)
+
+  const windowStart = DateTime.fromJSDate(now instanceof Date ? now : new Date())
+    .setZone(timezone || DEFAULT_TIMEZONE)
+    .startOf('day')
+    .minus({ days: 1 })
+  const windowEnd = windowStart.plus({ months: RRULE_LOOKAHEAD_MONTHS })
+
+  let between = []
+  try {
+    between = rule.between(windowStart.toJSDate(), windowEnd.toJSDate(), true) || []
+  } catch (error) {
+    return []
+  }
+
+  const exdates = new Set()
+  if (event?.exdate && typeof event.exdate === 'object') {
+    for (const value of Object.values(event.exdate)) {
+      const dt = toDateTime(value, timezone, { allDay: baseAllDay })
+      if (dt) exdates.add(dt.toISODate())
+    }
+  }
+
+  const overrides = new Map()
+  if (event?.recurrences && typeof event.recurrences === 'object') {
+    for (const value of Object.values(event.recurrences)) {
+      if (!value) continue
+      const overrideAllDay = isAllDayEvent(value) || baseAllDay
+      const overrideStart =
+        toDateTime(value.start || value.dtstart || value.recurrenceid, timezone, { allDay: overrideAllDay }) ||
+        toDateTime(value.recurrenceid, timezone, { allDay: overrideAllDay })
+      if (overrideStart) {
+        overrides.set(overrideStart.toISODate(), { data: value, allDay: overrideAllDay })
+      }
+    }
+  }
+
+  const occurrences = []
+  for (const occurrenceDate of between) {
+    if (!(occurrenceDate instanceof Date) || occurrences.length >= RRULE_MAX_OCCURRENCES) break
+    const start = DateTime.fromJSDate(occurrenceDate).setZone(timezone || DEFAULT_TIMEZONE)
+    if (!start.isValid) continue
+    const dateKey = start.toISODate()
+    if (exdates.has(dateKey)) continue
+
+    if (overrides.has(dateKey)) {
+      const { data: override, allDay: overrideAllDay } = overrides.get(dateKey)
+      const overrideStart =
+        toDateTime(override.start || override.dtstart || occurrenceDate, timezone, { allDay: overrideAllDay }) || start
+      const overrideEnd =
+        toDateTime(override.end || override.dtend, timezone, { isEnd: true, allDay: overrideAllDay }) ||
+        (durationMs > 0 ? overrideStart.plus({ milliseconds: durationMs }) : null)
+      occurrences.push(...buildOccurrencesFromRange(overrideStart, overrideEnd, overrideAllDay))
+    } else {
+      const end = durationMs > 0 ? start.plus({ milliseconds: durationMs }) : null
+      occurrences.push(...buildOccurrencesFromRange(start, end, baseAllDay))
+    }
+
+    if (occurrences.length >= RRULE_MAX_OCCURRENCES) break
+  }
+
+  return occurrences
+}
+
+function deriveOccurrencesFromSingleSpan(event, timezone) {
+  if (!event) return []
+  const allDay = isAllDayEvent(event)
+  if (allDay) return []
+  const start = toDateTime(event.start, timezone, { allDay })
+  const end = toDateTime(event.end, timezone, { isEnd: true, allDay })
+  if (!start || !end || !start.isValid || !end.isValid) return []
+  if (!start.startOf('day').equals(end.startOf('day'))) {
+    return splitTimedRange(start, end)
+  }
+  return []
+}
+
+function dedupeOccurrences(occurrences) {
+  const byDate = new Map()
+  for (const occurrence of occurrences) {
+    if (!occurrence?.start || !occurrence.start.isValid) continue
+    const key = occurrence.start.toISODate()
+    if (!key) continue
+    if (!byDate.has(key) || occurrence.start < byDate.get(key).start) {
+      byDate.set(key, occurrence)
+    }
+  }
+  return Array.from(byDate.values())
+}
+
+function buildOccurrencesFromRange(start, end, allDay) {
+  if (!start || !start.isValid) return []
+
+  if (allDay) {
+    const dayStart = start.startOf('day')
+    const exclusiveEnd = end && end.isValid ? end.startOf('day') : dayStart.plus({ days: 1 })
+    const occurrences = []
+    let cursor = dayStart
+    let count = 0
+    while (cursor < exclusiveEnd && count < MAX_SCHEDULE_DAYS) {
+      occurrences.push({
+        start: cursor,
+        end: cursor.endOf('day'),
+        allDay: true,
+      })
+      cursor = cursor.plus({ days: 1 })
+      count += 1
+    }
+    if (!occurrences.length) {
+      occurrences.push({
+        start: dayStart,
+        end: dayStart.endOf('day'),
+        allDay: true,
+      })
+    }
+    return occurrences
+  }
+
+  if (!end || !end.isValid || end <= start) {
+    return []
+  }
+
+  if (start.hasSame(end, 'day')) {
+    return [
+      {
+        start,
+        end,
+        allDay: false,
+      },
+    ]
+  }
+
+  return splitTimedRange(start, end)
+}
+
+function splitTimedRange(start, end) {
+  if (!start || !end || !start.isValid || !end.isValid) return []
+  if (end <= start) return []
+
+  const startMinutes = start.hour * 60 + start.minute
+  const endMinutes = end.hour * 60 + end.minute
+  if (endMinutes <= startMinutes) return []
+
+  const occurrences = []
+  let cursor = start.startOf('day')
+  const finalDay = end.startOf('day')
+  let count = 0
+  while (cursor <= finalDay && count < MAX_SCHEDULE_DAYS) {
+    const dayStart = cursor.set({
+      hour: start.hour,
+      minute: start.minute,
+      second: 0,
+      millisecond: 0,
+    })
+    const dayEnd = cursor.set({
+      hour: end.hour,
+      minute: end.minute,
+      second: 0,
+      millisecond: 0,
+    })
+    if (!dayEnd.isValid || dayEnd <= dayStart) {
+      return []
+    }
+    occurrences.push({
+      start: dayStart,
+      end: dayEnd,
+      allDay: false,
+    })
+    cursor = cursor.plus({ days: 1 })
+    count += 1
+  }
+
+  return occurrences
+}
+
+function computeDurationMs(event, timezone, allDay) {
+  const start = toDateTime(event?.start, timezone, { allDay })
+  const end = toDateTime(event?.end, timezone, { isEnd: true, allDay })
+  if (!start || !end || !start.isValid || !end.isValid || end <= start) return 0
+  return end.diff(start, 'milliseconds').milliseconds
+}
+
+function isAllDayEvent(event) {
+  if (!event) return false
+  if (event.datetype === 'date') return true
+  if (event.start?.dateOnly || event.end?.dateOnly) return true
+  if (event.params && typeof event.params === 'object') {
+    if (Array.isArray(event.params) && event.params.includes('VALUE=DATE')) return true
+    if (event.params.VALUE === 'DATE') return true
+  }
+  return false
+}
+
+function toDateTime(raw, timezone, options = {}) {
+  if (!raw) return null
+  const zone = timezone || DEFAULT_TIMEZONE
+
+  if (raw instanceof Date) {
+    if (raw.dateOnly) {
+      const year = raw.getUTCFullYear()
+      const month = raw.getUTCMonth() + 1
+      const day = raw.getUTCDate()
+      const dateOnly = DateTime.fromObject({ year, month, day }, { zone })
+      return options.isEnd ? dateOnly.startOf('day') : dateOnly.startOf('day')
+    }
+    const base = DateTime.fromJSDate(raw, { zone: 'utc' })
+    const dt = base.setZone(zone)
+    if (options.allDay) {
+      return options.isEnd ? dt.startOf('day') : dt.startOf('day')
+    }
+    return dt
+  }
+
+  if (raw?.toJSDate) {
+    const jsDate = raw.toJSDate()
+    if (jsDate instanceof Date) {
+      return toDateTime(jsDate, timezone, options)
+    }
+  }
+
+  return null
+}
+
+module.exports = {
+  expandIcsEvents,
+  _private: {
+    inferTimezone,
+    convertEventToOccurrences,
+    expandRruleOccurrences,
+    buildOccurrencesFromRange,
+    splitTimedRange,
+    isAllDayEvent,
+    toDateTime,
+  },
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "postbuild": "node scripts/generate-curated-html.js && node scripts/generate-sitemap.js && cp build/index.html build/404.html",
     "generate:curated": "node scripts/generate-curated-html.js",
     "ingest:events": "node scripts/ingest-events.js",
+    "events:backfill-daily": "node scripts/backfill-daily-schedule.mjs",
     "events:audit": "node scripts/events-cli.mjs --audit",
     "test": "node --test"
   },

--- a/public/cms/index.html
+++ b/public/cms/index.html
@@ -237,6 +237,8 @@
           if (!window.CMS || !window.React) return false
           try {
             registerEventsPreview(window.CMS, window.React)
+            registerDailyScheduleWidget(window.CMS, window.React)
+            activateLegacyFieldStyling()
             cmsEnhancementsReady = true
           } catch (error) {
             console.warn('[cms-login] failed to register CMS enhancements', error)
@@ -540,6 +542,463 @@
           }
 
           CMS.registerPreviewTemplate('events', EventPreview)
+        }
+
+        function registerDailyScheduleWidget(CMS, React) {
+          if (!CMS || typeof CMS.registerWidget !== 'function' || !React) {
+            return
+          }
+
+          const { useState, useEffect, useMemo } = React
+          const Immutable = window.Immutable
+
+          const containerStyle = {
+            border: '1px solid #e2e8f0',
+            borderRadius: '14px',
+            padding: '16px',
+            background: '#ffffff',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '12px',
+          }
+
+          const headerStyle = {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: '8px',
+          }
+
+          const actionsStyle = {
+            display: 'flex',
+            gap: '8px',
+            flexWrap: 'wrap',
+          }
+
+          const buttonStyle = {
+            borderRadius: '999px',
+            border: '1px solid #cbd5f5',
+            background: '#f8fafc',
+            color: '#1e3a8a',
+            fontSize: '12px',
+            fontWeight: 600,
+            padding: '6px 12px',
+            cursor: 'pointer',
+          }
+
+          const destructiveButtonStyle = {
+            ...buttonStyle,
+            borderColor: '#fecaca',
+            color: '#b91c1c',
+          }
+
+          const rowStyle = {
+            border: '1px solid #e2e8f0',
+            borderRadius: '12px',
+            padding: '12px',
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+            gap: '12px',
+            alignItems: 'flex-end',
+          }
+
+          const fieldStyle = {
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '4px',
+          }
+
+          const labelStyle = {
+            fontSize: '12px',
+            fontWeight: 600,
+            letterSpacing: '0.04em',
+            textTransform: 'uppercase',
+            color: '#475569',
+          }
+
+          const inputStyle = {
+            borderRadius: '10px',
+            border: '1px solid #cbd5f5',
+            padding: '8px 10px',
+            fontSize: '14px',
+            background: '#f8fafc',
+          }
+
+          const checkboxWrapperStyle = {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            paddingTop: '20px',
+          }
+
+          function createRow(overrides = {}) {
+            return {
+              date: '',
+              start_time: '',
+              end_time: '',
+              all_day: false,
+              ...overrides,
+            }
+          }
+
+          function normalizeRows(value) {
+            if (!value) return []
+            if (Immutable && typeof Immutable.List === 'function' && Immutable.List.isList(value)) {
+              return value
+                .toJS()
+                .map((row) =>
+                  createRow({
+                    date: (row?.date || '').trim(),
+                    start_time: row?.start_time || row?.startTime || '',
+                    end_time: row?.end_time || row?.endTime || '',
+                    all_day: Boolean(row?.all_day ?? row?.allDay),
+                  }),
+                )
+            }
+            if (Array.isArray(value)) {
+              return value.map((row) =>
+                createRow({
+                  date: (row?.date || '').trim(),
+                  start_time: row?.start_time || row?.startTime || '',
+                  end_time: row?.end_time || row?.endTime || '',
+                  all_day: Boolean(row?.all_day ?? row?.allDay),
+                }),
+              )
+            }
+            if (value && typeof value === 'object' && typeof value.toJS === 'function') {
+              try {
+                const jsValue = value.toJS()
+                return normalizeRows(jsValue)
+              } catch (error) {
+                return []
+              }
+            }
+            return []
+          }
+
+          function sortRows(rows) {
+            return [...rows].sort((a, b) => {
+              if (!a.date && !b.date) return 0
+              if (!a.date) return 1
+              if (!b.date) return -1
+              const aDate = new Date(a.date)
+              const bDate = new Date(b.date)
+              if (!Number.isNaN(aDate) && !Number.isNaN(bDate)) {
+                return aDate - bDate
+              }
+              return a.date.localeCompare(b.date)
+            })
+          }
+
+          function rowsEqual(a, b) {
+            if (a.length !== b.length) return false
+            for (let index = 0; index < a.length; index += 1) {
+              const first = a[index]
+              const second = b[index]
+              if (
+                first.date !== second.date ||
+                first.start_time !== second.start_time ||
+                first.end_time !== second.end_time ||
+                Boolean(first.all_day) !== Boolean(second.all_day)
+              ) {
+                return false
+              }
+            }
+            return true
+          }
+
+          function toImmutable(rows) {
+            if (Immutable && typeof Immutable.fromJS === 'function') {
+              return Immutable.fromJS(rows)
+            }
+            return rows
+          }
+
+          function parseDateInput(value) {
+            if (!value) return null
+            const trimmed = String(value).trim()
+            if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return null
+            const date = new Date(trimmed)
+            if (Number.isNaN(date.getTime())) return null
+            return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+          }
+
+          function formatIsoDate(date) {
+            const year = date.getFullYear()
+            const month = String(date.getMonth() + 1).padStart(2, '0')
+            const day = String(date.getDate()).padStart(2, '0')
+            return `${year}-${month}-${day}`
+          }
+
+          function DailyScheduleControl(props) {
+            const { value, onChange, forID, classNameWrapper } = props
+            const initialRows = useMemo(() => sortRows(normalizeRows(value)), [value])
+            const [rows, setRows] = useState(initialRows.length ? initialRows : [createRow()])
+
+            useEffect(() => {
+              const next = sortRows(normalizeRows(value))
+              if (!rowsEqual(next, rows)) {
+                setRows(next.length ? next : [createRow()])
+              }
+            }, [value, rows])
+
+            const sanitizedRows = useMemo(
+              () =>
+                rows
+                  .filter((row) => row.date)
+                  .map((row) => ({
+                    date: row.date,
+                    start_time: row.all_day ? '' : row.start_time,
+                    end_time: row.all_day ? '' : row.end_time,
+                    all_day: Boolean(row.all_day),
+                  })),
+              [rows],
+            )
+
+            useEffect(() => {
+              if (onChange) {
+                onChange(toImmutable(sanitizedRows))
+              }
+            }, [onChange, sanitizedRows])
+
+            function updateRow(index, updates) {
+              const next = rows.map((row, rowIndex) =>
+                rowIndex === index
+                  ? {
+                      ...row,
+                      ...updates,
+                    }
+                  : row,
+              )
+              setRows(sortRows(next))
+            }
+
+            function handleAddRow() {
+              setRows((prev) => sortRows([...prev, createRow()]))
+            }
+
+            function handleRemoveRow(index) {
+              const next = rows.filter((_, rowIndex) => rowIndex !== index)
+              setRows(next.length ? sortRows(next) : [createRow()])
+            }
+
+            function handleDuplicateHours(index) {
+              if (index <= 0) return
+              const source = rows[index - 1]
+              if (!source || source.all_day) return
+              updateRow(index, {
+                start_time: source.start_time,
+                end_time: source.end_time,
+                all_day: false,
+              })
+            }
+
+            function handleAddRange() {
+              const startInput = window.prompt('Start date (YYYY-MM-DD)')
+              if (!startInput) return
+              const endInput = window.prompt('End date (YYYY-MM-DD)', startInput)
+              if (!endInput) return
+              const startDate = parseDateInput(startInput)
+              const endDate = parseDateInput(endInput)
+              if (!startDate || !endDate) {
+                window.alert('Enter dates in YYYY-MM-DD format (e.g., 2025-11-15).')
+                return
+              }
+              if (endDate < startDate) {
+                window.alert('End date must be on or after the start date.')
+                return
+              }
+              const existing = new Set(rows.map((row) => row.date).filter(Boolean))
+              const additions = []
+              for (let cursor = new Date(startDate); cursor <= endDate; cursor.setDate(cursor.getDate() + 1)) {
+                const iso = formatIsoDate(cursor)
+                if (!existing.has(iso)) {
+                  additions.push(createRow({ date: iso }))
+                }
+              }
+              if (!additions.length) {
+                window.alert('All days in that range are already listed.')
+                return
+              }
+              setRows((prev) => sortRows([...prev, ...additions]))
+            }
+
+            return React.createElement(
+              'div',
+              { id: forID, className: classNameWrapper, style: containerStyle },
+              React.createElement(
+                'div',
+                { style: headerStyle },
+                React.createElement('strong', null, 'Daily schedule'),
+                React.createElement(
+                  'div',
+                  { style: actionsStyle },
+                  React.createElement(
+                    'button',
+                    { type: 'button', style: buttonStyle, onClick: handleAddRange },
+                    'Add days from range',
+                  ),
+                  React.createElement(
+                    'button',
+                    { type: 'button', style: buttonStyle, onClick: handleAddRow },
+                    'Add day',
+                  ),
+                ),
+              ),
+              rows.map((row, index) => {
+                const disableTimes = Boolean(row.all_day)
+                return React.createElement(
+                  'div',
+                  { key: row.key || `${row.date || 'row'}-${index}`, style: rowStyle },
+                  React.createElement(
+                    'label',
+                    { style: fieldStyle },
+                    React.createElement('span', { style: labelStyle }, 'Date'),
+                    React.createElement('input', {
+                      type: 'date',
+                      value: row.date,
+                      onChange: (event) => updateRow(index, { date: event.target.value }),
+                      style: inputStyle,
+                    }),
+                  ),
+                  React.createElement(
+                    'label',
+                    { style: fieldStyle },
+                    React.createElement('span', { style: labelStyle }, 'Start time'),
+                    React.createElement('input', {
+                      type: 'time',
+                      value: row.start_time,
+                      disabled: disableTimes,
+                      onChange: (event) => updateRow(index, { start_time: event.target.value }),
+                      style: { ...inputStyle, background: disableTimes ? '#e2e8f0' : inputStyle.background },
+                    }),
+                  ),
+                  React.createElement(
+                    'label',
+                    { style: fieldStyle },
+                    React.createElement('span', { style: labelStyle }, 'End time'),
+                    React.createElement('input', {
+                      type: 'time',
+                      value: row.end_time,
+                      disabled: disableTimes,
+                      onChange: (event) => updateRow(index, { end_time: event.target.value }),
+                      style: { ...inputStyle, background: disableTimes ? '#e2e8f0' : inputStyle.background },
+                    }),
+                  ),
+                  React.createElement(
+                    'div',
+                    { style: checkboxWrapperStyle },
+                    React.createElement('input', {
+                      type: 'checkbox',
+                      checked: Boolean(row.all_day),
+                      onChange: (event) =>
+                        updateRow(index, {
+                          all_day: event.target.checked,
+                          ...(event.target.checked ? { start_time: '', end_time: '' } : {}),
+                        }),
+                    }),
+                    React.createElement('span', { style: { fontSize: '13px', fontWeight: 500, color: '#1e293b' } }, 'All day'),
+                  ),
+                  React.createElement(
+                    'div',
+                    {
+                      style: {
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: '8px',
+                        justifyContent: 'flex-end',
+                      },
+                    },
+                    index > 0 && !disableTimes
+                      ? React.createElement(
+                          'button',
+                          {
+                            type: 'button',
+                            style: buttonStyle,
+                            onClick: () => handleDuplicateHours(index),
+                          },
+                          'Duplicate previous hours',
+                        )
+                      : null,
+                    React.createElement(
+                      'button',
+                      {
+                        type: 'button',
+                        style: destructiveButtonStyle,
+                        onClick: () => handleRemoveRow(index),
+                      },
+                      'Remove',
+                    ),
+                  ),
+                )
+              }),
+              sanitizedRows.length === 0
+                ? React.createElement(
+                    'p',
+                    { style: { fontSize: '12px', color: '#64748b', marginTop: '-4px' } },
+                    'Add at least one day when using the daily schedule.',
+                  )
+                : null,
+            )
+          }
+
+          CMS.registerWidget('dailySchedule', DailyScheduleControl)
+        }
+
+        let legacyStylingInitialized = false
+
+        function activateLegacyFieldStyling() {
+          if (legacyStylingInitialized) return
+          if (typeof document === 'undefined') return
+          legacyStylingInitialized = true
+
+          const styleId = 'ns-legacy-schedule-style'
+          if (!document.getElementById(styleId)) {
+            const style = document.createElement('style')
+            style.id = styleId
+            style.textContent = `
+              [data-field-name="startDate"].ns-legacy-muted,
+              [data-field-name="endDate"].ns-legacy-muted {
+                opacity: 0.55;
+                transition: opacity 0.2s ease-in-out;
+              }
+              [data-field-name="startDate"].ns-legacy-muted:hover,
+              [data-field-name="endDate"].ns-legacy-muted:hover {
+                opacity: 0.85;
+              }
+            `
+            document.head.appendChild(style)
+          }
+
+          const update = () => {
+            const flag = document.querySelector('[data-field-name="use_daily_schedule"] input[type="checkbox"]')
+            const startField = document.querySelector('[data-field-name="startDate"]')
+            const endField = document.querySelector('[data-field-name="endDate"]')
+            const muted = Boolean(flag && flag.checked)
+            ;[startField, endField].forEach((node) => {
+              if (!node) return
+              if (muted) {
+                node.classList.add('ns-legacy-muted')
+              } else {
+                node.classList.remove('ns-legacy-muted')
+              }
+            })
+          }
+
+          const observer = new MutationObserver(() => {
+            window.requestAnimationFrame(update)
+          })
+
+          observer.observe(document.body, { childList: true, subtree: true })
+
+          document.addEventListener('change', (event) => {
+            if (event.target && event.target.closest('[data-field-name="use_daily_schedule"]')) {
+              window.requestAnimationFrame(update)
+            }
+          })
+
+          window.requestAnimationFrame(update)
         }
 
         const form = document.getElementById('cms-login-form')

--- a/public/config.yml
+++ b/public/config.yml
@@ -124,6 +124,18 @@ collections:
         widget: 'boolean'
         required: false
         default: false
+      - name: 'use_daily_schedule'
+        label: 'Use daily schedule'
+        widget: 'boolean'
+        required: false
+        default: false
+        hint: 'Enable to manage per-day hours below. Start/End fields remain for compatibility.'
+      - name: 'daily_schedule'
+        label: 'Daily Schedule'
+        widget: 'dailySchedule'
+        required: false
+        collapsed: false
+        hint: 'Add one row per day. Provide times or mark as All day.'
       - name: 'recurrence'
         label: 'Recurrence (RRULE)'
         widget: 'string'

--- a/scripts/backfill-daily-schedule.mjs
+++ b/scripts/backfill-daily-schedule.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDir = path.resolve(__dirname, '..')
+const eventsDir = path.join(rootDir, 'public', 'data', 'events')
+
+const KEY_ORDER = [
+  'id',
+  'slug',
+  'title',
+  'summary',
+  'description',
+  'startDate',
+  'endDate',
+  'allDay',
+  'use_daily_schedule',
+  'daily_schedule',
+  'recurrence',
+  'category',
+  'town',
+  'subArea',
+  'location',
+  'locationName',
+  'address',
+  'lat',
+  'lng',
+  'priceType',
+  'priceNote',
+  'badges',
+  'qaTags',
+  'image',
+  'organizerName',
+  'organizerUrl',
+  'url',
+  'eventUrl',
+  'icsUrl',
+  'status',
+  'hidden',
+  'archived',
+  'notes',
+  'source',
+  'sourceName',
+  'sourceUrl',
+  'sourceDomain',
+  'sourcePriority',
+  'sourceRef',
+  'lastSyncedAt',
+  'firstSeenAt',
+  'updatedAt',
+]
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const MAX_DERIVED_DAYS = 90
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run')
+  let updated = 0
+  let skipped = 0
+
+  const entries = await fs.readdir(eventsDir, { withFileTypes: true })
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue
+    const filePath = path.join(eventsDir, entry.name)
+    const raw = await fs.readFile(filePath, 'utf8')
+    let data
+    try {
+      data = JSON.parse(raw)
+    } catch (error) {
+      console.warn(`[backfill] Skipping ${entry.name}: invalid JSON`)
+      skipped += 1
+      continue
+    }
+
+    if (Array.isArray(data.daily_schedule) && data.daily_schedule.length) {
+      skipped += 1
+      continue
+    }
+    if (data.use_daily_schedule) {
+      skipped += 1
+      continue
+    }
+    if (typeof data.recurrence === 'string' && data.recurrence.trim()) {
+      skipped += 1
+      continue
+    }
+
+    const proposal = deriveDailySchedule(data)
+    if (!proposal.length) {
+      skipped += 1
+      continue
+    }
+
+    const next = {
+      ...data,
+      daily_schedule: proposal,
+      use_daily_schedule: true,
+    }
+    const ordered = orderKeys(next)
+
+    if (!dryRun) {
+      await fs.writeFile(filePath, `${JSON.stringify(ordered, null, 2)}\n`, 'utf8')
+    }
+    updated += 1
+  }
+
+  console.log(`${dryRun ? 'Previewed' : 'Updated'} ${updated} event${updated === 1 ? '' : 's'}. Skipped ${skipped}.`)
+}
+
+function deriveDailySchedule(event) {
+  const start = parseDate(event?.startDate)
+  const end = parseDate(event?.endDate) || start
+  if (!start || !end) return []
+  if (end <= start) return []
+
+  const startMidnight = start.getHours() === 0 && start.getMinutes() === 0
+  const endMidnight = end.getHours() === 0 && end.getMinutes() === 0
+
+  const treatAsAllDay = Boolean(event?.allDay) || (startMidnight && endMidnight)
+  if (!treatAsAllDay) return []
+
+  const firstDay = toStartOfDay(start)
+  const lastDay = toStartOfDay(end)
+  if (!firstDay || !lastDay || lastDay < firstDay) return []
+
+  const results = []
+  let cursor = new Date(firstDay)
+  let days = 0
+  while (cursor <= lastDay && days < MAX_DERIVED_DAYS) {
+    const iso = toIsoDate(cursor)
+    results.push({
+      date: iso,
+      start_time: '',
+      end_time: '',
+      all_day: true,
+    })
+    cursor = new Date(cursor.getTime() + DAY_MS)
+    days += 1
+  }
+
+  return results
+}
+
+function parseDate(value) {
+  if (!value) return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return null
+  return parsed
+}
+
+function toStartOfDay(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null
+  const copy = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  copy.setHours(0, 0, 0, 0)
+  return copy
+}
+
+function toIsoDate(date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function orderKeys(event) {
+  const ordered = {}
+  for (const key of KEY_ORDER) {
+    if (event[key] !== undefined) {
+      ordered[key] = event[key]
+    }
+  }
+  for (const key of Object.keys(event)) {
+    if (!(key in ordered)) {
+      ordered[key] = event[key]
+    }
+  }
+  return ordered
+}
+
+main().catch((error) => {
+  console.error('[backfill] Unhandled error', error)
+  process.exit(1)
+})

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -9,6 +9,7 @@ const require = createRequire(import.meta.url)
 const Parser = require('rss-parser')
 const ical = require('node-ical')
 const { getAdapter } = require('../lib/event-source-adapters.js')
+const { expandIcsEvents } = require('../lib/events/ics.js')
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -51,7 +52,7 @@ async function main() {
     feedReport.startedAt = new Date().toISOString()
 
     try {
-      const items = await fetchFeed(feed, feedReport, syncState)
+      const items = await fetchFeed(feed, feedReport, syncState, now)
       const payload = Array.isArray(items) ? items : []
       feedReport.itemsFetched = payload.length
       if (!payload.length) {
@@ -201,7 +202,7 @@ function getSourceId(event) {
   return ''
 }
 
-async function fetchFeed(feed, feedReport, syncState) {
+async function fetchFeed(feed, feedReport, syncState, now) {
   if (!feed) return []
 
   try {
@@ -253,7 +254,8 @@ async function fetchFeed(feed, feedReport, syncState) {
     }
 
     if (type === 'ics') {
-      return fetchIcs(feed, feedReport, syncState)
+      const vevents = await fetchIcs(feed, feedReport, syncState)
+      return expandIcsEvents(vevents, feed, now)
     }
 
     if (type === 'html') {
@@ -1189,6 +1191,19 @@ function normalizeEvent(item, feed, now) {
     url: eventUrl,
     eventUrl,
     icsUrl,
+    use_daily_schedule:
+      Boolean(item.use_daily_schedule ?? item.useDailySchedule) ||
+      (Array.isArray(item.daily_schedule || item.dailySchedule)
+        ? (item.daily_schedule || item.dailySchedule).length > 0
+        : false),
+    daily_schedule: Array.isArray(item.daily_schedule || item.dailySchedule)
+      ? (item.daily_schedule || item.dailySchedule).map((entry) => ({
+          date: entry?.date || entry?.day || '',
+          start_time: entry?.start_time || entry?.startTime || '',
+          end_time: entry?.end_time || entry?.endTime || '',
+          all_day: Boolean(entry?.all_day ?? entry?.allDay),
+        }))
+      : undefined,
     source: { name: sourceName, id: sourceId },
     sourceName,
     sourceUrl: resolveUrl(item.sourceUrl || feed.sourceUrl || eventUrl, feed),
@@ -1335,6 +1350,8 @@ const KEY_ORDER = [
   'startDate',
   'endDate',
   'allDay',
+  'use_daily_schedule',
+  'daily_schedule',
   'recurrence',
   'category',
   'town',

--- a/src/community/EventCalendar.js
+++ b/src/community/EventCalendar.js
@@ -131,7 +131,7 @@ export default function EventCalendar({ events, initialMonth, onSelectEvent }) {
                   >
                     <span className="block truncate">{event.title}</span>
                     <span className="block text-[10px] font-normal text-emerald-700">
-                      {formatDateRange(occurrence, event.allDay)}
+                      {formatDateRange(occurrence, occurrence?.allDay ?? event.allDay)}
                     </span>
                   </button>
                 </li>

--- a/src/community/EventCard.js
+++ b/src/community/EventCard.js
@@ -19,7 +19,7 @@ function PlaceholderImage() {
 
 export default function EventCard({ event, onSelect, highlighted = false }) {
   const occurrence = event.nextOccurrence || event.occurrences?.[0]
-  const dateLabel = formatDateRange(occurrence, event.allDay)
+  const dateLabel = formatDateRange(occurrence, occurrence?.allDay ?? event.allDay)
   const isFree = event.priceType === 'Free'
   const townParts = []
   if (event.subArea) townParts.push(event.subArea)

--- a/src/community/EventDetailPage.js
+++ b/src/community/EventDetailPage.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useParams, Link, useLocation } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import {
   ArrowLeft,
@@ -26,6 +26,20 @@ import {
 
 const SITE_ORIGIN = 'https://northsidegta.ca'
 const FALLBACK_IMAGE = '/Images/hero-desktop.jpg'
+
+const scheduleListDateFormatter = new Intl.DateTimeFormat('en-CA', {
+  month: 'short',
+  day: 'numeric',
+})
+
+const scheduleListWeekdayFormatter = new Intl.DateTimeFormat('en-CA', {
+  weekday: 'short',
+})
+
+const scheduleListTimeFormatter = new Intl.DateTimeFormat('en-CA', {
+  hour: 'numeric',
+  minute: '2-digit',
+})
 
 function normalizeWhitespace(text) {
   if (typeof text !== 'string') return ''
@@ -54,12 +68,13 @@ function splitParagraphs(text) {
     .filter(Boolean)
 }
 
-function buildEventSchema(event, origin = SITE_ORIGIN, descriptionOverride = '') {
+function buildEventSchema(event, origin = SITE_ORIGIN, descriptionOverride = '', occurrenceOverride = null) {
   if (!event) return null
   const baseOrigin = typeof origin === 'string' && origin ? origin : SITE_ORIGIN
   const canonical = getCanonicalEventUrl(event.slug, baseOrigin)
-  const start = event.startDateObj || (event.startDate ? new Date(event.startDate) : null)
-  const end = event.endDateObj || start
+  const start =
+    occurrenceOverride?.start || event.startDateObj || (event.startDate ? new Date(event.startDate) : null)
+  const end = occurrenceOverride?.end || event.endDateObj || start
   const image = event.image
     ? toAbsoluteUrl(event.image, baseOrigin)
     : toAbsoluteUrl(FALLBACK_IMAGE, baseOrigin)
@@ -135,6 +150,7 @@ function buildEventSchema(event, origin = SITE_ORIGIN, descriptionOverride = '')
 
 export default function EventDetailPage() {
   const { slug: routeSlug } = useParams()
+  const location = useLocation()
   const slug = routeSlug ? decodeURIComponent(routeSlug) : ''
   const [event, setEvent] = React.useState(null)
   const [loading, setLoading] = React.useState(true)
@@ -192,15 +208,88 @@ export default function EventDetailPage() {
     }
   }, [])
 
+  const selectedDateParam = React.useMemo(() => {
+    if (!location || !location.search) return ''
+    try {
+      const params = new URLSearchParams(location.search)
+      const value = params.get('d') || params.get('date')
+      if (!value) return ''
+      const trimmed = String(value).trim()
+      return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? trimmed : ''
+    } catch (error) {
+      return ''
+    }
+  }, [location?.search])
+
+  const scheduleEntries = React.useMemo(() => {
+    if (!event?.dailySchedule?.length) return []
+    return event.dailySchedule.map((entry, index) => {
+      const start =
+        entry.start instanceof Date
+          ? entry.start
+          : entry.startIso
+            ? new Date(entry.startIso)
+            : null
+      const end =
+        entry.end instanceof Date
+          ? entry.end
+          : entry.endIso
+            ? new Date(entry.endIso)
+            : null
+      const dateLabel = start ? scheduleListDateFormatter.format(start) : entry.date || ''
+      const weekdayLabel = start ? scheduleListWeekdayFormatter.format(start) : ''
+      const timeLabel = entry.allDay
+        ? 'All day'
+        : start && end
+          ? `${scheduleListTimeFormatter.format(start)} – ${scheduleListTimeFormatter.format(end)}`
+          : ''
+      return {
+        ...entry,
+        start,
+        end,
+        dateLabel,
+        weekdayLabel,
+        timeLabel,
+        key: entry.date || `${index}-${entry.startIso || ''}`,
+      }
+    })
+  }, [event])
+
+  const selectedScheduleEntry = React.useMemo(() => {
+    if (!scheduleEntries.length) return null
+    if (selectedDateParam) {
+      const match = scheduleEntries.find((entry) => entry.date === selectedDateParam)
+      if (match) return match
+    }
+    const now = new Date()
+    const upcoming = scheduleEntries.find((entry) => entry.end && entry.end >= now)
+    return upcoming || scheduleEntries[scheduleEntries.length - 1]
+  }, [scheduleEntries, selectedDateParam])
+
   const occurrence = React.useMemo(() => {
     if (!event) return null
+    if (selectedScheduleEntry?.start instanceof Date && !Number.isNaN(selectedScheduleEntry.start)) {
+      const start = selectedScheduleEntry.start
+      const end =
+        selectedScheduleEntry.end && selectedScheduleEntry.end > start
+          ? selectedScheduleEntry.end
+          : start
+      return {
+        start,
+        end,
+        allDay: Boolean(selectedScheduleEntry.allDay),
+        scheduleDate: selectedScheduleEntry.date || '',
+      }
+    }
     const start = event.startDateObj || (event.startDate ? new Date(event.startDate) : null)
     const end = event.endDateObj || start
     if (!start) return null
-    return { start, end }
-  }, [event])
+    return { start, end, allDay: Boolean(event.allDay) }
+  }, [event, selectedScheduleEntry])
 
-  const dateLabel = occurrence ? formatDateRange(occurrence, event?.allDay) : ''
+  const dateLabel = occurrence
+    ? formatDateRange(occurrence, occurrence.allDay ?? event?.allDay)
+    : ''
 
   const descriptionParagraphs = React.useMemo(() => splitParagraphs(event?.description || ''), [event])
   const summaryParagraphs = React.useMemo(
@@ -248,22 +337,42 @@ export default function EventDetailPage() {
 
   const truncatedDescription = event ? truncateText(eventDescription || '', 160) : ''
   const schema = React.useMemo(
-    () => buildEventSchema(event, normalizedOrigin, truncatedDescription || eventDescription),
-    [event, eventDescription, normalizedOrigin, truncatedDescription],
+    () => buildEventSchema(event, normalizedOrigin, truncatedDescription || eventDescription, occurrence),
+    [event, eventDescription, normalizedOrigin, truncatedDescription, occurrence],
   )
 
   const pageTitle = event ? `${event.title} | NorthSide GTA` : 'Event Details | NorthSide GTA'
   const defaultDescription = 'Explore community events across the NorthSide GTA.'
-  const pageDescription = truncatedDescription || eventDescription || defaultDescription
+  const scheduleShareSnippet = selectedScheduleEntry
+    ? [
+        selectedScheduleEntry.weekdayLabel,
+        selectedScheduleEntry.dateLabel,
+        selectedScheduleEntry.timeLabel,
+      ]
+        .filter(Boolean)
+        .join(' • ')
+    : ''
+  const baseDescription = truncatedDescription || eventDescription || defaultDescription
+  const pageDescription = scheduleShareSnippet ? `${scheduleShareSnippet}. ${baseDescription}` : baseDescription
   const canonicalUrl = event ? getCanonicalEventUrl(event.slug, normalizedOrigin) : `${normalizedOrigin}/events`
   const ogImage = event?.image
     ? toAbsoluteUrl(event.image, normalizedOrigin)
     : toAbsoluteUrl(FALLBACK_IMAGE, normalizedOrigin)
-  const shareUrl = canonicalUrl
-  const shareTitle = event ? event.title : 'NorthSide GTA Event'
+  const shareUrl = React.useMemo(() => {
+    if (!event || !selectedScheduleEntry?.date) return canonicalUrl
+    const separator = canonicalUrl.includes('?') ? '&' : '?'
+    return `${canonicalUrl}${separator}d=${selectedScheduleEntry.date}`
+  }, [canonicalUrl, event, selectedScheduleEntry])
+  const shareTitle = event
+    ? `${event.title}${scheduleShareSnippet ? ` — ${scheduleShareSnippet}` : ''}`
+    : 'NorthSide GTA Event'
   const shareText = event ? pageDescription : 'Check out this NorthSide GTA event.'
   const emailBody = shareText ? `${shareText}\n\n${shareUrl}` : shareUrl
-  const publishedTime = event?.startDate ? new Date(event.startDate).toISOString() : ''
+  const publishedTime = occurrence?.start
+    ? new Date(occurrence.start).toISOString()
+    : event?.startDate
+      ? new Date(event.startDate).toISOString()
+      : ''
 
   const handleAddToCalendar = React.useCallback(() => {
     if (!event) return
@@ -337,7 +446,7 @@ export default function EventDetailPage() {
         <meta property="og:title" content={shareTitle} />
         <meta property="og:description" content={pageDescription} />
         <meta property="og:type" content="event" />
-        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:url" content={shareUrl} />
         {ogImage && <meta property="og:image" content={ogImage} />}
         {ogImage && <meta property="og:image:alt" content={shareTitle} />}
         <meta property="og:site_name" content="NorthSide GTA" />
@@ -408,6 +517,30 @@ export default function EventDetailPage() {
                     </p>
                   )}
                   {event.priceNote && <p className="text-xs text-slate-500">{event.priceNote}</p>}
+                  {scheduleEntries.length > 0 && (
+                    <section className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                      <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Schedule</h2>
+                      <dl className="mt-2 space-y-2">
+                        {scheduleEntries.map((entry) => {
+                          const isSelected = selectedScheduleEntry?.date === entry.date
+                          return (
+                            <div
+                              key={entry.key}
+                              className={`flex flex-col gap-1 rounded-xl px-3 py-2 transition sm:flex-row sm:items-baseline sm:justify-between ${
+                                isSelected ? 'bg-white shadow-sm ring-1 ring-emerald-100' : ''
+                              }`}
+                              aria-current={isSelected ? 'true' : undefined}
+                            >
+                              <dt className="text-sm font-semibold text-slate-900">
+                                {entry.weekdayLabel ? `${entry.weekdayLabel}, ${entry.dateLabel}` : entry.dateLabel}
+                              </dt>
+                              <dd className="text-sm text-slate-600">{entry.timeLabel || 'Times TBA'}</dd>
+                            </div>
+                          )
+                        })}
+                      </dl>
+                    </section>
+                  )}
                   {summaryParagraphs.length > 0 && (
                     <div className="space-y-3 text-sm text-slate-600">
                       {summaryParagraphs.map((paragraph, index) => (

--- a/src/community/EventMap.js
+++ b/src/community/EventMap.js
@@ -111,7 +111,11 @@ export default function EventMap({ events, onSelectEvent }) {
                     {cluster.events[0].title}
                   </button>
                   <p className="mt-1 text-xs text-slate-600">
-                    {formatDateRange(cluster.events[0].nextOccurrence || cluster.events[0].occurrences?.[0], cluster.events[0].allDay)}
+                    {formatDateRange(
+                      cluster.events[0].nextOccurrence || cluster.events[0].occurrences?.[0],
+                      (cluster.events[0].nextOccurrence || cluster.events[0].occurrences?.[0])?.allDay ??
+                        cluster.events[0].allDay,
+                    )}
                   </p>
                 </Popup>
               </Marker>
@@ -141,7 +145,9 @@ export default function EventMap({ events, onSelectEvent }) {
                 >
                   <span className="block text-base font-semibold">{event.title}</span>
                   <span className="block text-xs text-slate-600">{event.town}</span>
-                  <span className="block text-xs text-slate-500">{formatDateRange(occurrence, event.allDay)}</span>
+                  <span className="block text-xs text-slate-500">
+                    {formatDateRange(occurrence, occurrence?.allDay ?? event.allDay)}
+                  </span>
                 </button>
               </li>
             )

--- a/src/community/EventModal.js
+++ b/src/community/EventModal.js
@@ -25,7 +25,7 @@ function splitParagraphs(text) {
 export default function EventModal({ event, onClose }) {
   const modalRoot = getModalRoot()
   const occurrence = event?.nextOccurrence || event?.occurrences?.[0]
-  const dateLabel = formatDateRange(occurrence, event?.allDay)
+  const dateLabel = formatDateRange(occurrence, occurrence?.allDay ?? event?.allDay)
   const townParts = []
   if (event?.subArea) townParts.push(event.subArea)
   if (event?.town) townParts.push(event.town)

--- a/src/community/eventUtils.js
+++ b/src/community/eventUtils.js
@@ -89,10 +89,257 @@ const dateFormatter = new Intl.DateTimeFormat('en-CA', {
   day: 'numeric',
 })
 
+const scheduleDateFormatter = new Intl.DateTimeFormat('en-CA', {
+  month: 'short',
+  day: 'numeric',
+})
+
 const timeFormatter = new Intl.DateTimeFormat('en-CA', {
   hour: 'numeric',
   minute: '2-digit',
 })
+
+const timeFormatter24 = new Intl.DateTimeFormat('en-CA', {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+})
+
+function parseBoolean(value) {
+  if (value === true || value === false) return value
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (!normalized) return false
+    if (['true', '1', 'yes', 'y'].includes(normalized)) return true
+    if (['false', '0', 'no', 'n'].includes(normalized)) return false
+  }
+  if (typeof value === 'number') {
+    return value !== 0
+  }
+  return false
+}
+
+function parseDateOnly(value) {
+  if (!value) return null
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    const copy = new Date(value.getTime())
+    copy.setHours(0, 0, 0, 0)
+    return copy
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+    if (isoMatch) {
+      const year = Number(isoMatch[1])
+      const month = Number(isoMatch[2]) - 1
+      const day = Number(isoMatch[3])
+      if (
+        Number.isFinite(year) &&
+        Number.isFinite(month) &&
+        Number.isFinite(day)
+      ) {
+        const date = new Date(year, month, day)
+        date.setHours(0, 0, 0, 0)
+        return date
+      }
+    }
+    const parsed = new Date(trimmed)
+    if (!Number.isNaN(parsed.getTime())) {
+      parsed.setHours(0, 0, 0, 0)
+      return parsed
+    }
+  }
+  return null
+}
+
+function parseTimeOfDay(value) {
+  if (!value && value !== 0) return null
+  const text = String(value).trim()
+  if (!text) return null
+  const match = text.match(
+    /^(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?\s*(AM|PM)?$/i,
+  )
+  if (!match) return null
+  let hours = Number(match[1])
+  const minutes = Number(match[2] || '0')
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null
+  if (minutes < 0 || minutes > 59) return null
+  const meridiem = match[4] ? match[4].toUpperCase() : ''
+  if (meridiem === 'AM' && hours === 12) {
+    hours = 0
+  } else if (meridiem === 'PM' && hours < 12) {
+    hours += 12
+  }
+  if (hours < 0 || hours > 23) return null
+  return { hours, minutes }
+}
+
+function applyTimeToDate(date, time) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null
+  if (!time || typeof time.hours !== 'number' || typeof time.minutes !== 'number') {
+    return null
+  }
+  const result = new Date(date.getTime())
+  result.setHours(time.hours, time.minutes, 0, 0)
+  return result
+}
+
+function normalizeDailySchedule(raw = {}) {
+  const schedule = Array.isArray(raw.daily_schedule)
+    ? raw.daily_schedule
+    : Array.isArray(raw.dailySchedule)
+      ? raw.dailySchedule
+      : []
+
+  const entries = []
+  const seenDates = new Set()
+
+  schedule.forEach((row, index) => {
+    if (!row || typeof row !== 'object') return
+    const dateValue = row.date ?? row.day ?? row.start_date
+    const parsedDate = parseDateOnly(dateValue)
+    if (!parsedDate) return
+
+    const isoDate = `${parsedDate.getFullYear()}-${String(
+      parsedDate.getMonth() + 1,
+    ).padStart(2, '0')}-${String(parsedDate.getDate()).padStart(2, '0')}`
+    if (seenDates.has(isoDate)) return
+
+    const allDay = parseBoolean(row.all_day ?? row.allDay)
+    const startTime = parseTimeOfDay(row.start_time ?? row.startTime)
+    const endTime = parseTimeOfDay(row.end_time ?? row.endTime)
+
+    let start = null
+    let end = null
+
+    if (allDay) {
+      start = startOfDay(parsedDate)
+      end = endOfDay(parsedDate)
+    } else if (startTime && endTime) {
+      start = applyTimeToDate(parsedDate, startTime)
+      end = applyTimeToDate(parsedDate, endTime)
+      if (!start || !end || end <= start) {
+        return
+      }
+    } else {
+      return
+    }
+
+    const labelDate = scheduleDateFormatter.format(parsedDate)
+    let label = labelDate
+    if (allDay) {
+      label = `${labelDate}: All day`
+    } else {
+      const startLabel = timeFormatter.format(start)
+      const endLabel = timeFormatter.format(end)
+      label = `${labelDate}: ${startLabel}–${endLabel}`
+    }
+
+    entries.push({
+      date: isoDate,
+      allDay,
+      start,
+      end,
+      startIso: start?.toISOString() || '',
+      endIso: end?.toISOString() || '',
+      startTimeLabel: allDay ? '' : timeFormatter.format(start),
+      endTimeLabel: allDay ? '' : timeFormatter.format(end),
+      startTimeValue: allDay ? '' : timeFormatter24.format(start),
+      endTimeValue: allDay ? '' : timeFormatter24.format(end),
+      label,
+      index,
+    })
+    seenDates.add(isoDate)
+  })
+
+  entries.sort((a, b) => {
+    if (a.start && b.start) return a.start.getTime() - b.start.getTime()
+    if (a.start && !b.start) return -1
+    if (!a.start && b.start) return 1
+    return 0
+  })
+
+  const earliest = entries[0]?.start || null
+  const latest = entries[entries.length - 1]?.end || earliest
+
+  const useDailySchedule = parseBoolean(raw.use_daily_schedule ?? raw.useDailySchedule)
+  const normalizedUse = useDailySchedule && entries.length > 0
+
+  return {
+    entries,
+    useDailySchedule: normalizedUse,
+    startDateObj: earliest || null,
+    endDateObj: latest || null,
+    startDateIso: earliest ? earliest.toISOString() : '',
+    endDateIso: latest ? latest.toISOString() : '',
+  }
+}
+
+function deriveScheduleFromLegacy(raw = {}) {
+  const start = parseDate(raw.startDate)
+  const end = parseDate(raw.endDate) || start
+  if (!(start instanceof Date) || Number.isNaN(start)) {
+    return { entries: [], useDailySchedule: false, startDateObj: null, endDateObj: null, startDateIso: '', endDateIso: '' }
+  }
+
+  const entries = []
+
+  const treatAsAllDay =
+    Boolean(raw.allDay) ||
+    (end instanceof Date &&
+      !Number.isNaN(end) &&
+      end > start &&
+      start.getHours() === 0 &&
+      start.getMinutes() === 0 &&
+      end.getHours() === 0 &&
+      end.getMinutes() === 0)
+
+  if (treatAsAllDay && end instanceof Date && !Number.isNaN(end) && end > start) {
+    const firstDay = startOfDay(start)
+    const lastDay = startOfDay(end)
+    if (firstDay && lastDay && lastDay >= firstDay) {
+      const MAX_DERIVED_DAYS = 90
+      let count = 0
+      for (let cursor = new Date(firstDay); cursor <= lastDay && count < MAX_DERIVED_DAYS; cursor.setDate(cursor.getDate() + 1)) {
+        const dayStart = startOfDay(cursor)
+        const dayEnd = endOfDay(cursor)
+        const isoDate = formatDateForSlug(dayStart)
+        entries.push({
+          date: isoDate,
+          allDay: true,
+          start: dayStart,
+          end: dayEnd,
+          startIso: dayStart.toISOString(),
+          endIso: dayEnd.toISOString(),
+          startTimeLabel: '',
+          endTimeLabel: '',
+          startTimeValue: '',
+          endTimeValue: '',
+          label: `${scheduleDateFormatter.format(dayStart)}: All day`,
+          index: entries.length,
+        })
+        count += 1
+      }
+    }
+  }
+
+  if (!entries.length) {
+    return { entries: [], useDailySchedule: false, startDateObj: null, endDateObj: null, startDateIso: '', endDateIso: '' }
+  }
+
+  const earliest = entries[0]?.start || null
+  const latest = entries[entries.length - 1]?.end || earliest
+
+  return {
+    entries,
+    useDailySchedule: false,
+    startDateObj: earliest,
+    endDateObj: latest,
+    startDateIso: earliest ? earliest.toISOString() : '',
+    endDateIso: latest ? latest.toISOString() : '',
+  }
+}
 
 export function hydrateEvents(rawEvents = []) {
   return rawEvents
@@ -102,9 +349,21 @@ export function hydrateEvents(rawEvents = []) {
 
 export function sanitizeEvent(raw) {
   if (!raw || typeof raw !== 'object') return null
-  const startDateObj = parseDate(raw.startDate)
-  const endDateObj = parseDate(raw.endDate) || startDateObj
-  const durationMs = getDuration(startDateObj, endDateObj)
+  let scheduleInfo = normalizeDailySchedule(raw)
+  if (!scheduleInfo.entries.length) {
+    const derived = deriveScheduleFromLegacy(raw)
+    if (derived.entries.length) {
+      scheduleInfo = derived
+    }
+  }
+  const startDateObj = scheduleInfo.startDateObj || parseDate(raw.startDate)
+  const endDateObj = scheduleInfo.endDateObj || parseDate(raw.endDate) || startDateObj
+  const durationMs = scheduleInfo.entries.length
+    ? Math.max(
+        scheduleInfo.entries[0].end?.getTime() - scheduleInfo.entries[0].start?.getTime() || 0,
+        DEFAULT_DURATION_MS,
+      )
+    : getDuration(startDateObj, endDateObj)
 
   const slug = buildEventSlug(raw)
 
@@ -145,8 +404,8 @@ export function sanitizeEvent(raw) {
     category: String(raw.category || ''),
     town,
     subArea,
-    startDate: raw.startDate,
-    endDate: raw.endDate,
+    startDate: raw.startDate || scheduleInfo.startDateIso || '',
+    endDate: raw.endDate || scheduleInfo.endDateIso || raw.startDate || scheduleInfo.startDateIso || '',
     startDateObj,
     endDateObj,
     durationMs,
@@ -181,6 +440,8 @@ export function sanitizeEvent(raw) {
     lat: typeof raw.lat === 'number' ? raw.lat : null,
     lng: typeof raw.lng === 'number' ? raw.lng : null,
     hasLocation: typeof raw.lat === 'number' && typeof raw.lng === 'number',
+    useDailySchedule: scheduleInfo.useDailySchedule,
+    dailySchedule: scheduleInfo.entries,
     searchText: buildSearchText(raw),
   }
 }
@@ -242,8 +503,10 @@ function buildSearchText(raw) {
 
 export function formatDateRange(occurrence, allDay) {
   if (!occurrence || !occurrence.start) return ''
+  const effectiveAllDay =
+    typeof occurrence.allDay === 'boolean' ? occurrence.allDay : Boolean(allDay)
   const dateLabel = dateFormatter.format(occurrence.start)
-  if (allDay) {
+  if (effectiveAllDay) {
     if (isMultiDay(occurrence)) {
       return `${dateLabel} – ${dateFormatter.format(occurrence.end)}`
     }
@@ -366,6 +629,29 @@ function getWeekendRange(now) {
 }
 
 export function getEventOccurrences(event, rangeStart, rangeEnd) {
+  if (!event) return []
+
+  if (Array.isArray(event.dailySchedule) && event.dailySchedule.length) {
+    const occurrences = []
+    for (const entry of event.dailySchedule) {
+      if (!entry) continue
+      const start = entry.start instanceof Date ? new Date(entry.start) : entry.startIso ? new Date(entry.startIso) : null
+      const endCandidate = entry.end instanceof Date ? new Date(entry.end) : entry.endIso ? new Date(entry.endIso) : null
+      if (!(start instanceof Date) || Number.isNaN(start)) continue
+      const end = endCandidate && endCandidate > start ? endCandidate : new Date(start.getTime() + DEFAULT_DURATION_MS)
+      const dateKey = entry.date || formatDateForSlug(start)
+      occurrences.push({
+        start,
+        end,
+        key: `${event.slug || 'event'}-${dateKey || start.toISOString()}`,
+        allDay: Boolean(entry.allDay),
+        scheduleIndex: typeof entry.index === 'number' ? entry.index : occurrences.length,
+        scheduleDate: entry.date || '',
+      })
+    }
+    return occurrences.sort((a, b) => a.start.getTime() - b.start.getTime())
+  }
+
   if (!event?.startDateObj) return []
   const occurrences = []
   const duration = event.durationMs || DEFAULT_DURATION_MS
@@ -570,10 +856,52 @@ function truncateText(text, length) {
 }
 
 export function generateIcsContent(event, occurrence) {
-  const occ = occurrence || event.nextOccurrence || event.occurrences?.[0]
-  const start = occ?.start || event.startDateObj
-  const end = occ?.end || event.endDateObj || start
-  if (!start) return ''
+  if (!event) return ''
+
+  const occurrences = []
+
+  if (Array.isArray(event.dailySchedule) && event.dailySchedule.length) {
+    if (occurrence && occurrence.start) {
+      occurrences.push({
+        start: occurrence.start,
+        end: occurrence.end,
+        allDay: typeof occurrence.allDay === 'boolean' ? occurrence.allDay : Boolean(event.allDay),
+        dateKey: occurrence.scheduleDate || formatDateForSlug(occurrence.start),
+      })
+    } else {
+      for (const entry of event.dailySchedule) {
+        if (!entry) continue
+        const start = entry.start instanceof Date ? entry.start : entry.startIso ? new Date(entry.startIso) : null
+        const end = entry.end instanceof Date ? entry.end : entry.endIso ? new Date(entry.endIso) : null
+        if (!(start instanceof Date) || Number.isNaN(start)) continue
+        const resolvedEnd = end && end > start ? end : new Date(start.getTime() + DEFAULT_DURATION_MS)
+        occurrences.push({
+          start,
+          end: resolvedEnd,
+          allDay: Boolean(entry.allDay),
+          dateKey: entry.date || formatDateForSlug(start),
+        })
+      }
+    }
+  } else {
+    const occ = occurrence || event.nextOccurrence || event.occurrences?.[0]
+    const start = occ?.start || event.startDateObj
+    const end = occ?.end || event.endDateObj || start
+    if (start) {
+      occurrences.push({
+        start,
+        end,
+        allDay: typeof occ?.allDay === 'boolean' ? occ.allDay : Boolean(event.allDay),
+        dateKey: formatDateForSlug(start),
+      })
+    }
+  }
+
+  const validOccurrences = occurrences.filter((entry) => entry.start instanceof Date && !Number.isNaN(entry.start))
+  if (!validOccurrences.length) return ''
+
+  const timestamp = formatAsUtc(new Date())
+  const baseId = (event.slug && String(event.slug).trim()) || cryptoSafeId()
 
   const lines = [
     'BEGIN:VCALENDAR',
@@ -581,28 +909,39 @@ export function generateIcsContent(event, occurrence) {
     'PRODID:-//NorthSide GTA//Community Events//EN',
     'CALSCALE:GREGORIAN',
     'METHOD:PUBLISH',
-    'BEGIN:VEVENT',
-    `UID:${event.slug || cryptoSafeId() }@northsidegta.ca`,
-    `DTSTAMP:${formatAsUtc(new Date())}`,
-    `DTSTART:${formatDateForIcs(start, event.allDay)}`,
-    `DTEND:${formatDateForIcs(end, event.allDay)}`,
-    `SUMMARY:${escapeIcsText(event.title)}`,
   ]
 
-  if (event.locationName || event.address) {
-    const location = [event.locationName, event.address].filter(Boolean).join(', ')
-    lines.push(`LOCATION:${escapeIcsText(location)}`)
-  }
-  if (event.summary) {
-    lines.push(`DESCRIPTION:${escapeIcsText(event.summary)}`)
-  } else if (event.description) {
-    lines.push(`DESCRIPTION:${escapeIcsText(event.description)}`)
-  }
-  if (event.eventUrl) {
-    lines.push(`URL:${escapeIcsText(event.eventUrl)}`)
-  }
+  validOccurrences.forEach((entry, index) => {
+    const start = entry.start instanceof Date ? entry.start : new Date(entry.start)
+    const end = entry.end instanceof Date ? entry.end : new Date(entry.end || entry.start)
+    const allDay = Boolean(entry.allDay)
+    const suffix = entry.dateKey || `${index + 1}`
+    const uidSafe = `${baseId}-${suffix}`.replace(/[^a-zA-Z0-9-]/g, '-').replace(/-+/g, '-').replace(/-$/, '')
 
-  lines.push('END:VEVENT', 'END:VCALENDAR')
+    lines.push('BEGIN:VEVENT')
+    lines.push(`UID:${uidSafe}@northsidegta.ca`)
+    lines.push(`DTSTAMP:${timestamp}`)
+    lines.push(`DTSTART:${formatDateForIcs(start, allDay)}`)
+    lines.push(`DTEND:${formatDateForIcs(end, allDay)}`)
+    lines.push(`SUMMARY:${escapeIcsText(event.title)}`)
+
+    if (event.locationName || event.address) {
+      const location = [event.locationName, event.address].filter(Boolean).join(', ')
+      lines.push(`LOCATION:${escapeIcsText(location)}`)
+    }
+    if (event.summary) {
+      lines.push(`DESCRIPTION:${escapeIcsText(event.summary)}`)
+    } else if (event.description) {
+      lines.push(`DESCRIPTION:${escapeIcsText(event.description)}`)
+    }
+    if (event.eventUrl) {
+      lines.push(`URL:${escapeIcsText(event.eventUrl)}`)
+    }
+
+    lines.push('END:VEVENT')
+  })
+
+  lines.push('END:VCALENDAR')
   return lines.join('\r\n')
 }
 

--- a/tests/ics-schedule.test.js
+++ b/tests/ics-schedule.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const ical = require('node-ical')
+const { expandIcsEvents } = require('../lib/events/ics')
+
+async function parseIcs(content) {
+  const parsed = await ical.async.parseICS(content)
+  return Object.values(parsed).filter((entry) => entry && entry.type === 'VEVENT')
+}
+
+test('expands RRULE occurrences into daily schedule rows', async () => {
+  const ics = `BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:rrule@example.com\nDTSTART:20240520T140000Z\nDTEND:20240520T160000Z\nRRULE:FREQ=DAILY;COUNT=3\nSUMMARY:Daily Event\nEND:VEVENT\nEND:VCALENDAR`
+  const events = await parseIcs(ics)
+  const normalized = expandIcsEvents(events, { timezone: 'America/Toronto' }, new Date('2024-05-19T12:00:00Z'))
+  assert.equal(normalized.length, 1)
+  const event = normalized[0]
+  assert.equal(event.use_daily_schedule, true)
+  assert.ok(Array.isArray(event.daily_schedule))
+  assert.equal(event.daily_schedule.length, 3)
+  assert.deepEqual(event.daily_schedule[0], {
+    date: '2024-05-20',
+    start_time: '10:00',
+    end_time: '12:00',
+    all_day: false,
+  })
+  assert.match(event.start, /^2024-05-20T10:00:00/)
+  assert.match(event.end, /^2024-05-22T12:00:00/)
+  assert.equal(event.rrule, 'FREQ=DAILY;COUNT=3')
+})
+
+test('splits multi-day timed spans when hours are unambiguous', async () => {
+  const ics = `BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:span@example.com\nDTSTART:20240510T130000Z\nDTEND:20240512T210000Z\nSUMMARY:Weekend Fair\nEND:VEVENT\nEND:VCALENDAR`
+  const events = await parseIcs(ics)
+  const normalized = expandIcsEvents(events, { timezone: 'America/Toronto' }, new Date('2024-05-01T12:00:00Z'))
+  const event = normalized[0]
+  assert.equal(event.use_daily_schedule, true)
+  assert.equal(event.daily_schedule.length, 3)
+  assert.deepEqual(event.daily_schedule[0], {
+    date: '2024-05-10',
+    start_time: '09:00',
+    end_time: '17:00',
+    all_day: false,
+  })
+  assert.deepEqual(event.daily_schedule[2], {
+    date: '2024-05-12',
+    start_time: '09:00',
+    end_time: '17:00',
+    all_day: false,
+  })
+})
+
+test('derives all-day entries for VALUE=DATE spans', async () => {
+  const ics = `BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:allday@example.com\nDTSTART;VALUE=DATE:20240515\nDTEND;VALUE=DATE:20240518\nSUMMARY:Festival\nEND:VEVENT\nEND:VCALENDAR`
+  const events = await parseIcs(ics)
+  const normalized = expandIcsEvents(events, { timezone: 'America/Toronto' }, new Date('2024-05-10T12:00:00Z'))
+  const event = normalized[0]
+  assert.equal(event.use_daily_schedule, true)
+  assert.equal(event.daily_schedule.length, 3)
+  assert.deepEqual(event.daily_schedule[0], {
+    date: '2024-05-15',
+    start_time: '',
+    end_time: '',
+    all_day: true,
+  })
+  assert.deepEqual(event.daily_schedule[2], {
+    date: '2024-05-17',
+    start_time: '',
+    end_time: '',
+    all_day: true,
+  })
+})
+
+test('falls back to legacy span when hours are ambiguous', async () => {
+  const ics = `BEGIN:VCALENDAR\nBEGIN:VEVENT\nUID:ambiguous@example.com\nDTSTART:20240510T140000Z\nDTEND:20240511T140000Z\nSUMMARY:Continuous Retreat\nEND:VEVENT\nEND:VCALENDAR`
+  const events = await parseIcs(ics)
+  const normalized = expandIcsEvents(events, { timezone: 'America/Toronto' }, new Date('2024-05-01T00:00:00Z'))
+  const event = normalized[0]
+  assert.ok(!event.use_daily_schedule)
+  assert.ok(!event.daily_schedule)
+})


### PR DESCRIPTION
## Summary
- add a reusable daily schedule widget to Decap CMS and soften legacy start/end inputs when it is enabled
- render per-day occurrences across cards, calendars, detail pages, and ICS exports whenever schedule rows exist
- introduce a backfill utility that can populate daily rows for unambiguous multi-day events while keeping legacy fields intact

## Testing
- npm run events:backfill-daily -- --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e3b94e6fd883248da11e5a3cc24efe