### PR TITLE
Fix CMS login request body parsing

### DIFF
--- a/api/cms-login.js
+++ b/api/cms-login.js
@@ -27,36 +27,77 @@ function validateEnv() {
   return token
 }
 
+function parseJsonString(raw) {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (!trimmed) return {}
+  try {
+    return JSON.parse(trimmed)
+  } catch (error) {
+    throw new Error('Invalid JSON body')
+  }
+}
+
+function parseJsonBuffer(buffer) {
+  if (!buffer || !buffer.length) return {}
+  const raw = buffer.toString('utf8')
+  return parseJsonString(raw)
+}
+
+function tryParseJsonPayload(payload) {
+  if (payload == null) return null
+
+  if (typeof payload === 'string') {
+    return parseJsonString(payload)
+  }
+
+  if (Buffer.isBuffer(payload)) {
+    return parseJsonBuffer(payload)
+  }
+
+  if (ArrayBuffer.isView(payload)) {
+    const view = payload
+    const buffer = Buffer.from(view.buffer, view.byteOffset, view.byteLength)
+    return parseJsonBuffer(buffer)
+  }
+
+  if (payload instanceof ArrayBuffer) {
+    const buffer = Buffer.from(payload)
+    return parseJsonBuffer(buffer)
+  }
+
+  if (typeof payload === 'object') {
+    return payload
+  }
+
+  return null
+}
+
 async function readRequestBody(req) {
-  if (req.body) {
-    if (typeof req.body === 'string') {
-      if (!req.body.trim()) return {}
-      try {
-        return JSON.parse(req.body)
-      } catch (error) {
-        throw new Error('Invalid JSON body')
-      }
-    }
-    if (typeof req.body === 'object') {
-      return req.body
-    }
+  const parsed = tryParseJsonPayload(req.body)
+  if (parsed !== null) {
+    return parsed
   }
 
   const chunks = []
   for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    if (!chunk) continue
+    if (Buffer.isBuffer(chunk)) {
+      chunks.push(chunk)
+    } else if (typeof chunk === 'string') {
+      if (chunk) chunks.push(Buffer.from(chunk))
+    } else if (ArrayBuffer.isView(chunk)) {
+      const view = chunk
+      chunks.push(Buffer.from(view.buffer, view.byteOffset, view.byteLength))
+    } else if (chunk instanceof ArrayBuffer) {
+      chunks.push(Buffer.from(chunk))
+    }
   }
 
   if (!chunks.length) return {}
 
-  const raw = Buffer.concat(chunks).toString('utf8')
-  if (!raw) return {}
-
-  try {
-    return JSON.parse(raw)
-  } catch (error) {
-    throw new Error('Invalid JSON body')
-  }
+  const raw = Buffer.concat(chunks)
+  return parseJsonBuffer(raw)
 }
 
 export default async function handler(req, res) {

--- a/tests/cms-login.test.js
+++ b/tests/cms-login.test.js
@@ -1,0 +1,92 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const USERNAME = 'admin'
+const PASSWORD = 'secret'
+const TOKEN = 'ghp_test_token'
+
+process.env.CMS_LOGIN_USERNAME = USERNAME
+process.env.CMS_LOGIN_PASSWORD = PASSWORD
+process.env.GITHUB_TOKEN = TOKEN
+
+let handlerPromise
+function getHandler() {
+  if (!handlerPromise) {
+    handlerPromise = import('../api/cms-login.js').then((mod) => mod.default)
+  }
+  return handlerPromise
+}
+
+function createReq({ body, method = 'POST', streamChunks } = {}) {
+  return {
+    method,
+    body,
+    async *[Symbol.asyncIterator]() {
+      if (!streamChunks) return
+      for (const chunk of streamChunks) {
+        yield chunk
+      }
+    },
+  }
+}
+
+function createRes() {
+  return {
+    statusCode: 0,
+    headers: {},
+    payload: undefined,
+    setHeader(name, value) {
+      this.headers[name] = value
+    },
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(payload) {
+      this.payload = payload
+      return this
+    },
+  }
+}
+
+async function runHandler(options) {
+  const handler = await getHandler()
+  const req = createReq(options)
+  const res = createRes()
+  await handler(req, res)
+  return res
+}
+
+test('accepts JSON provided as a Buffer body', async () => {
+  const buffer = Buffer.from(JSON.stringify({ username: USERNAME, password: PASSWORD }))
+  const res = await runHandler({ body: buffer })
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.payload.token, TOKEN)
+})
+
+test('accepts JSON provided as a typed array body', async () => {
+  const encoder = new TextEncoder()
+  const typedArray = encoder.encode(JSON.stringify({ username: USERNAME, password: PASSWORD }))
+  const res = await runHandler({ body: typedArray })
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.payload.token, TOKEN)
+})
+
+test('falls back to reading the request stream when body is unset', async () => {
+  const encoder = new TextEncoder()
+  const chunk = encoder.encode(JSON.stringify({ username: USERNAME, password: PASSWORD }))
+  const res = await runHandler({ body: undefined, streamChunks: [chunk] })
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.payload.token, TOKEN)
+})
+
+test('returns a 400 for invalid JSON payloads', async () => {
+  const buffer = Buffer.from('not-json')
+  const res = await runHandler({ body: buffer })
+
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.payload.error, 'Invalid JSON body')
+})


### PR DESCRIPTION
## Summary
- ensure the CMS login API correctly parses buffer and typed array request bodies before validating credentials
- add regression tests that cover buffer, typed array, streamed payloads, and invalid JSON handling for the login endpoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e80e93395483249ed0cf7de1d58c8c