### PR TITLE
Restyle homepage to align with contact design

### DIFF
--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -51,9 +51,12 @@ function ReviewSlider() {
   }, []);
 
   return (
-    <div className="rounded-xl border border-gray-200 shadow-sm bg-gray-50 overflow-hidden max-w-3xl mx-auto">
-      <div className="bg-[#4285F4] h-1" />
-      <div className="relative px-4 sm:px-8 py-6 min-h-[180px] sm:min-h-[150px]">
+    <div className="relative overflow-hidden rounded-3xl bg-white/95 shadow-xl shadow-emerald-100/40 ring-1 ring-slate-100 backdrop-blur">
+      <div
+        className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-emerald-500 via-emerald-400 to-emerald-600"
+        aria-hidden
+      />
+      <div className="relative px-6 py-10 sm:px-12 sm:py-12 min-h-[220px] sm:min-h-[200px]">
         {reviews.map((r, idx) => (
           <div
             key={idx}
@@ -65,20 +68,22 @@ function ReviewSlider() {
               <img
                 src="/Images/google-logo.png"
                 alt="Google"
-                className="h-5 w-5 sm:h-6 sm:w-6 object-contain"
+                className="h-5 w-5 sm:h-6 sm:w-6 object-contain drop-shadow-sm"
               />
-              <span className="font-semibold text-xs sm:text-sm text-gray-700 whitespace-nowrap">
+              <span className="font-semibold text-xs sm:text-sm text-slate-700 whitespace-nowrap">
                 Finally&nbsp;Home&nbsp;Agents
               </span>
-              <div className="flex text-[#FBBC05] text-xs sm:text-sm leading-none">
+              <div className="flex text-amber-400 text-xs sm:text-sm leading-none drop-shadow">
                 {"★★★★★".split("").map((_, s) => (
                   <span key={s}>★</span>
                 ))}
               </div>
             </div>
-            <p className="italic max-w-xs sm:max-w-md text-xs sm:text-sm">{r.quote}</p>
-            <p className="mt-1 sm:mt-2 font-semibold text-xs sm:text-sm">— {r.name}</p>
-            <p className="text-[10px] sm:text-xs text-gray-500">Verified&nbsp;Client&nbsp;Review</p>
+            <p className="max-w-xs text-sm italic text-slate-700 sm:max-w-md sm:text-base">{r.quote}</p>
+            <p className="mt-2 text-xs font-semibold text-slate-900 sm:text-sm">— {r.name}</p>
+            <p className="text-[10px] text-slate-400 sm:text-xs">
+              Verified&nbsp;Client&nbsp;Review
+            </p>
           </div>
         ))}
       </div>
@@ -91,104 +96,156 @@ function ReviewSlider() {
    ──────────────────────────────────────────────────────────── */
 export default function HomePage() {
   return (
-    <div className="bg-white text-gray-900 min-h-screen">
+    <div className="flex min-h-screen flex-col bg-slate-50 text-slate-900">
+      <Helmet>
+        <title>NorthSide GTA | Real Estate Agents for Buyers & Sellers</title>
+        <meta
+          name="description"
+          content="Find your perfect home or sell for more in the NorthSide GTA. Local experts serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
+        />
+        <meta
+          name="keywords"
+          content="NorthSide GTA real estate, homes for sale North GTA, sell my home, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog, Finally Home Agents"
+        />
+        <link rel="canonical" href="https://www.northsidegta.ca/" />
+
+        {/* Open Graph */}
+        <meta
+          property="og:title"
+          content="NorthSide GTA | Real Estate Agents for Buyers & Sellers"
+        />
+        <meta
+          property="og:description"
+          content="Local team helping you buy and sell in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://www.northsidegta.ca/" />
+        <meta
+          property="og:image"
+          content="https://www.northsidegta.ca/Images/og-home.jpg"
+        />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta
+          property="og:image:alt"
+          content="NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog"
+        />
+
+        {/* Twitter Cards */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content="NorthSide GTA | Real Estate Agents for Buyers & Sellers"
+        />
+        <meta
+          name="twitter:description"
+          content="Find your perfect home or sell for more in the NorthSide GTA with expert agents."
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.northsidegta.ca/Images/og-home.jpg"
+        />
+
+        {/* JSON-LD: Organization + Website */}
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "RealEstateAgent",
+            name: "Finally Home Agents",
+            url: "https://www.northsidegta.ca/",
+            areaServed: [
+              "Georgina",
+              "East Gwillimbury",
+              "Newmarket",
+              "Aurora",
+              "Whitchurch-Stouffville",
+              "Uxbridge",
+              "Scugog",
+            ],
+            sameAs: [
+              "https://instagram.com/finallyhomeagents",
+              "https://facebook.com/finallyhomeagents",
+            ],
+          })}
+        </script>
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            name: "NorthSide GTA",
+            url: "https://www.northsidegta.ca/",
+            potentialAction: {
+              "@type": "SearchAction",
+              target: "https://www.northsidegta.ca/search?q={query}",
+              "query-input": "required name=query",
+            },
+          })}
+        </script>
+      </Helmet>
+
       {/* Navigation */}
       <Navigation />
-<Helmet>
-  <title>NorthSide GTA | Real Estate Agents for Buyers & Sellers</title>
-  <meta
-    name="description"
-    content="Find your perfect home or sell for more in the NorthSide GTA. Local experts serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
-  />
-  <meta
-    name="keywords"
-    content="NorthSide GTA real estate, homes for sale North GTA, sell my home, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog, Finally Home Agents"
-  />
-  <link rel="canonical" href="https://www.northsidegta.ca/" />
 
