### PR TITLE
Use Decap React for CMS widgets

### DIFF
--- a/public/cms/index.html
+++ b/public/cms/index.html
@@ -231,7 +231,6 @@
         ]
         const STORAGE_KEYS = ['decap-cms-user', 'netlify-cms-user']
         let __nsEnhancementsReady = false
-        let __nsReactLoading = false
         let __nsEnhancementsResolvers = []
 
         function findDecapContext() {
@@ -244,93 +243,30 @@
 
           for (const w of windows) {
             try {
-              const CMS = w?.CMS || w?.netlifyCMS || w?.decapCMS
+              const CMS = w?.CMS
               if (!CMS || typeof CMS.registerWidget !== 'function') continue
 
-              const ReactCandidate = [
+              const candidates = [
                 w.React,
                 CMS.React,
                 CMS.react,
                 CMS?.imports?.React,
                 CMS?.imports?.react,
-              ].find(Boolean)
+              ].filter(Boolean)
 
-              return { win: w, CMS, React: ReactCandidate || null }
+              for (const R of candidates) {
+                if (
+                  R &&
+                  typeof R.useMemo === 'function' &&
+                  typeof R.createElement === 'function'
+                ) {
+                  return { win: w, CMS, React: R }
+                }
+              }
             } catch (error) {}
           }
 
           return null
-        }
-
-        function registerEnhancements(ctx) {
-          if (__nsEnhancementsReady || !ctx || !ctx.CMS) return
-
-          const { win, CMS } = ctx
-          let React = ctx.React
-
-          const hasHooks = (candidate) =>
-            !!candidate &&
-            typeof candidate.useMemo === 'function' &&
-            typeof candidate.createElement === 'function'
-
-          const finalize = (candidate) => {
-            if (!hasHooks(candidate)) return false
-
-            if (!win.React) win.React = candidate
-
-            registerEventsPreview(CMS, candidate, win)
-            registerDailyScheduleWidget(CMS, candidate, win)
-            activateLegacyFieldStyling(win)
-            applyCmsHeaderLayoutFix(win)
-
-            __nsEnhancementsReady = true
-            __nsEnhancementsResolvers.forEach((resolve) => resolve(true))
-            __nsEnhancementsResolvers = []
-            console.info('[cms-login] enhancements ready')
-            return true
-          }
-
-          if (finalize(React)) {
-            return
-          }
-
-          if (__nsReactLoading) {
-            return
-          }
-          __nsReactLoading = true
-
-          const addScript = (src) =>
-            new Promise((resolve, reject) => {
-              try {
-                const script = win.document.createElement('script')
-                script.src = src
-                script.async = true
-                script.onload = () => resolve()
-                script.onerror = () => reject(new Error('Failed to load ' + src))
-                ;(win.document.head || win.document.documentElement).appendChild(
-                  script,
-                )
-              } catch (error) {
-                reject(error)
-              }
-            })
-
-          ;(async () => {
-            try {
-              await addScript(
-                'https://cdn.jsdelivr.net/npm/react@18.2.0/umd/react.production.min.js',
-              )
-              const resolvedReact = win.React || React || null
-              if (!finalize(resolvedReact)) {
-                console.warn(
-                  '[cms-login] React loaded but hooks not detected; widget not registered.',
-                )
-              }
-            } catch (error) {
-              __nsReactLoading = false
-              console.warn('[cms-login] Failed to load React fallback', error)
-            }
-          })()
         }
 
         function ensureCmsEnhancementsReady() {
@@ -340,49 +276,79 @@
 
           return new Promise((resolve) => {
             __nsEnhancementsResolvers.push(resolve)
-            const ctx = findDecapContext()
-            if (ctx) registerEnhancements(ctx)
           })
         }
 
