### PR TITLE
Fix Decap daily schedule configuration

### DIFF
--- a/public/cms/config.yml
+++ b/public/cms/config.yml
@@ -149,11 +149,24 @@ collections:
         required: false
         collapsed: false
         summary: "{{date}} — {{ all_day | ternary('All day', (start_time | default(''))) }} {{ end_time | default('') }}"
+        hint: 'Add one row per day with optional start/end times.'
         fields:
           - { name: 'date',       label: 'Date',       widget: 'date',    format: 'YYYY-MM-DD' }
           - { name: 'all_day',    label: 'All day',    widget: 'boolean', required: false, default: false }
-          - { name: 'start_time', label: 'Start',      widget: 'string',  required: false, pattern: ['^\\d{2}:\\d{2}$', 'Use HH:MM (e.g., 09:30)'] }
-          - { name: 'end_time',   label: 'End',        widget: 'string',  required: false, pattern: ['^\\d{2}:\\d{2}$', 'Use HH:MM (e.g., 17:00)'] }
+          - name: 'start_time'
+            label: 'Start time'
+            widget: 'time'
+            required: false
+            format: 'HH:mm'
+            picker_utc: false
+            hint: 'Choose the opening time (24-hour clock).'
+          - name: 'end_time'
+            label: 'End time'
+            widget: 'time'
+            required: false
+            format: 'HH:mm'
+            picker_utc: false
+            hint: 'Choose the closing time (24-hour clock).'
 
       - name: 'recurrence'
         label: 'Recurrence (RRULE)'

--- a/public/config.yml
+++ b/public/config.yml
@@ -132,10 +132,28 @@ collections:
         hint: 'Toggle on to manage per-day hours below. Leave off to fall back to the start/end fields.'
       - name: 'daily_schedule'
         label: 'Daily Schedule'
-        widget: 'dailySchedule'
+        widget: 'list'
         required: false
         collapsed: false
-        hint: 'Add one row per day. Data stays saved even if the toggle is off.'
+        hint: 'Add one row per day with optional start/end times. Data stays saved even if the toggle is off.'
+        summary: "{{date}} — {{ all_day | ternary('All day', (start_time | default(''))) }} {{ end_time | default('') }}"
+        fields:
+          - { name: 'date',       label: 'Date',       widget: 'date',    format: 'YYYY-MM-DD' }
+          - { name: 'all_day',    label: 'All day',    widget: 'boolean', required: false, default: false }
+          - name: 'start_time'
+            label: 'Start time'
+            widget: 'time'
+            required: false
+            format: 'HH:mm'
+            picker_utc: false
+            hint: 'Choose the opening time (24-hour clock).'
+          - name: 'end_time'
+            label: 'End time'
+            widget: 'time'
+            required: false
+            format: 'HH:mm'
+            picker_utc: false
+            hint: 'Choose the closing time (24-hour clock).'
       - name: 'recurrence'
         label: 'Recurrence (RRULE)'
         widget: 'string'


### PR DESCRIPTION
## Summary
- replace the custom daily schedule widget with a Decap list configuration using built-in fields
- switch the start and end time inputs to the core time widget and add guidance for editors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6c8312494832485da3dae8d08e87b