-  {/* Open Graph */}
-  <meta property="og:title" content="NorthSide GTA | Real Estate Agents for Buyers & Sellers" />
-  <meta property="og:description" content="Local team helping you buy and sell in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.northsidegta.ca/" />
-  <meta property="og:image" content="https://www.northsidegta.ca/Images/og-home.jpg" />
-  <meta property="og:image:width" content="1200" />
-  <meta property="og:image:height" content="630" />
-  <meta property="og:image:alt" content="NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog" />
+      <main className="flex-1">
+        {/* Map-first Hero */}
+        <section className="relative isolate overflow-hidden">
+          <div
+            className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-white via-emerald-50/40 to-transparent"
+            aria-hidden
+          />
+          <MapHero />
+        </section>
 
-  {/* Twitter Cards */}
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="NorthSide GTA | Real Estate Agents for Buyers & Sellers" />
-  <meta name="twitter:description" content="Find your perfect home or sell for more in the NorthSide GTA with expert agents." />
-  <meta name="twitter:image" content="https://www.northsidegta.ca/Images/og-home.jpg" />
+        {/* Town Strip */}
+        <section className="relative z-10 mx-auto -mt-10 max-w-6xl px-4">
+          <div className="rounded-3xl bg-white/90 p-4 shadow-xl shadow-emerald-100/40 ring-1 ring-emerald-100/70 backdrop-blur">
+            <TownStrip />
+          </div>
+        </section>
 
-  {/* JSON-LD: Organization + Website */}
-  <script type="application/ld+json">
-    {JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "RealEstateAgent",
-      name: "Finally Home Agents",
-      url: "https://www.northsidegta.ca/",
-      areaServed: [
-        "Georgina",
-        "East Gwillimbury",
-        "Newmarket",
-        "Aurora",
-        "Whitchurch-Stouffville",
-        "Uxbridge",
-        "Scugog"
-      ],
-      sameAs: [
-        "https://instagram.com/finallyhomeagents",
-        "https://facebook.com/finallyhomeagents"
-      ]
-    })}
-  </script>
-  <script type="application/ld+json">
-    {JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "WebSite",
-      name: "NorthSide GTA",
-      url: "https://www.northsidegta.ca/",
-      potentialAction: {
-        "@type": "SearchAction",
-        target: "https://www.northsidegta.ca/search?q={query}",
-        "query-input": "required name=query"
-      }
-    })}
-  </script>
-</Helmet>
+        {/* Google Review Slider */}
+        <section className="relative mt-20 px-4">
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-600">
+              What clients are saying
+            </p>
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+              Google reviews from NorthSide GTA buyers & sellers
+            </h2>
+            <p className="mt-4 text-base text-slate-600">
+              Genuine feedback shared by families we’ve helped move north of the city.
+            </p>
+          </div>
+          <div className="mx-auto mt-10 max-w-4xl">
+            <ReviewSlider />
+          </div>
+        </section>
 
-      {/* Map-first Hero */}
-      <MapHero />
-
-  
-
-      {/* Town Strip */}
-      <section className="mx-auto max-w-6xl px-4 mt-6 md:mt-8">
-        <TownStrip />
-      </section>
-
-      {/* Google Review Slider */}
-      <section className="py-16 px-4 text-center">
-        <ReviewSlider />
-      </section>
-
-      {/* CTA Section */}
-      <section className="bg-green-700 text-white py-16 px-4 text-center">
-        <h2 className="text-3xl md:text-5xl font-bold mb-4">
-          Ready to Explore the NorthSide GTA?
-        </h2>
-        <p className="text-lg md:text-xl max-w-xl mx-auto mb-6">
-          Let us help you find your perfect town and home.
-        </p>
-        <a
-          href="/homeanalysis"
-          className="inline-block bg-white text-green-700 font-semibold py-2 px-6 rounded hover:bg-gray-200 transition"
-        >
-          Get Your Home Analysis
-        </a>
-      </section>
+        {/* CTA Section */}
+        <section className="relative mt-24 px-4">
+          <div className="relative isolate overflow-hidden rounded-3xl bg-gradient-to-r from-emerald-600 via-emerald-500 to-emerald-600 px-6 py-16 shadow-2xl sm:px-12">
+            <div className="absolute -top-24 -right-12 h-56 w-56 rounded-full bg-emerald-400/30 blur-3xl" aria-hidden />
+            <div className="absolute -bottom-24 -left-12 h-56 w-56 rounded-full bg-teal-400/30 blur-3xl" aria-hidden />
+            <div className="relative mx-auto max-w-3xl text-center text-white">
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-100">
+                Ready when you are
+              </p>
+              <h2 className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
+                Ready to explore the NorthSide GTA?
+              </h2>
+              <p className="mt-4 text-lg text-emerald-50/90">
+                Let us help you compare towns, understand pricing, and line up the perfect move.
+              </p>
+              <a
+                href="/homeanalysis"
+                className="mt-8 inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-emerald-700 shadow-lg shadow-emerald-900/20 transition hover:-translate-y-0.5 hover:bg-emerald-50"
+              >
+                Get Your Home Analysis
+              </a>
+            </div>
+          </div>
+        </section>
+      </main>
 
       {/* Footer */}
       <Footer />


### PR DESCRIPTION
## Summary
- restyled the homepage shell with slate background gradients and spacing to match the contact page aesthetic
- refreshed the Google review slider and CTA styling to reuse the contact page’s emerald palette while preserving existing content
- wrapped the town strip carousel in a frosted card container to keep layout consistent with the new design language

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e927f0422c832499c2e8092d4430f3