### PR TITLE
Harden CMS manual init sequence

### DIFF
--- a/public/cms/index.html
+++ b/public/cms/index.html
@@ -300,27 +300,45 @@
             const { win, CMS, React } = ctx
 
             try {
-              if (win && !win.React) {
+              if (win && !win.React && React) {
                 win.React = React
               }
             } catch (error) {
               // Ignore assignment errors
             }
 
-            if (typeof registerEventsPreview === 'function') {
-              registerEventsPreview(CMS, React, win)
-            }
-            if (typeof registerDailyScheduleWidget === 'function') {
-              registerDailyScheduleWidget(CMS, React, win)
-            }
-            if (typeof activateLegacyFieldStyling === 'function') {
-              activateLegacyFieldStyling(win)
-            }
-            if (typeof applyCmsHeaderLayoutFix === 'function') {
-              applyCmsHeaderLayoutFix(win)
+            const callSafely = (label, fn) => {
+              if (typeof fn !== 'function') return
+              try {
+                fn()
+              } catch (error) {
+                console.error(`[cms-login] ${label} failed`, error)
+              }
             }
 
+            callSafely('events preview registration', () => {
+              if (typeof registerEventsPreview === 'function') {
+                registerEventsPreview(CMS, React, win)
+              }
+            })
+            callSafely('daily schedule widget registration', () => {
+              if (typeof registerDailyScheduleWidget === 'function') {
+                registerDailyScheduleWidget(CMS, React, win)
+              }
+            })
+            callSafely('legacy field styling activation', () => {
+              if (typeof activateLegacyFieldStyling === 'function') {
+                activateLegacyFieldStyling(win)
+              }
+            })
+            callSafely('CMS header layout fix activation', () => {
+              if (typeof applyCmsHeaderLayoutFix === 'function') {
+                applyCmsHeaderLayoutFix(win)
+              }
+            })
+
             registered = true
+
             if (CMS && typeof CMS.init === 'function') {
               try {
                 if (!win.__nsCmsInitialized) {
@@ -334,6 +352,7 @@
             } else {
               console.warn('[cms-login] CMS.init is not available for manual initialization')
             }
+
             notifyCmsEnhancementsReady()
             console.info('[cms-login] enhancements ready')
             return true


### PR DESCRIPTION
## Summary
- wrap CMS enhancement hooks in safe guards so individual errors do not block initialization
- keep manual CMS.init execution even when custom widget registration raises errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e677a9a1a48324b19bb10b969e86fa