### PR TITLE
Improve Decap CMS enhancements loading and layout

### DIFF
--- a/public/cms/index.html
+++ b/public/cms/index.html
@@ -233,79 +233,187 @@
         let cmsEnhancementsReady = false
         let cmsEnhancementsPromise = null
         let cmsEnhancementWaitLogged = false
+        let cmsEnhancementIframeLogged = false
 
-        function findCMSContext() {
-          if (window.CMS && window.React) return window
-          const iframes = Array.from(document.querySelectorAll('iframe'))
-          for (const f of iframes) {
-            try {
-              if (f.contentWindow?.CMS && f.contentWindow?.React) {
-                return f.contentWindow
-              }
-            } catch (e) {}
-          }
-          return null
+        const CMS_POLL_INTERVAL = 100
+        const CMS_POLL_TIMEOUT = 30000
+
+        function logWaitingForCms() {
+          if (cmsEnhancementWaitLogged) return
+          cmsEnhancementWaitLogged = true
+          console.info('[cms-login] waiting for CMS…')
         }
 
-        function tryRegisterCmsEnhancements(context) {
+        function logIframeContextFound() {
+          if (cmsEnhancementIframeLogged) return
+          cmsEnhancementIframeLogged = true
+          console.info('[cms-login] found iframe context, waiting for CMS…')
+        }
+
+        function registerCmsEnhancementsInContext(contextWindow) {
           if (cmsEnhancementsReady) return true
-          if (!context || !context.CMS || !context.React) return false
-          try {
-            registerEventsPreview(context.CMS, context.React)
-            registerDailyScheduleWidget(context.CMS, context.React)
-            activateLegacyFieldStyling()
-            cmsEnhancementsReady = true
-            console.info('[cms-login] enhancements ready')
-            return true
-          } catch (error) {
-            console.error('[cms-login] failed to register CMS enhancements', error)
+          if (!contextWindow || !contextWindow.CMS || !contextWindow.React) {
             return false
           }
+
+          registerEventsPreview(contextWindow.CMS, contextWindow.React)
+          registerDailyScheduleWidget(contextWindow.CMS, contextWindow.React)
+          activateLegacyFieldStyling(contextWindow)
+          applyCmsHeaderLayoutFix(contextWindow)
+
+          cmsEnhancementsReady = true
+          console.info('[cms-login] enhancements ready')
+          return true
+        }
+
+        function waitForCmsGlobals(contextWindow) {
+          return new Promise((resolve) => {
+            const start = Date.now()
+            const timer = window.setInterval(() => {
+              try {
+                if (contextWindow.CMS && contextWindow.React) {
+                  window.clearInterval(timer)
+                  resolve(contextWindow)
+                  return
+                }
+              } catch (error) {
+                window.clearInterval(timer)
+                resolve(null)
+                return
+              }
+
+              if (Date.now() - start >= CMS_POLL_TIMEOUT) {
+                window.clearInterval(timer)
+                resolve(null)
+              }
+            }, CMS_POLL_INTERVAL)
+          })
         }
 
         function ensureCmsEnhancementsReady() {
           if (cmsEnhancementsReady) return Promise.resolve(true)
-          const existingContext = findCMSContext()
-          if (tryRegisterCmsEnhancements(existingContext)) {
-            return Promise.resolve(true)
-          }
-          if (cmsEnhancementsPromise) {
-            return cmsEnhancementsPromise
-          }
+          if (cmsEnhancementsPromise) return cmsEnhancementsPromise
 
           cmsEnhancementsPromise = new Promise((resolve) => {
-            const start = Date.now()
-            const maxWaitMs = 5000
-            const intervalMs = 80
+            logWaitingForCms()
 
-            if (!cmsEnhancementWaitLogged) {
-              cmsEnhancementWaitLogged = true
-              console.info('[cms-login] waiting for CMS…')
+            let finished = false
+            const watchedWindows = new WeakSet()
+            let observer = null
+            let timeoutId = null
+            const schedule =
+              typeof window.requestAnimationFrame === 'function'
+                ? window.requestAnimationFrame.bind(window)
+                : (callback) => window.setTimeout(callback, 16)
+
+            const fail = (error) => {
+              if (finished || cmsEnhancementsReady) return
+              finished = true
+              if (observer) observer.disconnect()
+              if (timeoutId) window.clearTimeout(timeoutId)
+              cmsEnhancementsPromise = null
+              console.error('[cms-login] failed to register CMS enhancements', error)
+              resolve(false)
             }
 
-            const handleSuccess = () => {
-              const context = findCMSContext()
-              if (tryRegisterCmsEnhancements(context)) {
-                window.clearInterval(timer)
-                cmsEnhancementsPromise = null
-                resolve(true)
-                return true
-              }
-              return false
+            const succeed = () => {
+              if (finished) return
+              finished = true
+              if (observer) observer.disconnect()
+              if (timeoutId) window.clearTimeout(timeoutId)
+              cmsEnhancementsPromise = null
+              resolve(true)
             }
 
-            const timer = window.setInterval(() => {
-              if (handleSuccess()) return
-              if (Date.now() - start > maxWaitMs) {
-                window.clearInterval(timer)
-                cmsEnhancementsPromise = null
-                const timeoutError = new Error('Timed out waiting for Decap CMS globals')
-                console.error('[cms-login] failed to register CMS enhancements', timeoutError)
-                resolve(false)
+            const watchWindow = (candidateWindow, { fromIframe } = {}) => {
+              if (finished || !candidateWindow || watchedWindows.has(candidateWindow)) {
+                return
               }
-            }, intervalMs)
 
-            handleSuccess()
+              watchedWindows.add(candidateWindow)
+
+              if (fromIframe) {
+                logIframeContextFound()
+              }
+
+              try {
+                if (registerCmsEnhancementsInContext(candidateWindow)) {
+                  succeed()
+                  return
+                }
+              } catch (error) {
+                fail(error)
+                return
+              }
+
+              waitForCmsGlobals(candidateWindow).then((context) => {
+                if (finished || cmsEnhancementsReady || !context) return
+
+                try {
+                  if (registerCmsEnhancementsInContext(context)) {
+                    succeed()
+                  }
+                } catch (error) {
+                  fail(error)
+                }
+              })
+            }
+
+            const handleIframe = (iframe) => {
+              if (!(iframe instanceof window.HTMLIFrameElement)) return
+              if (finished || cmsEnhancementsReady) return
+
+              const mark = '__nsCmsEnhancerAttached'
+              if (iframe[mark]) return
+              iframe[mark] = true
+
+              const attempt = () => {
+                if (finished || cmsEnhancementsReady) return
+                try {
+                  const candidateWindow = iframe.contentWindow
+                  if (!candidateWindow) return
+                  watchWindow(candidateWindow, { fromIframe: true })
+                } catch (error) {}
+              }
+
+              iframe.addEventListener('load', attempt, { once: false })
+              attempt()
+            }
+
+            const existingIframes = Array.from(document.querySelectorAll('iframe'))
+            existingIframes.forEach((iframe) => handleIframe(iframe))
+
+            watchWindow(window)
+
+            observer = new MutationObserver((mutations) => {
+              for (const mutation of mutations) {
+                mutation.addedNodes.forEach((node) => {
+                  if (node instanceof window.HTMLIFrameElement) {
+                    handleIframe(node)
+                  } else if (node && typeof node.querySelectorAll === 'function') {
+                    const nestedIframes = node.querySelectorAll('iframe')
+                    nestedIframes.forEach((iframe) => handleIframe(iframe))
+                  }
+                })
+              }
+            })
+
+            const attachObserver = () => {
+              if (finished || cmsEnhancementsReady) return
+              if (document.body) {
+                observer.observe(document.body, { childList: true, subtree: true })
+              } else {
+                schedule(attachObserver)
+              }
+            }
+
+            attachObserver()
+
+            timeoutId = window.setTimeout(() => {
+              if (finished || cmsEnhancementsReady) return
+              const timeoutError = new Error('Timed out waiting for Decap CMS globals')
+              fail(timeoutError)
+            }, CMS_POLL_TIMEOUT + 500)
           })
 
           return cmsEnhancementsPromise
@@ -1083,16 +1191,31 @@
           CMS.registerWidget('dailySchedule', DailyScheduleControl)
         }
 
-        let legacyStylingInitialized = false
+        const legacyStylingInitializedFor = new WeakSet()
 
-        function activateLegacyFieldStyling() {
-          if (legacyStylingInitialized) return
-          if (typeof document === 'undefined') return
-          legacyStylingInitialized = true
+        function activateLegacyFieldStyling(contextWindow) {
+          const targetWindow = contextWindow && contextWindow.document ? contextWindow : window
+          const targetDocument = targetWindow.document
+          if (!targetDocument) return
+          if (legacyStylingInitializedFor.has(targetWindow)) return
+          legacyStylingInitializedFor.add(targetWindow)
 
-          const styleId = 'ns-legacy-schedule-style'
-          if (!document.getElementById(styleId)) {
-            const style = document.createElement('style')
+          const raf =
+            typeof targetWindow.requestAnimationFrame === 'function'
+              ? targetWindow.requestAnimationFrame.bind(targetWindow)
+              : (callback) => targetWindow.setTimeout(callback, 16)
+
+          const ensureStyleElement = () => {
+            const styleId = 'ns-legacy-schedule-style'
+            if (targetDocument.getElementById(styleId)) return
+
+            const head = targetDocument.head || targetDocument.getElementsByTagName('head')[0]
+            if (!head) {
+              raf(ensureStyleElement)
+              return
+            }
+
+            const style = targetDocument.createElement('style')
             style.id = styleId
             style.textContent = `
               [data-field-name="startDate"].ns-legacy-muted,
@@ -1105,13 +1228,15 @@
                 opacity: 0.85;
               }
             `
-            document.head.appendChild(style)
+            head.appendChild(style)
           }
 
           const update = () => {
-            const flag = document.querySelector('[data-field-name="use_daily_schedule"] input[type="checkbox"]')
-            const startField = document.querySelector('[data-field-name="startDate"]')
-            const endField = document.querySelector('[data-field-name="endDate"]')
+            const flag = targetDocument.querySelector(
+              '[data-field-name="use_daily_schedule"] input[type="checkbox"]',
+            )
+            const startField = targetDocument.querySelector('[data-field-name="startDate"]')
+            const endField = targetDocument.querySelector('[data-field-name="endDate"]')
             const muted = Boolean(flag && flag.checked)
             ;[startField, endField].forEach((node) => {
               if (!node) return
@@ -1123,19 +1248,146 @@
             })
           }
 
-          const observer = new MutationObserver(() => {
-            window.requestAnimationFrame(update)
+          const observer = new targetWindow.MutationObserver(() => {
+            raf(update)
           })
 
-          observer.observe(document.body, { childList: true, subtree: true })
+          const startObserving = () => {
+            if (!targetDocument.body) {
+              raf(startObserving)
+              return
+            }
+            observer.observe(targetDocument.body, { childList: true, subtree: true })
+          }
 
-          document.addEventListener('change', (event) => {
+          ensureStyleElement()
+          startObserving()
+
+          targetDocument.addEventListener('change', (event) => {
             if (event.target && event.target.closest('[data-field-name="use_daily_schedule"]')) {
-              window.requestAnimationFrame(update)
+              raf(update)
             }
           })
 
-          window.requestAnimationFrame(update)
+          raf(update)
+        }
+
+        const headerLayoutFixAppliedFor = new WeakSet()
+
+        function applyCmsHeaderLayoutFix(contextWindow) {
+          const targetWindow = contextWindow && contextWindow.document ? contextWindow : window
+          const targetDocument = targetWindow.document
+          if (!targetDocument) return
+          if (headerLayoutFixAppliedFor.has(targetWindow)) return
+          headerLayoutFixAppliedFor.add(targetWindow)
+
+          const raf =
+            typeof targetWindow.requestAnimationFrame === 'function'
+              ? targetWindow.requestAnimationFrame.bind(targetWindow)
+              : (callback) => targetWindow.setTimeout(callback, 16)
+
+          const ensureStyleElement = () => {
+            const styleId = 'ns-cms-header-layout-fix'
+            if (targetDocument.getElementById(styleId)) return
+
+            const head = targetDocument.head || targetDocument.getElementsByTagName('head')[0]
+            if (!head) {
+              raf(ensureStyleElement)
+              return
+            }
+
+            const style = targetDocument.createElement('style')
+            style.id = styleId
+            style.textContent = `
+              #nc-root [data-testid="collection-top"],
+              #nc-root [class*="CollectionTop_top"] {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: center;
+                gap: 8px;
+              }
+              #nc-root [data-testid="collection-top"] > *:first-child,
+              #nc-root [class*="CollectionTop_top"] > *:first-child {
+                flex: 1 1 auto;
+                min-width: 200px;
+              }
+              #nc-root [data-testid="collection-top"] [data-testid="collection-actions"],
+              #nc-root [class*="CollectionTop_top"] [data-testid="collection-actions"],
+              #nc-root [class*="CollectionTop_top"] [class*="CollectionTop_actions"],
+              #nc-root [class*="CollectionTop_top"] [class*="CollectionTop_topActions"] {
+                margin-left: auto;
+                display: flex;
+                flex-wrap: wrap;
+                align-items: center;
+                gap: 8px;
+                justify-content: flex-end;
+              }
+            `
+            head.appendChild(style)
+          }
+
+          const applyInlineLayout = () => {
+            const topContainer =
+              targetDocument.querySelector('#nc-root [data-testid="collection-top"]') ||
+              targetDocument.querySelector('#nc-root [class*="CollectionTop_top"]')
+
+            if (!topContainer) return
+
+            topContainer.style.display = 'flex'
+            topContainer.style.alignItems = 'center'
+            topContainer.style.flexWrap = 'wrap'
+            topContainer.style.gap = '8px'
+
+            const headingContainer = topContainer.firstElementChild
+            if (headingContainer) {
+              headingContainer.style.flex = '1 1 auto'
+              headingContainer.style.minWidth = '200px'
+            }
+
+            const findActionsContainer = () => {
+              const directMatch = topContainer.querySelector('[data-testid="collection-actions"]')
+              if (directMatch) return directMatch
+
+              const classMatch = topContainer.querySelector(
+                '[class*="CollectionTop_actions"], [class*="CollectionTop_topActions"]',
+              )
+              if (classMatch) return classMatch
+
+              const lastChild = topContainer.lastElementChild
+              if (lastChild && lastChild !== headingContainer) {
+                return lastChild
+              }
+              return null
+            }
+
+            const actionsContainer = findActionsContainer()
+            if (actionsContainer) {
+              actionsContainer.style.marginLeft = 'auto'
+              actionsContainer.style.display = 'flex'
+              actionsContainer.style.alignItems = 'center'
+              actionsContainer.style.flexWrap = 'wrap'
+              actionsContainer.style.gap = '8px'
+              actionsContainer.style.justifyContent = 'flex-end'
+              actionsContainer.style.order = '2'
+            }
+          }
+
+          const startObserving = () => {
+            if (!targetDocument.body) {
+              raf(startObserving)
+              return
+            }
+
+            const observer = new targetWindow.MutationObserver(() => {
+              raf(applyInlineLayout)
+            })
+
+            observer.observe(targetDocument.body, { childList: true, subtree: true })
+            raf(applyInlineLayout)
+          }
+
+          ensureStyleElement()
+          startObserving()
         }
 
         const form = document.getElementById('cms-login-form')


### PR DESCRIPTION
## Summary
- add iframe-aware polling and registration so CMS enhancements attach to whichever window exposes Decap
- update the legacy daily schedule styling helper and add a header layout fix so styles apply within the CMS context

## Testing
- Not run (not requested)

## Validation
1. Load https://northsidegta.ca/cms → open DevTools → Network tab → enable “Disable cache” → hard reload the page.
2. Confirm the console logs show “waiting for CMS…” followed by “enhancements ready”.
3. In the parent console run:
   ```js
   Array.from(document.querySelectorAll('iframe')).map(f => ({ src: f.src, hasCMS: !!f.contentWindow?.CMS }))
   ```
   At least one iframe should report `hasCMS: true` (or the enhancements execute in the parent if there is no iframe).
4. Switch the console context to the CMS iframe and run:
   ```js
   !!window.CMS, !!window.React, CMS.getWidget('dailySchedule')
   ```
   Expect `true true` and that `CMS.getWidget('dailySchedule')` returns an object.
5. Open a Community Event entry → toggle **Use daily schedule** → verify the editor renders and saves without errors.
6. Inspect the CMS header at 375 px, 768 px, and ≥1024 px widths to ensure the collection title and Quick Add/actions never overlap.


------
https://chatgpt.com/codex/tasks/task_e_68e4023af76483249534f86b25376995