### PR TITLE
Add reliable CMS widget loading and daily schedule form

### DIFF
--- a/api/community/submit-event.js
+++ b/api/community/submit-event.js
@@ -225,6 +225,131 @@ async function validateImageUrl(url) {
   }
 }
 
+function formatScheduleLabel(date) {
+  const parsed = DateTime.fromISO(date || '', { zone: TORONTO_ZONE })
+  return parsed.isValid ? parsed.toFormat('ccc, MMM d') : date
+}
+
+function validateDailyScheduleInput(payload, startDate, endDate) {
+  const wantsSchedule = Boolean(payload.useDailySchedule ?? payload.use_daily_schedule)
+  const rawSchedule = Array.isArray(payload.daily_schedule) ? payload.daily_schedule : []
+  if (!wantsSchedule && !rawSchedule.length) {
+    return { ok: true, schedule: [], derivedStart: startDate, derivedEnd: endDate }
+  }
+
+  if (!startDate?.isValid || !endDate?.isValid || endDate <= startDate) {
+    return { ok: false, error: 'Set valid start and end times before using the daily schedule.' }
+  }
+
+  if (!rawSchedule.length) {
+    return { ok: false, error: 'Provide at least one day in the daily schedule.' }
+  }
+
+  const dates = []
+  let cursor = startDate.startOf('day')
+  const last = endDate.startOf('day')
+  let steps = 0
+  while (cursor <= last && steps <= MAX_DURATION_DAYS) {
+    dates.push(cursor.toISODate())
+    cursor = cursor.plus({ days: 1 })
+    steps += 1
+  }
+
+  if (!dates.length) {
+    return { ok: false, error: 'Unable to derive the daily schedule range.' }
+  }
+
+  const scheduleMap = new Map()
+  rawSchedule.forEach((entry) => {
+    if (!entry || typeof entry !== 'object') return
+    const date = typeof entry.date === 'string' ? entry.date.trim() : ''
+    if (!date) return
+    scheduleMap.set(date, entry)
+  })
+
+  const sanitized = []
+  let earliest = null
+  let latest = null
+
+  for (const date of dates) {
+    const source = scheduleMap.get(date)
+    const label = formatScheduleLabel(date)
+    if (!source) {
+      return { ok: false, error: `Add hours for ${label}.` }
+    }
+
+    const allDay = Boolean(source.all_day ?? source.allDay)
+    if (allDay) {
+      sanitized.push({ date, all_day: true, blocks: [] })
+      const dayStart = DateTime.fromISO(`${date}T00:00`, { zone: TORONTO_ZONE })
+      const dayEnd = DateTime.fromISO(`${date}T23:59`, { zone: TORONTO_ZONE })
+      if (!earliest || dayStart < earliest) earliest = dayStart
+      if (!latest || dayEnd > latest) latest = dayEnd
+      continue
+    }
+
+    let blocks = []
+    if (Array.isArray(source.blocks) && source.blocks.length) {
+      blocks = source.blocks
+    } else if (source.start_time || source.startTime) {
+      blocks = [
+        {
+          start: source.start_time || source.startTime,
+          end: source.end_time || source.endTime,
+        },
+      ]
+    }
+
+    if (!blocks.length) {
+      return { ok: false, error: `Add at least one time range for ${label}.` }
+    }
+
+    const normalizedBlocks = []
+    for (const block of blocks) {
+      const startText = typeof block?.start === 'string' ? block.start.trim() : ''
+      const endText = typeof block?.end === 'string' ? block.end.trim() : ''
+      if (!startText || !endText) {
+        return { ok: false, error: `Complete the time range for ${label}.` }
+      }
+      if (!/^\d{2}:\d{2}$/.test(startText) || !/^\d{2}:\d{2}$/.test(endText)) {
+        return { ok: false, error: `Use HH:MM format for times on ${label}.` }
+      }
+      const startTime = DateTime.fromISO(`${date}T${startText}`, { zone: TORONTO_ZONE })
+      const endTime = DateTime.fromISO(`${date}T${endText}`, { zone: TORONTO_ZONE })
+      if (!startTime.isValid || !endTime.isValid) {
+        return { ok: false, error: `Enter valid times for ${label}.` }
+      }
+      if (endTime <= startTime) {
+        return { ok: false, error: `End time must be after the start time on ${label}.` }
+      }
+      normalizedBlocks.push({ start: startText, end: endText, startTime, endTime })
+    }
+
+    normalizedBlocks.sort((a, b) => a.startTime.toMillis() - b.startTime.toMillis())
+    for (let index = 1; index < normalizedBlocks.length; index += 1) {
+      if (normalizedBlocks[index].startTime < normalizedBlocks[index - 1].endTime) {
+        return { ok: false, error: `Time ranges overlap on ${label}.` }
+      }
+    }
+
+    const first = normalizedBlocks[0].startTime
+    const lastBlock = normalizedBlocks[normalizedBlocks.length - 1].endTime
+    if (!earliest || first < earliest) earliest = first
+    if (!latest || lastBlock > latest) latest = lastBlock
+
+    sanitized.push({
+      date,
+      all_day: false,
+      blocks: normalizedBlocks.map(({ start, end }) => ({ start, end })),
+    })
+  }
+
+  const derivedStart = earliest ?? startDate
+  const derivedEnd = latest ?? endDate
+
+  return { ok: true, schedule: sanitized, derivedStart, derivedEnd }
+}
+
 function validateSubmission(payload) {
   const errors = {}
   const data = {}
@@ -333,6 +458,23 @@ function validateSubmission(payload) {
 
   const imageUrl = normalizeText(payload.imageUrl)
   data.imageUrl = imageUrl
+
+  data.useDailySchedule = false
+  data.dailySchedule = []
+
+  const scheduleResult = validateDailyScheduleInput(payload, start, end)
+  if (!scheduleResult.ok) {
+    errors.dailySchedule = scheduleResult.error
+  } else {
+    data.useDailySchedule = scheduleResult.schedule.length > 0
+    data.dailySchedule = scheduleResult.schedule
+    if (scheduleResult.derivedStart?.isValid) {
+      data.startDate = scheduleResult.derivedStart
+    }
+    if (scheduleResult.derivedEnd?.isValid) {
+      data.endDate = scheduleResult.derivedEnd
+    }
+  }
 
   const rawAudience = Array.isArray(payload.audienceTags) ? payload.audienceTags : []
   data.audienceTags = rawAudience
@@ -604,6 +746,8 @@ export default async function handler(req, res) {
     sourceName: data.organizerName,
     submittedAt: DateTime.now().setZone(TORONTO_ZONE).toUTC().toISO(),
     contactConsent: data.contactConsent,
+    use_daily_schedule: data.useDailySchedule,
+    daily_schedule: data.useDailySchedule ? data.dailySchedule : [],
     moderation: {
       ip,
       submittedVia: 'public-form',
@@ -641,6 +785,8 @@ export default async function handler(req, res) {
       organizerEmail: pendingEvent.organizerEmail,
       ticketsUrl: pendingEvent.ticketsUrl,
       registrationUrl: pendingEvent.registrationUrl,
+      daily_schedule: pendingEvent.daily_schedule,
+      useDailySchedule: pendingEvent.use_daily_schedule,
     },
   })
 }

--- a/lib/events/ics.js
+++ b/lib/events/ics.js
@@ -61,7 +61,7 @@ function aggregateGroup(group, feed, now) {
 
   deduped.sort((a, b) => a.start.toMillis() - b.start.toMillis())
 
-  const schedule = []
+  const scheduleMap = new Map()
   let earliest = null
   let latest = null
 
@@ -79,22 +79,40 @@ function aggregateGroup(group, feed, now) {
       latest = occurrence.end
     }
 
-    if (occurrence.allDay) {
-      schedule.push({
-        date: isoDate,
-        start_time: '',
-        end_time: '',
-        all_day: true,
-      })
-    } else {
-      schedule.push({
-        date: isoDate,
-        start_time: occurrence.start.toFormat('HH:mm'),
-        end_time: occurrence.end.toFormat('HH:mm'),
-        all_day: false,
-      })
+    if (!scheduleMap.has(isoDate)) {
+      scheduleMap.set(isoDate, { date: isoDate, all_day: false, blocks: [] })
     }
+
+    const entry = scheduleMap.get(isoDate)
+    if (occurrence.allDay) {
+      entry.all_day = true
+      entry.blocks = []
+      continue
+    }
+
+    if (entry.all_day) {
+      continue
+    }
+
+    entry.blocks.push({
+      start: occurrence.start.toFormat('HH:mm'),
+      end: occurrence.end.toFormat('HH:mm'),
+    })
   }
+
+  const schedule = Array.from(scheduleMap.values())
+    .map((entry) => {
+      if (entry.all_day) {
+        return { date: entry.date, all_day: true, blocks: [] }
+      }
+      const blocks = entry.blocks
+        .filter((block) => block && block.start && block.end)
+        .map((block) => ({ start: block.start, end: block.end }))
+        .sort((a, b) => a.start.localeCompare(b.start))
+      return { date: entry.date, all_day: false, blocks }
+    })
+    .filter((entry) => entry.all_day || entry.blocks.length > 0)
+    .sort((a, b) => a.date.localeCompare(b.date))
 
   if (!schedule.length) {
     return normalizeLegacy(base)

--- a/public/cms/index.html
+++ b/public/cms/index.html
@@ -231,8 +231,10 @@
         ]
         const STORAGE_KEYS = ['decap-cms-user', 'netlify-cms-user']
         let cmsEnhancementsReady = false
+        let cmsEnhancementsPromise = null
+        let cmsEnhancementWaitLogged = false
 
-        function setupCMSEnhancements() {
+        function tryRegisterCmsEnhancements() {
           if (cmsEnhancementsReady) return true
           if (!window.CMS || !window.React) return false
           try {
@@ -240,10 +242,58 @@
             registerDailyScheduleWidget(window.CMS, window.React)
             activateLegacyFieldStyling()
             cmsEnhancementsReady = true
+            console.info('[cms-login] enhancements ready')
+            return true
           } catch (error) {
-            console.warn('[cms-login] failed to register CMS enhancements', error)
+            console.error('[cms-login] failed to register CMS enhancements', error)
+            return false
           }
-          return cmsEnhancementsReady
+        }
+
+        function ensureCmsEnhancementsReady() {
+          if (cmsEnhancementsReady) return Promise.resolve(true)
+          if (tryRegisterCmsEnhancements()) {
+            return Promise.resolve(true)
+          }
+          if (cmsEnhancementsPromise) {
+            return cmsEnhancementsPromise
+          }
+
+          cmsEnhancementsPromise = new Promise((resolve) => {
+            const start = Date.now()
+            const maxWaitMs = 5000
+            const intervalMs = 80
+
+            if (!cmsEnhancementWaitLogged) {
+              cmsEnhancementWaitLogged = true
+              console.info('[cms-login] waiting for CMS…')
+            }
+
+            const handleSuccess = () => {
+              if (tryRegisterCmsEnhancements()) {
+                window.clearInterval(timer)
+                cmsEnhancementsPromise = null
+                resolve(true)
+                return true
+              }
+              return false
+            }
+
+            const timer = window.setInterval(() => {
+              if (handleSuccess()) return
+              if (Date.now() - start > maxWaitMs) {
+                window.clearInterval(timer)
+                cmsEnhancementsPromise = null
+                const timeoutError = new Error('Timed out waiting for Decap CMS globals')
+                console.error('[cms-login] failed to register CMS enhancements', timeoutError)
+                resolve(false)
+              }
+            }, intervalMs)
+
+            handleSuccess()
+          })
+
+          return cmsEnhancementsPromise
         }
 
         function registerEventsPreview(CMS, React) {
@@ -632,8 +682,12 @@
             paddingTop: '20px',
           }
 
+          let rowIdCounter = 0
+
           function createRow(overrides = {}) {
+            rowIdCounter += 1
             return {
+              id: overrides.id || `row-${Date.now()}-${rowIdCounter}`,
               date: '',
               start_time: '',
               end_time: '',
@@ -644,50 +698,90 @@
 
           function normalizeRows(value) {
             if (!value) return []
+
+            let raw = []
             if (Immutable && typeof Immutable.List === 'function' && Immutable.List.isList(value)) {
-              return value
-                .toJS()
-                .map((row) =>
-                  createRow({
-                    date: (row?.date || '').trim(),
-                    start_time: row?.start_time || row?.startTime || '',
-                    end_time: row?.end_time || row?.endTime || '',
-                    all_day: Boolean(row?.all_day ?? row?.allDay),
-                  }),
-                )
-            }
-            if (Array.isArray(value)) {
-              return value.map((row) =>
-                createRow({
-                  date: (row?.date || '').trim(),
-                  start_time: row?.start_time || row?.startTime || '',
-                  end_time: row?.end_time || row?.endTime || '',
-                  all_day: Boolean(row?.all_day ?? row?.allDay),
-                }),
-              )
-            }
-            if (value && typeof value === 'object' && typeof value.toJS === 'function') {
+              raw = value.toJS()
+            } else if (Array.isArray(value)) {
+              raw = value
+            } else if (value && typeof value === 'object' && typeof value.toJS === 'function') {
               try {
-                const jsValue = value.toJS()
-                return normalizeRows(jsValue)
+                raw = value.toJS()
               } catch (error) {
-                return []
+                raw = []
               }
             }
-            return []
+
+            if (!Array.isArray(raw)) return []
+
+            const rows = []
+
+            raw.forEach((entry) => {
+              if (!entry || typeof entry !== 'object') return
+              const date = (entry.date || entry.day || '').trim()
+              const allDay = Boolean(entry.all_day ?? entry.allDay)
+              const blocks = Array.isArray(entry.blocks) ? entry.blocks : null
+
+              if (allDay) {
+                rows.push(
+                  createRow({
+                    date,
+                    all_day: true,
+                    start_time: '',
+                    end_time: '',
+                  }),
+                )
+                return
+              }
+
+              if (blocks && blocks.length) {
+                blocks.forEach((block) => {
+                  if (!block || typeof block !== 'object') return
+                  const startValue = block.start || block.start_time || block.startTime || ''
+                  const endValue = block.end || block.end_time || block.endTime || ''
+                  rows.push(
+                    createRow({
+                      date,
+                      start_time: typeof startValue === 'string' ? startValue : '',
+                      end_time: typeof endValue === 'string' ? endValue : '',
+                      all_day: false,
+                    }),
+                  )
+                })
+                return
+              }
+
+              const startValue = entry.start_time || entry.startTime || ''
+              const endValue = entry.end_time || entry.endTime || ''
+              rows.push(
+                createRow({
+                  date,
+                  start_time: typeof startValue === 'string' ? startValue : '',
+                  end_time: typeof endValue === 'string' ? endValue : '',
+                  all_day: false,
+                }),
+              )
+            })
+
+            return rows
           }
 
           function sortRows(rows) {
             return [...rows].sort((a, b) => {
-              if (!a.date && !b.date) return 0
-              if (!a.date) return 1
-              if (!b.date) return -1
-              const aDate = new Date(a.date)
-              const bDate = new Date(b.date)
-              if (!Number.isNaN(aDate) && !Number.isNaN(bDate)) {
-                return aDate - bDate
-              }
-              return a.date.localeCompare(b.date)
+              const dateA = a.date || ''
+              const dateB = b.date || ''
+              if (!dateA && !dateB) return 0
+              if (!dateA) return 1
+              if (!dateB) return -1
+              if (dateA !== dateB) return dateA.localeCompare(dateB)
+              if (a.all_day && !b.all_day) return -1
+              if (!a.all_day && b.all_day) return 1
+              const startA = a.start_time || ''
+              const startB = b.start_time || ''
+              if (startA && startB) return startA.localeCompare(startB)
+              if (startA) return -1
+              if (startB) return 1
+              return 0
             })
           }
 
@@ -743,18 +837,46 @@
               }
             }, [value, rows])
 
-            const sanitizedRows = useMemo(
-              () =>
-                rows
-                  .filter((row) => row.date)
-                  .map((row) => ({
-                    date: row.date,
-                    start_time: row.all_day ? '' : row.start_time,
-                    end_time: row.all_day ? '' : row.end_time,
-                    all_day: Boolean(row.all_day),
-                  })),
-              [rows],
-            )
+            const sanitizedRows = useMemo(() => {
+              const grouped = new Map()
+
+              rows.forEach((row) => {
+                if (!row.date) return
+                const key = row.date
+                if (!grouped.has(key)) {
+                  grouped.set(key, { date: key, all_day: false, blocks: [] })
+                }
+                const entry = grouped.get(key)
+                if (row.all_day) {
+                  entry.all_day = true
+                  entry.blocks = []
+                  return
+                }
+                if (entry.all_day) {
+                  return
+                }
+                entry.blocks.push({
+                  start: (row.start_time || '').trim(),
+                  end: (row.end_time || '').trim(),
+                })
+              })
+
+              const results = Array.from(grouped.values())
+                .map((entry) => {
+                  if (entry.all_day) {
+                    return { date: entry.date, all_day: true, blocks: [] }
+                  }
+                  const blocks = entry.blocks
+                    .filter((block) => block.start && block.end)
+                    .map((block) => ({ start: block.start, end: block.end }))
+                    .sort((a, b) => a.start.localeCompare(b.start))
+                  return { date: entry.date, all_day: false, blocks }
+                })
+                .filter((entry) => entry.all_day || entry.blocks.length > 0)
+                .sort((a, b) => a.date.localeCompare(b.date))
+
+              return results
+            }, [rows])
 
             useEffect(() => {
               if (onChange) {
@@ -850,7 +972,7 @@
                 const disableTimes = Boolean(row.all_day)
                 return React.createElement(
                   'div',
-                  { key: row.key || `${row.date || 'row'}-${index}`, style: rowStyle },
+                  { key: row.id || row.key || `${row.date || 'row'}-${index}`, style: rowStyle },
                   React.createElement(
                     'label',
                     { style: fieldStyle },
@@ -1085,7 +1207,7 @@
 
         async function loadCMSInterface(fromLogin = false) {
           if (window.__cmsLoaded) {
-            setupCMSEnhancements()
+            await ensureCmsEnhancementsReady()
             if (fromLogin) setLoading(false)
             return true
           }
@@ -1110,7 +1232,7 @@
           for (const src of CMS_SCRIPT_URLS) {
             try {
               await loadScript(src)
-              setupCMSEnhancements()
+              await ensureCmsEnhancementsReady()
               if (fromLogin) setLoading(false)
               return true
             } catch (error) {

--- a/scripts/backfill-daily-schedule.mjs
+++ b/scripts/backfill-daily-schedule.mjs
@@ -134,9 +134,8 @@ function deriveDailySchedule(event) {
     const iso = toIsoDate(cursor)
     results.push({
       date: iso,
-      start_time: '',
-      end_time: '',
       all_day: true,
+      blocks: [],
     })
     cursor = new Date(cursor.getTime() + DAY_MS)
     days += 1

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -1197,12 +1197,34 @@ function normalizeEvent(item, feed, now) {
         ? (item.daily_schedule || item.dailySchedule).length > 0
         : false),
     daily_schedule: Array.isArray(item.daily_schedule || item.dailySchedule)
-      ? (item.daily_schedule || item.dailySchedule).map((entry) => ({
-          date: entry?.date || entry?.day || '',
-          start_time: entry?.start_time || entry?.startTime || '',
-          end_time: entry?.end_time || entry?.endTime || '',
-          all_day: Boolean(entry?.all_day ?? entry?.allDay),
-        }))
+      ? (item.daily_schedule || item.dailySchedule).map((entry) => {
+          const date = entry?.date || entry?.day || ''
+          const allDay = Boolean(entry?.all_day ?? entry?.allDay)
+          const blocks = []
+
+          if (allDay) {
+            return { date, all_day: true, blocks: [] }
+          }
+
+          if (Array.isArray(entry?.blocks) && entry.blocks.length) {
+            entry.blocks.forEach((block) => {
+              if (!block) return
+              const start = block.start || block.start_time || block.startTime || ''
+              const end = block.end || block.end_time || block.endTime || ''
+              if (start && end) {
+                blocks.push({ start, end })
+              }
+            })
+          } else {
+            const start = entry?.start_time || entry?.startTime || ''
+            const end = entry?.end_time || entry?.endTime || ''
+            if (start && end) {
+              blocks.push({ start, end })
+            }
+          }
+
+          return { date, all_day: false, blocks }
+        })
       : undefined,
     source: { name: sourceName, id: sourceId },
     sourceName,

--- a/src/community/EventDetailPage.js
+++ b/src/community/EventDetailPage.js
@@ -224,27 +224,69 @@ export default function EventDetailPage() {
   const scheduleEntries = React.useMemo(() => {
     if (!event?.dailySchedule?.length) return []
     return event.dailySchedule.map((entry, index) => {
-      const start =
-        entry.start instanceof Date
+      const normalizedBlocks = Array.isArray(entry.blocks)
+        ? entry.blocks
+            .map((block) => {
+              if (!block) return null
+              const blockStart =
+                block.start instanceof Date
+                  ? block.start
+                  : block.startIso
+                    ? new Date(block.startIso)
+                    : null
+              const blockEnd =
+                block.end instanceof Date
+                  ? block.end
+                  : block.endIso
+                    ? new Date(block.endIso)
+                    : null
+              if (!(blockStart instanceof Date) || Number.isNaN(blockStart)) return null
+              const resolvedEnd =
+                blockEnd instanceof Date && !Number.isNaN(blockEnd) && blockEnd > blockStart
+                  ? blockEnd
+                  : null
+              const label = resolvedEnd
+                ? `${scheduleListTimeFormatter.format(blockStart)} – ${scheduleListTimeFormatter.format(resolvedEnd)}`
+                : scheduleListTimeFormatter.format(blockStart)
+              return {
+                ...block,
+                start: blockStart,
+                end: resolvedEnd,
+                label,
+              }
+            })
+            .filter(Boolean)
+        : []
+
+      const start = entry.allDay
+        ? entry.start instanceof Date
           ? entry.start
           : entry.startIso
             ? new Date(entry.startIso)
             : null
-      const end =
-        entry.end instanceof Date
+        : normalizedBlocks[0]?.start || (entry.startIso ? new Date(entry.startIso) : null)
+
+      const end = entry.allDay
+        ? entry.end instanceof Date
           ? entry.end
           : entry.endIso
             ? new Date(entry.endIso)
             : null
+        : normalizedBlocks[normalizedBlocks.length - 1]?.end || (entry.endIso ? new Date(entry.endIso) : null)
+
       const dateLabel = start ? scheduleListDateFormatter.format(start) : entry.date || ''
       const weekdayLabel = start ? scheduleListWeekdayFormatter.format(start) : ''
       const timeLabel = entry.allDay
         ? 'All day'
-        : start && end
-          ? `${scheduleListTimeFormatter.format(start)} – ${scheduleListTimeFormatter.format(end)}`
-          : ''
+        : normalizedBlocks.length
+          ? normalizedBlocks.map((block) => block.label).join('; ')
+          : start && end
+            ? `${scheduleListTimeFormatter.format(start)} – ${scheduleListTimeFormatter.format(end)}`
+            : ''
+
       return {
         ...entry,
+        blocks: normalizedBlocks,
         start,
         end,
         dateLabel,

--- a/src/community/SubmitEventPage.js
+++ b/src/community/SubmitEventPage.js
@@ -85,7 +85,182 @@ function initialFormState() {
     contactConsent: false,
     honeypot: '',
     captchaToken: '',
+    useDailySchedule: false,
+    dailySchedule: [],
   }
+}
+
+function createScheduleBlock(overrides = {}) {
+  return {
+    id: overrides.id || `block-${Math.random().toString(36).slice(2, 10)}`,
+    start: typeof overrides.start === 'string' ? overrides.start : '',
+    end: typeof overrides.end === 'string' ? overrides.end : '',
+  }
+}
+
+function createScheduleDay(date, overrides = {}) {
+  const normalizedDate = typeof date === 'string' ? date : ''
+  const allDay = Boolean(overrides.allDay)
+  const sourceBlocks = Array.isArray(overrides.blocks) ? overrides.blocks : []
+  const blocks = allDay
+    ? []
+    : sourceBlocks.length
+      ? sourceBlocks.map((block) => createScheduleBlock(block))
+      : [createScheduleBlock()]
+  const preserved = Array.isArray(overrides.preservedBlocks)
+    ? overrides.preservedBlocks.map((block) => createScheduleBlock(block))
+    : []
+  return {
+    id: overrides.id || `day-${Math.random().toString(36).slice(2, 9)}`,
+    date: normalizedDate,
+    allDay,
+    blocks,
+    preservedBlocks: preserved,
+  }
+}
+
+function cloneScheduleBlocks(blocks) {
+  if (!Array.isArray(blocks) || !blocks.length) {
+    return [createScheduleBlock()]
+  }
+  return blocks.map((block) => createScheduleBlock(block))
+}
+
+function computeScheduleDates(startIso, endIso) {
+  const start = DateTime.fromISO(startIso || '', { zone: TORONTO_ZONE })
+  const end = DateTime.fromISO(endIso || '', { zone: TORONTO_ZONE })
+  if (!start.isValid || !end.isValid || end < start) return []
+  const startDay = start.startOf('day')
+  const endDay = end.startOf('day')
+  const dates = []
+  let cursor = startDay
+  let steps = 0
+  while (cursor <= endDay && steps <= MAX_EVENT_DURATION_DAYS) {
+    dates.push(cursor.toISODate())
+    cursor = cursor.plus({ days: 1 })
+    steps += 1
+  }
+  return dates
+}
+
+function hasScheduleDayData(day) {
+  if (!day) return false
+  if (day.allDay) return true
+  if (!Array.isArray(day.blocks)) return false
+  return day.blocks.some((block) => {
+    const start = typeof block?.start === 'string' ? block.start.trim() : ''
+    const end = typeof block?.end === 'string' ? block.end.trim() : ''
+    return Boolean(start && end)
+  })
+}
+
+function syncScheduleDays(existingDays, startIso, endIso) {
+  const targetDates = computeScheduleDates(startIso, endIso)
+  const existingMap = new Map((existingDays || []).map((day) => [day.date, day]))
+  const days = targetDates.map((date) => {
+    const existing = existingMap.get(date)
+    if (existing) {
+      return createScheduleDay(date, existing)
+    }
+    return createScheduleDay(date)
+  })
+  const removed = Array.isArray(existingDays)
+    ? existingDays.filter((day) => day && !targetDates.includes(day.date))
+    : []
+  return { days, removed, targetDates }
+}
+
+function formatScheduleDateLabel(date) {
+  const parsed = DateTime.fromISO(date || '', { zone: TORONTO_ZONE })
+  return parsed.isValid ? parsed.toFormat('ccc, MMM d') : date
+}
+
+function validateDailyScheduleFormState(form) {
+  const result = { schedule: [], error: '', derivedStart: '', derivedEnd: '' }
+  if (!form.useDailySchedule) return result
+
+  const start = DateTime.fromISO(form.startDate || '', { zone: TORONTO_ZONE })
+  const end = DateTime.fromISO(form.endDate || '', { zone: TORONTO_ZONE })
+  if (!start.isValid || !end.isValid || end < start) {
+    return { ...result, error: 'Set valid start and end dates before using the daily schedule.' }
+  }
+
+  const dates = computeScheduleDates(form.startDate, form.endDate)
+  if (!dates.length) {
+    return { ...result, error: 'Choose a valid date range for the daily schedule.' }
+  }
+
+  const dayMap = new Map((form.dailySchedule || []).map((day) => [day.date, day]))
+  const sanitized = []
+  let earliest = null
+  let latest = null
+
+  for (const date of dates) {
+    const day = dayMap.get(date)
+    const readable = formatScheduleDateLabel(date)
+    if (!day) {
+      return { ...result, error: `Add hours for ${readable}.` }
+    }
+
+    if (day.allDay) {
+      sanitized.push({ date, all_day: true, blocks: [] })
+      const dayStart = DateTime.fromISO(`${date}T00:00`, { zone: TORONTO_ZONE })
+      const dayEnd = DateTime.fromISO(`${date}T23:59`, { zone: TORONTO_ZONE })
+      if (!earliest || dayStart < earliest) earliest = dayStart
+      if (!latest || dayEnd > latest) latest = dayEnd
+      continue
+    }
+
+    const blocks = Array.isArray(day.blocks) ? day.blocks : []
+    if (!blocks.length) {
+      return { ...result, error: `Add at least one time range for ${readable}.` }
+    }
+
+    const normalizedBlocks = []
+    for (const block of blocks) {
+      const startText = typeof block?.start === 'string' ? block.start.trim() : ''
+      const endText = typeof block?.end === 'string' ? block.end.trim() : ''
+      if (!startText || !endText) {
+        return { ...result, error: `Complete the time range for ${readable}.` }
+      }
+      if (!/^\d{2}:\d{2}$/.test(startText) || !/^\d{2}:\d{2}$/.test(endText)) {
+        return { ...result, error: `Use HH:MM format for times on ${readable}.` }
+      }
+      const startTime = DateTime.fromISO(`${date}T${startText}`, { zone: TORONTO_ZONE })
+      const endTime = DateTime.fromISO(`${date}T${endText}`, { zone: TORONTO_ZONE })
+      if (!startTime.isValid || !endTime.isValid) {
+        return { ...result, error: `Enter valid times for ${readable}.` }
+      }
+      if (endTime <= startTime) {
+        return { ...result, error: `End time must be after the start time on ${readable}.` }
+      }
+      normalizedBlocks.push({ start: startText, end: endText, startTime, endTime })
+    }
+
+    normalizedBlocks.sort((a, b) => a.startTime.toMillis() - b.startTime.toMillis())
+    for (let index = 1; index < normalizedBlocks.length; index += 1) {
+      const previous = normalizedBlocks[index - 1]
+      const current = normalizedBlocks[index]
+      if (current.startTime < previous.endTime) {
+        return { ...result, error: `Time ranges overlap on ${readable}.` }
+      }
+    }
+
+    const first = normalizedBlocks[0]
+    const last = normalizedBlocks[normalizedBlocks.length - 1]
+    if (!earliest || first.startTime < earliest) earliest = first.startTime
+    if (!latest || last.endTime > latest) latest = last.endTime
+    sanitized.push({
+      date,
+      all_day: false,
+      blocks: normalizedBlocks.map(({ start, end }) => ({ start, end })),
+    })
+  }
+
+  const derivedStart = earliest ? earliest.setZone(TORONTO_ZONE).toFormat("yyyy-LL-dd'T'HH:mm") : ''
+  const derivedEnd = latest ? latest.setZone(TORONTO_ZONE).toFormat("yyyy-LL-dd'T'HH:mm") : ''
+
+  return { schedule: sanitized, error: '', derivedStart, derivedEnd }
 }
 
 function stripHtml(value) {
@@ -338,9 +513,153 @@ export default function SubmitEventPage() {
 
   const finalImageUrl = form.uploadedImageUrl || form.imageUrl.trim()
 
+  const markScheduleTouched = React.useCallback(() => {
+    setTouched((prev) => ({ ...prev, dailySchedule: true }))
+  }, [setTouched])
+
+  const orderedScheduleDays = React.useMemo(() => {
+    if (!Array.isArray(form.dailySchedule)) return []
+    return [...form.dailySchedule].sort((a, b) => {
+      if (!a?.date && !b?.date) return 0
+      if (!a?.date) return 1
+      if (!b?.date) return -1
+      return a.date.localeCompare(b.date)
+    })
+  }, [form.dailySchedule])
+
   const setField = React.useCallback((name, value) => {
     setForm((prev) => ({ ...prev, [name]: value }))
   }, [])
+
+  const handleUseDailyScheduleChange = React.useCallback(
+    (event) => {
+      const checked = event.target.checked
+      if (checked) {
+        const { days } = syncScheduleDays(form.dailySchedule, form.startDate, form.endDate)
+        setTouched((prev) => ({ ...prev, dailySchedule: true }))
+        setForm((prev) => ({ ...prev, useDailySchedule: true, dailySchedule: days }))
+        console.info(`[submit-event] daily schedule enabled (${days.length} days)`)
+      } else {
+        setForm((prev) => ({ ...prev, useDailySchedule: false }))
+      }
+    },
+    [form.dailySchedule, form.startDate, form.endDate],
+  )
+
+  const handleStartDateChange = React.useCallback(
+    (value) => {
+      if (form.useDailySchedule) {
+        const { days, removed } = syncScheduleDays(form.dailySchedule, value, form.endDate)
+        if (
+          removed.some((day) => hasScheduleDayData(day)) &&
+          typeof window !== 'undefined' &&
+          !window.confirm('Shortening the range will remove daily schedule hours. Continue?')
+        ) {
+          return
+        }
+        setForm((prev) => ({ ...prev, startDate: value, dailySchedule: days }))
+      } else {
+        setForm((prev) => ({ ...prev, startDate: value }))
+      }
+    },
+    [form.dailySchedule, form.endDate, form.useDailySchedule],
+  )
+
+  const handleEndDateChange = React.useCallback(
+    (value) => {
+      if (form.useDailySchedule) {
+        const { days, removed } = syncScheduleDays(form.dailySchedule, form.startDate, value)
+        if (
+          removed.some((day) => hasScheduleDayData(day)) &&
+          typeof window !== 'undefined' &&
+          !window.confirm('Shortening the range will remove daily schedule hours. Continue?')
+        ) {
+          return
+        }
+        setForm((prev) => ({ ...prev, endDate: value, dailySchedule: days }))
+      } else {
+        setForm((prev) => ({ ...prev, endDate: value }))
+      }
+    },
+    [form.dailySchedule, form.startDate, form.useDailySchedule],
+  )
+
+  const updateScheduleBlock = React.useCallback(
+    (dayId, blockId, updates) => {
+      markScheduleTouched()
+      setForm((prev) => ({
+        ...prev,
+        dailySchedule: prev.dailySchedule.map((day) => {
+          if (day.id !== dayId || day.allDay) return day
+          const nextBlocks = day.blocks.map((block) =>
+            block.id === blockId ? { ...block, ...updates } : block,
+          )
+          return { ...day, blocks: nextBlocks }
+        }),
+      }))
+    },
+    [markScheduleTouched],
+  )
+
+  const addScheduleBlock = React.useCallback(
+    (dayId) => {
+      markScheduleTouched()
+      setForm((prev) => ({
+        ...prev,
+        dailySchedule: prev.dailySchedule.map((day) => {
+          if (day.id !== dayId || day.allDay) return day
+          return { ...day, blocks: [...day.blocks, createScheduleBlock()] }
+        }),
+      }))
+    },
+    [markScheduleTouched],
+  )
+
+  const removeScheduleBlock = React.useCallback(
+    (dayId, blockId) => {
+      markScheduleTouched()
+      setForm((prev) => ({
+        ...prev,
+        dailySchedule: prev.dailySchedule.map((day) => {
+          if (day.id !== dayId || day.allDay) return day
+          const nextBlocks = day.blocks.filter((block) => block.id !== blockId)
+          return { ...day, blocks: nextBlocks.length ? nextBlocks : [createScheduleBlock()] }
+        }),
+      }))
+    },
+    [markScheduleTouched],
+  )
+
+  const handleDayAllDayChange = React.useCallback(
+    (dayId, checked) => {
+      markScheduleTouched()
+      setForm((prev) => ({
+        ...prev,
+        dailySchedule: prev.dailySchedule.map((day) => {
+          if (day.id !== dayId) return day
+          if (checked) {
+            const preserved = day.blocks.length ? day.blocks : day.preservedBlocks
+            return {
+              ...day,
+              allDay: true,
+              blocks: [],
+              preservedBlocks: preserved,
+            }
+          }
+          const restored = day.preservedBlocks && day.preservedBlocks.length
+            ? day.preservedBlocks.map((block) => createScheduleBlock(block))
+            : cloneScheduleBlocks(day.blocks)
+          return {
+            ...day,
+            allDay: false,
+            blocks: restored,
+            preservedBlocks: [],
+          }
+        }),
+      }))
+    },
+    [markScheduleTouched],
+  )
 
   const handleBlur = React.useCallback(
     (name) => {
@@ -482,21 +801,39 @@ export default function SubmitEventPage() {
         nextErrors[name] = err
       }
     })
+
+    let scheduleResult = { schedule: [], error: '', derivedStart: '', derivedEnd: '' }
+    if (form.useDailySchedule) {
+      scheduleResult = validateDailyScheduleFormState(form)
+      nextErrors.dailySchedule = scheduleResult.error || ''
+    } else {
+      nextErrors.dailySchedule = ''
+    }
+
     setErrors(nextErrors)
-    return nextErrors
+    return { errors: nextErrors, scheduleResult }
   }
 
   const handleSubmit = async (event) => {
     event.preventDefault()
     setSubmitError('')
 
-    const validation = validateAll()
-    if (Object.values(validation).some(Boolean)) {
-      setTouched((prev) => ({ ...prev, submitAttempted: true }))
+    const { errors: validationErrors, scheduleResult } = validateAll()
+    if (Object.values(validationErrors).some(Boolean)) {
+      setTouched((prev) => ({
+        ...prev,
+        submitAttempted: true,
+        dailySchedule: form.useDailySchedule ? true : prev.dailySchedule,
+      }))
       return
     }
 
     setSubmitting(true)
+
+    const startDateForPayload =
+      form.useDailySchedule && scheduleResult.derivedStart ? scheduleResult.derivedStart : form.startDate
+    const endDateForPayload =
+      form.useDailySchedule && scheduleResult.derivedEnd ? scheduleResult.derivedEnd : form.endDate
 
     const payload = {
       title: form.title,
@@ -505,8 +842,8 @@ export default function SubmitEventPage() {
       eventType: form.eventType,
       shortDescription: stripHtml(form.shortDescription).trim(),
       fullDescription: stripHtml(form.fullDescription).trim(),
-      startDate: form.startDate,
-      endDate: form.endDate,
+      startDate: startDateForPayload,
+      endDate: endDateForPayload,
       venueName: form.venueName,
       streetAddress: form.streetAddress,
       city: form.city,
@@ -522,6 +859,8 @@ export default function SubmitEventPage() {
       honeypot: form.honeypot,
       captchaToken: form.captchaToken,
       captchaProvider: CAPTCHA_PROVIDER,
+      useDailySchedule: form.useDailySchedule,
+      daily_schedule: form.useDailySchedule ? scheduleResult.schedule : [],
     }
 
     try {
@@ -552,6 +891,33 @@ export default function SubmitEventPage() {
 
   if (submitResult?.ok) {
     const summary = submitResult.event || {}
+    const summaryScheduleLines = Array.isArray(summary.daily_schedule)
+      ? summary.daily_schedule.map((day, index) => {
+          const label = formatScheduleDateLabel(day?.date || '')
+          if (day?.all_day) {
+            return { key: `${day.date || index}-all-day`, label: `${label}: All day` }
+          }
+          const blocks = Array.isArray(day?.blocks) ? day.blocks : []
+          if (blocks.length) {
+            const times = blocks
+              .map((block, blockIndex) => {
+                if (!block?.start || !block?.end) return null
+                const start = DateTime.fromISO(`${day.date}T${block.start}`, { zone: TORONTO_ZONE })
+                const end = DateTime.fromISO(`${day.date}T${block.end}`, { zone: TORONTO_ZONE })
+                if (start.isValid && end.isValid) {
+                  return `${start.toFormat('h:mm a')} – ${end.toFormat('h:mm a')}`
+                }
+                return `${block.start} – ${block.end}`
+              })
+              .filter(Boolean)
+            return {
+              key: `${day.date || index}-blocks`,
+              label: times.length ? `${label}: ${times.join(', ')}` : `${label}: Times TBA`,
+            }
+          }
+          return { key: `${day.date || index}-empty`, label: `${label}: Times TBA` }
+        })
+      : []
     return (
       <div className="min-h-screen bg-emerald-950/5 py-12">
         <Helmet>
@@ -606,17 +972,27 @@ export default function SubmitEventPage() {
                     <dd className="font-medium text-slate-900">{summary.categoryTags.join(', ')}</dd>
                   </div>
                 ) : null}
+                {summaryScheduleLines.length ? (
+                  <div className="sm:col-span-2">
+                    <dt className="text-xs uppercase tracking-wide text-slate-500">Daily Schedule</dt>
+                    <dd className="mt-1 space-y-1 font-medium text-slate-900">
+                      {summaryScheduleLines.map((entry) => (
+                        <div key={entry.key}>{entry.label}</div>
+                      ))}
+                    </dd>
+                  </div>
+                ) : null}
               </dl>
-            {summary.image ? (
-              <div className="mt-6">
-                  <dt className="text-xs uppercase tracking-wide text-slate-500">Image</dt>
-                  <dd className="mt-2">
+              {summary.image ? (
+                <div className="mt-6">
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Image</p>
+                  <div className="mt-2">
                     <img
                       src={summary.image}
                       alt="Submitted event"
                       className="w-full rounded-2xl border border-slate-200 object-cover"
                     />
-                  </dd>
+                  </div>
                 </div>
               ) : null}
             </div>
@@ -857,7 +1233,7 @@ export default function SubmitEventPage() {
                     id="start-date"
                     type="datetime-local"
                     value={form.startDate}
-                    onChange={(event) => setField('startDate', event.target.value)}
+                    onChange={(event) => handleStartDateChange(event.target.value)}
                     onBlur={() => handleBlur('startDate')}
                     className={classNames(
                       'mt-2 w-full rounded-2xl border px-4 py-3 text-base shadow-sm focus:outline-none focus:ring-2',
@@ -879,7 +1255,7 @@ export default function SubmitEventPage() {
                     id="end-date"
                     type="datetime-local"
                     value={form.endDate}
-                    onChange={(event) => setField('endDate', event.target.value)}
+                    onChange={(event) => handleEndDateChange(event.target.value)}
                     onBlur={() => handleBlur('endDate')}
                     className={classNames(
                       'mt-2 w-full rounded-2xl border px-4 py-3 text-base shadow-sm focus:outline-none focus:ring-2',
@@ -891,6 +1267,116 @@ export default function SubmitEventPage() {
                   <Hint>End time must be after the start. Duration up to 14 days.</Hint>
                   <FormError message={errors.endDate && (touched.endDate || touched.submitAttempted) ? errors.endDate : ''} />
                 </div>
+              </div>
+              <div className="mt-6 rounded-2xl border border-emerald-200 bg-emerald-50/40 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <label className="flex items-center gap-2 text-sm font-semibold text-emerald-900">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-emerald-300 text-emerald-600 focus:ring-emerald-500"
+                      checked={form.useDailySchedule}
+                      onChange={handleUseDailyScheduleChange}
+                    />
+                    Use Daily Schedule (optional)
+                  </label>
+                  {form.useDailySchedule && (
+                    <span className="text-xs font-medium uppercase tracking-wide text-emerald-700">
+                      {orderedScheduleDays.length} day{orderedScheduleDays.length === 1 ? '' : 's'}
+                    </span>
+                  )}
+                </div>
+                <p className="mt-2 text-sm text-slate-600">
+                  When enabled, set hours for each day between the start and end dates. Adjusting the range updates the list
+                  automatically.
+                </p>
+                {form.useDailySchedule ? (
+                  orderedScheduleDays.length ? (
+                    <div className="mt-4 space-y-4">
+                      {orderedScheduleDays.map((day) => (
+                        <div key={day.id} className="rounded-xl border border-emerald-100 bg-white p-4 shadow-sm">
+                          <div className="flex flex-wrap items-center justify-between gap-3">
+                            <div>
+                              <p className="text-sm font-semibold text-emerald-900">{formatScheduleDateLabel(day.date)}</p>
+                              <p className="text-xs text-slate-500">{day.date || 'Set date'}</p>
+                            </div>
+                            <label className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                              <input
+                                type="checkbox"
+                                className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+                                checked={Boolean(day.allDay)}
+                                onChange={(event) => handleDayAllDayChange(day.id, event.target.checked)}
+                              />
+                              All day
+                            </label>
+                          </div>
+                          {day.allDay ? (
+                            <p className="mt-3 text-xs text-slate-600">This day is marked as an all-day event.</p>
+                          ) : (
+                            <div className="mt-4 space-y-3">
+                              {day.blocks.map((block) => (
+                                <div key={block.id} className="flex flex-wrap items-end gap-3">
+                                  <div className="min-w-[140px] flex-1">
+                                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                      Start time
+                                    </label>
+                                    <input
+                                      type="time"
+                                      value={block.start}
+                                      onChange={(event) => updateScheduleBlock(day.id, block.id, { start: event.target.value })}
+                                      className="mt-1 w-full rounded-xl border border-emerald-200 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                                    />
+                                  </div>
+                                  <div className="min-w-[140px] flex-1">
+                                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                      End time
+                                    </label>
+                                    <input
+                                      type="time"
+                                      value={block.end}
+                                      onChange={(event) => updateScheduleBlock(day.id, block.id, { end: event.target.value })}
+                                      className="mt-1 w-full rounded-xl border border-emerald-200 px-3 py-2 text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                                    />
+                                  </div>
+                                  {day.blocks.length > 1 && (
+                                    <button
+                                      type="button"
+                                      onClick={() => removeScheduleBlock(day.id, block.id)}
+                                      className="inline-flex items-center gap-1 rounded-full border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-600 transition hover:border-rose-300 hover:text-rose-700"
+                                    >
+                                      Remove
+                                    </button>
+                                  )}
+                                </div>
+                              ))}
+                              <button
+                                type="button"
+                                onClick={() => addScheduleBlock(day.id)}
+                                className="inline-flex items-center gap-2 rounded-full border border-emerald-300 px-3 py-1 text-xs font-semibold text-emerald-700 transition hover:border-emerald-400 hover:text-emerald-900"
+                              >
+                                Add another time range
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-4 text-sm font-medium text-emerald-800">
+                      Set both the start and end date to generate daily rows for editing.
+                    </p>
+                  )
+                ) : (
+                  <p className="mt-4 text-sm text-slate-500">
+                    Enable the daily schedule if the event spans multiple days or uses different hours each day.
+                  </p>
+                )}
+                <FormError
+                  message={
+                    errors.dailySchedule && (touched.dailySchedule || touched.submitAttempted)
+                      ? errors.dailySchedule
+                      : ''
+                  }
+                />
               </div>
             </section>
 

--- a/src/community/eventUtils.js
+++ b/src/community/eventUtils.js
@@ -192,73 +192,138 @@ function normalizeDailySchedule(raw = {}) {
       ? raw.dailySchedule
       : []
 
-  const entries = []
-  const seenDates = new Set()
+  const grouped = new Map()
 
-  schedule.forEach((row, index) => {
+  schedule.forEach((row) => {
     if (!row || typeof row !== 'object') return
     const dateValue = row.date ?? row.day ?? row.start_date
     const parsedDate = parseDateOnly(dateValue)
     if (!parsedDate) return
 
-    const isoDate = `${parsedDate.getFullYear()}-${String(
-      parsedDate.getMonth() + 1,
-    ).padStart(2, '0')}-${String(parsedDate.getDate()).padStart(2, '0')}`
-    if (seenDates.has(isoDate)) return
+    const isoDate = formatDateForSlug(parsedDate)
+    if (!isoDate) return
 
+    if (!grouped.has(isoDate)) {
+      grouped.set(isoDate, {
+        date: isoDate,
+        dateObj: parsedDate,
+        allDay: false,
+        blocks: [],
+      })
+    }
+
+    const entry = grouped.get(isoDate)
     const allDay = parseBoolean(row.all_day ?? row.allDay)
-    const startTime = parseTimeOfDay(row.start_time ?? row.startTime)
-    const endTime = parseTimeOfDay(row.end_time ?? row.endTime)
-
-    let start = null
-    let end = null
 
     if (allDay) {
-      start = startOfDay(parsedDate)
-      end = endOfDay(parsedDate)
-    } else if (startTime && endTime) {
-      start = applyTimeToDate(parsedDate, startTime)
-      end = applyTimeToDate(parsedDate, endTime)
-      if (!start || !end || end <= start) {
-        return
-      }
-    } else {
+      entry.allDay = true
+      entry.blocks = []
       return
     }
 
-    const labelDate = scheduleDateFormatter.format(parsedDate)
-    let label = labelDate
-    if (allDay) {
-      label = `${labelDate}: All day`
-    } else {
-      const startLabel = timeFormatter.format(start)
-      const endLabel = timeFormatter.format(end)
-      label = `${labelDate}: ${startLabel}–${endLabel}`
+    const blockList = Array.isArray(row.blocks) ? row.blocks : null
+
+    const pushBlock = (block) => {
+      if (!block || typeof block !== 'object') return
+      const rawStart = block.start ?? block.start_time ?? block.startTime
+      const rawEnd = block.end ?? block.end_time ?? block.endTime
+      const startTime = parseTimeOfDay(rawStart)
+      const endTime = parseTimeOfDay(rawEnd)
+      if (!startTime || !endTime) return
+      const start = applyTimeToDate(parsedDate, startTime)
+      const end = applyTimeToDate(parsedDate, endTime)
+      if (!start || !end || end <= start) return
+      entry.blocks.push({ start, end })
     }
 
-    entries.push({
-      date: isoDate,
-      allDay,
-      start,
-      end,
-      startIso: start?.toISOString() || '',
-      endIso: end?.toISOString() || '',
-      startTimeLabel: allDay ? '' : timeFormatter.format(start),
-      endTimeLabel: allDay ? '' : timeFormatter.format(end),
-      startTimeValue: allDay ? '' : timeFormatter24.format(start),
-      endTimeValue: allDay ? '' : timeFormatter24.format(end),
-      label,
-      index,
-    })
-    seenDates.add(isoDate)
+    if (blockList && blockList.length) {
+      blockList.forEach((block) => pushBlock(block))
+    } else {
+      pushBlock({
+        start: row.start_time ?? row.startTime,
+        end: row.end_time ?? row.endTime,
+      })
+    }
   })
 
-  entries.sort((a, b) => {
-    if (a.start && b.start) return a.start.getTime() - b.start.getTime()
-    if (a.start && !b.start) return -1
-    if (!a.start && b.start) return 1
-    return 0
-  })
+  const entries = []
+
+  Array.from(grouped.values())
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .forEach((entry, index) => {
+      if (!entry) return
+      const labelDate = entry.dateObj ? scheduleDateFormatter.format(entry.dateObj) : entry.date
+
+      if (entry.allDay) {
+        const start = startOfDay(entry.dateObj)
+        const end = endOfDay(entry.dateObj)
+        entries.push({
+          date: entry.date,
+          allDay: true,
+          start,
+          end,
+          startIso: start ? start.toISOString() : '',
+          endIso: end ? end.toISOString() : '',
+          startTimeLabel: '',
+          endTimeLabel: '',
+          startTimeValue: '',
+          endTimeValue: '',
+          label: `${labelDate}: All day`,
+          blocks: [],
+          blockCount: 0,
+          index,
+        })
+        return
+      }
+
+      const sortedBlocks = entry.blocks
+        .filter((block) => block?.start instanceof Date && block?.end instanceof Date && block.end > block.start)
+        .sort((a, b) => a.start.getTime() - b.start.getTime())
+
+      if (!sortedBlocks.length) {
+        return
+      }
+
+      const detailedBlocks = sortedBlocks.map((block, blockIndex) => {
+        const startIso = block.start.toISOString()
+        const endIso = block.end.toISOString()
+        const startLabel = timeFormatter.format(block.start)
+        const endLabel = timeFormatter.format(block.end)
+        return {
+          start: block.start,
+          end: block.end,
+          startIso,
+          endIso,
+          startTimeLabel: startLabel,
+          endTimeLabel: endLabel,
+          startTimeValue: timeFormatter24.format(block.start),
+          endTimeValue: timeFormatter24.format(block.end),
+          label: `${startLabel} – ${endLabel}`,
+          blockIndex,
+        }
+      })
+
+      const first = detailedBlocks[0]
+      const last = detailedBlocks[detailedBlocks.length - 1]
+      const timeSummary = detailedBlocks.map((block) => block.label).join(', ')
+
+      entries.push({
+        date: entry.date,
+        allDay: false,
+        start: first.start,
+        end: last.end,
+        startIso: first.startIso,
+        endIso: last.endIso,
+        startTimeLabel: first.startTimeLabel,
+        endTimeLabel: last.endTimeLabel,
+        startTimeValue: first.startTimeValue,
+        endTimeValue: last.endTimeValue,
+        label: `${labelDate}: ${timeSummary}`,
+        blocks: detailedBlocks,
+        blockCount: detailedBlocks.length,
+        index,
+      })
+    })
 
   const earliest = entries[0]?.start || null
   const latest = entries[entries.length - 1]?.end || earliest
@@ -635,6 +700,29 @@ export function getEventOccurrences(event, rangeStart, rangeEnd) {
     const occurrences = []
     for (const entry of event.dailySchedule) {
       if (!entry) continue
+      const hasBlocks = Array.isArray(entry.blocks) && entry.blocks.length > 0
+
+      if (hasBlocks) {
+        entry.blocks.forEach((block) => {
+          if (!block) return
+          const start = block.start instanceof Date ? new Date(block.start) : block.startIso ? new Date(block.startIso) : null
+          const endCandidate = block.end instanceof Date ? new Date(block.end) : block.endIso ? new Date(block.endIso) : null
+          if (!(start instanceof Date) || Number.isNaN(start)) return
+          const end = endCandidate && endCandidate > start ? endCandidate : new Date(start.getTime() + DEFAULT_DURATION_MS)
+          const dateKey = entry.date || formatDateForSlug(start)
+          occurrences.push({
+            start,
+            end,
+            key: `${event.slug || 'event'}-${dateKey}-${block.blockIndex ?? 'block'}`,
+            allDay: Boolean(entry.allDay),
+            scheduleIndex: typeof entry.index === 'number' ? entry.index : occurrences.length,
+            scheduleDate: entry.date || '',
+            scheduleBlockIndex: typeof block.blockIndex === 'number' ? block.blockIndex : undefined,
+          })
+        })
+        continue
+      }
+
       const start = entry.start instanceof Date ? new Date(entry.start) : entry.startIso ? new Date(entry.startIso) : null
       const endCandidate = entry.end instanceof Date ? new Date(entry.end) : entry.endIso ? new Date(entry.endIso) : null
       if (!(start instanceof Date) || Number.isNaN(start)) continue
@@ -871,13 +959,31 @@ export function generateIcsContent(event, occurrence) {
     } else {
       for (const entry of event.dailySchedule) {
         if (!entry) continue
+        const hasBlocks = Array.isArray(entry.blocks) && entry.blocks.length > 0
+        if (hasBlocks) {
+          entry.blocks.forEach((block) => {
+            if (!block) return
+            const start = block.start instanceof Date ? block.start : block.startIso ? new Date(block.startIso) : null
+            const endCandidate = block.end instanceof Date ? block.end : block.endIso ? new Date(block.endIso) : null
+            if (!(start instanceof Date) || Number.isNaN(start)) return
+            const end = endCandidate && endCandidate > start ? endCandidate : new Date(start.getTime() + DEFAULT_DURATION_MS)
+            occurrences.push({
+              start,
+              end,
+              allDay: Boolean(entry.allDay),
+              dateKey: entry.date || formatDateForSlug(start),
+            })
+          })
+          continue
+        }
+
         const start = entry.start instanceof Date ? entry.start : entry.startIso ? new Date(entry.startIso) : null
-        const end = entry.end instanceof Date ? entry.end : entry.endIso ? new Date(entry.endIso) : null
+        const endCandidate = entry.end instanceof Date ? entry.end : entry.endIso ? new Date(entry.endIso) : null
         if (!(start instanceof Date) || Number.isNaN(start)) continue
-        const resolvedEnd = end && end > start ? end : new Date(start.getTime() + DEFAULT_DURATION_MS)
+        const end = endCandidate && endCandidate > start ? endCandidate : new Date(start.getTime() + DEFAULT_DURATION_MS)
         occurrences.push({
           start,
-          end: resolvedEnd,
+          end,
           allDay: Boolean(entry.allDay),
           dateKey: entry.date || formatDateForSlug(start),
         })

--- a/tests/ics-schedule.test.js
+++ b/tests/ics-schedule.test.js
@@ -19,9 +19,8 @@ test('expands RRULE occurrences into daily schedule rows', async () => {
   assert.equal(event.daily_schedule.length, 3)
   assert.deepEqual(event.daily_schedule[0], {
     date: '2024-05-20',
-    start_time: '10:00',
-    end_time: '12:00',
     all_day: false,
+    blocks: [{ start: '10:00', end: '12:00' }],
   })
   assert.match(event.start, /^2024-05-20T10:00:00/)
   assert.match(event.end, /^2024-05-22T12:00:00/)
@@ -37,15 +36,13 @@ test('splits multi-day timed spans when hours are unambiguous', async () => {
   assert.equal(event.daily_schedule.length, 3)
   assert.deepEqual(event.daily_schedule[0], {
     date: '2024-05-10',
-    start_time: '09:00',
-    end_time: '17:00',
     all_day: false,
+    blocks: [{ start: '09:00', end: '17:00' }],
   })
   assert.deepEqual(event.daily_schedule[2], {
     date: '2024-05-12',
-    start_time: '09:00',
-    end_time: '17:00',
     all_day: false,
+    blocks: [{ start: '09:00', end: '17:00' }],
   })
 })
 
@@ -58,15 +55,13 @@ test('derives all-day entries for VALUE=DATE spans', async () => {
   assert.equal(event.daily_schedule.length, 3)
   assert.deepEqual(event.daily_schedule[0], {
     date: '2024-05-15',
-    start_time: '',
-    end_time: '',
     all_day: true,
+    blocks: [],
   })
   assert.deepEqual(event.daily_schedule[2], {
     date: '2024-05-17',
-    start_time: '',
-    end_time: '',
     all_day: true,
+    blocks: [],
   })
 })
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,9 @@
 {
+  "redirects": [
+    { "source": "/admin", "destination": "/cms", "statusCode": 308 },
+    { "source": "/admin/(.*)", "destination": "/cms/$1", "statusCode": 308 }
+  ],
   "rewrites": [
-    { "source": "/admin", "destination": "/admin/" },
-    { "source": "/admin/", "destination": "/admin/index.html" },
-    { "source": "/admin/config.yml", "destination": "/admin/config.yml" },
-    { "source": "/admin/(.*)", "destination": "/admin/$1" },
-
     { "source": "/cms", "destination": "/cms/" },
     { "source": "/cms/", "destination": "/cms/index.html" },
     { "source": "/cms/config.yml", "destination": "/cms/config.yml" },


### PR DESCRIPTION
## Summary
- ensure Decap CMS enhancements wait for window globals before registering and log readiness, keeping the daily schedule widget available
- add a daily schedule editor to the public submit event form with validation, syncing API storage, and display updates across event utilities and detail pages
- generate daily schedule blocks from ICS ingestion and scripts while redirecting /admin to /cms

## Testing
- npm test

## Verification
- In the CMS console, run `CMS.getWidget('dailySchedule')` and confirm it returns an object.

## Notes
- `/admin` now issues a 308 redirect to `/cms` via Vercel configuration.

------
https://chatgpt.com/codex/tasks/task_e_68e3d484d1248324861132e55afaebca