-        function bootEnhancements() {
-          const started = Date.now()
-          let observer = null
+        ;(function bootstrapCmsEnhancements() {
+          let didRegister = false
 
-          const tryNow = () => {
-            if (__nsEnhancementsReady) {
-              if (observer) {
-                observer.disconnect()
-                observer = null
-              }
-              return
-            }
-            const ctx = findDecapContext()
-            if (ctx && ctx.CMS) {
-              registerEnhancements(ctx)
-            }
-          }
-
-          const tick = () => {
+          function notifyReady() {
             if (__nsEnhancementsReady) return
-            tryNow()
-            if (!__nsEnhancementsReady && Date.now() - started < 6000) {
-              setTimeout(tick, 150)
-            }
+            __nsEnhancementsReady = true
+            const resolvers = __nsEnhancementsResolvers.slice()
+            __nsEnhancementsResolvers = []
+            resolvers.forEach((resolve) => resolve(true))
           }
 
-          tick()
+          function registerIfReady() {
+            if (didRegister) return true
 
-          observer = new MutationObserver(() => tryNow())
-          observer.observe(document.documentElement, {
-            childList: true,
-            subtree: true,
-          })
+            const ctx = findDecapContext()
+            if (!ctx) return false
 
-          window.addEventListener('load', tryNow)
-        }
+            const { win, CMS, React } = ctx
+            if (
+              !React ||
+              typeof React.useMemo !== 'function' ||
+              typeof React.createElement !== 'function'
+            ) {
+              return false
+            }
 
-        bootEnhancements()
+            try {
+              if (!win.React) win.React = React
+            } catch (error) {}
+
+            if (typeof registerDailyScheduleWidget === 'function') {
+              registerDailyScheduleWidget(CMS, React, win)
+            }
+            if (typeof registerEventsPreview === 'function') {
+              registerEventsPreview(CMS, React, win)
+            }
+            if (typeof activateLegacyFieldStyling === 'function') {
+              activateLegacyFieldStyling(win)
+            }
+            if (typeof applyCmsHeaderLayoutFix === 'function') {
+              applyCmsHeaderLayoutFix(win)
+            }
+
+            didRegister = true
+            notifyReady()
+            console.info('[cms-login] enhancements ready (using Decap React)')
+            return true
+          }
+
+          if (registerIfReady()) {
+            return
+          }
+
+          let tries = 0
+          const interval = setInterval(() => {
+            if (tries++ > 60 || registerIfReady()) {
+              clearInterval(interval)
+            }
+          }, 100)
+
+          new MutationObserver(registerIfReady).observe(
+            document.documentElement,
+            {
+              childList: true,
+              subtree: true,
+            },
+          )
+
+          window.addEventListener('load', registerIfReady)
+        })()
 
         function registerEventsPreview(CMS, React) {
           if (!CMS || typeof CMS.registerPreviewTemplate !== 'function') {
@@ -991,7 +957,9 @@
                 lastLoadedSummaryRef.current = summaryKey
                 const dayCount = schedule.length
                 const blockCount = countBlocks(schedule)
-                console.info(`[cms] events dailySchedule loaded: ${dayCount} day(s), ${blockCount} block(s)`)
+                console.debug(
+                  `[cms] events dailySchedule loaded: ${dayCount} day(s), ${blockCount} block(s)`
+                )
               }
               if (!rowsEqual(next, rows)) {
                 setRows(next.length ? next : [createRow()])
@@ -1007,7 +975,9 @@
                 lastSavedSummaryRef.current = scheduleJson
                 const dayCount = sanitizedRows.length
                 const blockCount = countBlocks(sanitizedRows)
-                console.info(`[cms] events dailySchedule saved: ${dayCount} day(s), ${blockCount} block(s)`)
+                console.debug(
+                  `[cms] events dailySchedule saved: ${dayCount} day(s), ${blockCount} block(s)`
+                )
               }
               onChange(toImmutable(sanitizedRows))
             }, [onChange, sanitizedRows])
@@ -1220,7 +1190,7 @@
           try {
             CMS.registerWidget('dailySchedule', DailyScheduleControl)
             dailyScheduleRegisteredWindows.add(targetWindow)
-            console.info('[cms] widget registered: dailySchedule')
+            console.debug('[cms] widget registered: dailySchedule')
           } catch (error) {
             console.error('[cms] failed to register dailySchedule widget', error)
           }


### PR DESCRIPTION
## Summary
- register CMS enhancements only after finding Decap's React context
- remove the CDN React fallback and legacy polling logic from the CMS bootstrap

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e53f2454f08324bc3213e648a4b701