### PR TITLE
Revamp homepage styling to mirror contact page aesthetic

### DIFF
--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -1,196 +1,174 @@
+
 // src/HomePage.js
-import React, { useEffect, useState } from "react";
+import React, { useMemo } from "react";
 import { Helmet } from "react-helmet-async";
 import Navigation from "./Navigation";
 import MapHero from "./MapHero";
 import TownStrip from "./TownStrip";
-import QuickContactCard from "./QuickContactCard";
 import Footer from "./Footer";
+import ReviewsCarousel from "./components/contact/ReviewsCarousel";
+import { CANONICAL_TESTIMONIALS } from "./data/testimonials";
 
-/* ────────────────────────────────────────────────────────────
-   Google-style rotating review slider
-   ──────────────────────────────────────────────────────────── */
-function ReviewSlider() {
-  const reviews = [
-    {
-      name: "Susan Booth",
-      quote:
-        "“Finally Home Agents exceeded our expectations when selling our home in Holland Landing. Their professionalism and personal attention set them apart.”",
-    },
-    {
-      name: "Logan Abernethy",
-      quote:
-        "“As a first-time buyer I had plenty of questions. Landon was patient and made my experience fantastic.”",
-    },
-    {
-      name: "Jessica Le",
-      quote:
-        "“Landon made renting stress-free. Really nice to work with and very easy to communicate with.”",
-    },
-    {
-      name: "Tessa Conway",
-      quote:
-        "“Landon took all the stress out of renting in a brand-new city — I am forever thankful!”",
-    },
-    {
-      name: "Olivia Oprea",
-      quote:
-        "“Matthew found me my dream home during a crazy market. Wouldn’t have got it without him.”",
-    },
-    {
-      name: "Arron Breen",
-      quote:
-        "“Matt sold our house above market and negotiated our forever home for less. Highly recommend.”",
-    },
-  ];
-
-  const [i, setI] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => setI((x) => (x + 1) % reviews.length), 6000);
-    return () => clearInterval(id);
-  }, []);
+export default function HomePage() {
+  const reviews = useMemo(
+    () =>
+      CANONICAL_TESTIMONIALS.map((review) => ({
+        id: review.id,
+        name: review.shortName || review.name,
+        rating: review.rating || 5,
+        quote: review.quote,
+        date: review.date,
+      })),
+    []
+  );
 
   return (
-    <div className="rounded-xl border border-gray-200 shadow-sm bg-gray-50 overflow-hidden max-w-3xl mx-auto">
-      <div className="bg-[#4285F4] h-1" />
-      <div className="relative px-4 sm:px-8 py-6 min-h-[180px] sm:min-h-[150px]">
-        {reviews.map((r, idx) => (
-          <div
-            key={idx}
-            className={`absolute inset-0 flex flex-col items-center justify-center text-center transition-opacity duration-700 ${
-              idx === i ? "opacity-100" : "opacity-0"
-            }`}
-          >
-            <div className="flex flex-wrap items-center justify-center gap-2 mb-2">
-              <img
-                src="/Images/google-logo.png"
-                alt="Google"
-                className="h-5 w-5 sm:h-6 sm:w-6 object-contain"
+    <div className="min-h-screen bg-slate-50 text-slate-900">
+      <Navigation />
+      <Helmet>
+        <title>NorthSide GTA | Real Estate Agents for Buyers & Sellers</title>
+        <meta
+          name="description"
+          content="Find your perfect home or sell for more in the NorthSide GTA. Local experts serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
+        />
+        <meta
+          name="keywords"
+          content="NorthSide GTA real estate, homes for sale North GTA, sell my home, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog, Finally Home Agents"
+        />
+        <link rel="canonical" href="https://www.northsidegta.ca/" />
+
+        <meta property="og:title" content="NorthSide GTA | Real Estate Agents for Buyers & Sellers" />
+        <meta
+          property="og:description"
+          content="Local team helping you buy and sell in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://www.northsidegta.ca/" />
+        <meta property="og:image" content="https://www.northsidegta.ca/Images/og-home.jpg" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta
+          property="og:image:alt"
+          content="NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog"
+        />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="NorthSide GTA | Real Estate Agents for Buyers & Sellers" />
+        <meta
+          name="twitter:description"
+          content="Find your perfect home or sell for more in the NorthSide GTA with expert agents."
+        />
+        <meta name="twitter:image" content="https://www.northsidegta.ca/Images/og-home.jpg" />
+
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "RealEstateAgent",
+            name: "Finally Home Agents",
+            url: "https://www.northsidegta.ca/",
+            areaServed: [
+              "Georgina",
+              "East Gwillimbury",
+              "Newmarket",
+              "Aurora",
+              "Whitchurch-Stouffville",
+              "Uxbridge",
+              "Scugog",
+            ],
+            sameAs: [
+              "https://instagram.com/finallyhomeagents",
+              "https://facebook.com/finallyhomeagents",
+            ],
+          })}
+        </script>
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            name: "NorthSide GTA",
+            url: "https://www.northsidegta.ca/",
+            potentialAction: {
+              "@type": "SearchAction",
+              target: "https://www.northsidegta.ca/search?q={query}",
+              "query-input": "required name=query",
+            },
+          })}
+        </script>
+      </Helmet>
+
+      <main>
+        <MapHero />
+
+        <section className="relative z-10 mx-auto -mt-6 max-w-6xl px-4 sm:-mt-10 lg:-mt-16">
+          <div className="rounded-[32px] border border-white/70 bg-white/95 p-5 shadow-xl shadow-emerald-900/5 backdrop-blur sm:p-8">
+            <TownStrip />
+          </div>
+        </section>
+
+        <section className="mx-auto mt-16 max-w-5xl px-4 text-center">
+          <div className="space-y-3">
+            <span className="inline-flex items-center justify-center gap-2 rounded-full bg-emerald-100/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-emerald-700">
+              What clients are saying
+            </span>
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+              Google reviews from NorthSide GTA movers
+            </h2>
+            <p className="text-sm text-slate-600 sm:text-base">
+              Real feedback from families upgrading their lifestyle north of Toronto.
+            </p>
+          </div>
+          <div className="mt-8">
+            <ReviewsCarousel reviews={reviews} disclaimer="Real reviews from real clients." />
+          </div>
+        </section>
+
+        <section className="relative mt-20 px-4">
+          <div className="mx-auto max-w-6xl">
+            <div className="relative overflow-hidden rounded-[44px] border border-emerald-100/60 bg-emerald-950 text-white shadow-2xl">
+              <div
+                className="absolute inset-0 bg-gradient-to-br from-emerald-950 via-emerald-900 to-emerald-700 opacity-95"
+                aria-hidden
               />
-              <span className="font-semibold text-xs sm:text-sm text-gray-700 whitespace-nowrap">
-                Finally&nbsp;Home&nbsp;Agents
-              </span>
-              <div className="flex text-[#FBBC05] text-xs sm:text-sm leading-none">
-                {"★★★★★".split("").map((_, s) => (
-                  <span key={s}>★</span>
-                ))}
+              <div
+                className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.4),_transparent_60%)]"
+                aria-hidden
+              />
+              <div className="pointer-events-none absolute -top-24 right-[-18%] h-64 w-64 rounded-full bg-emerald-400/20 blur-3xl" aria-hidden />
+              <div className="pointer-events-none absolute bottom-[-30%] left-[-12%] h-72 w-72 rounded-full bg-emerald-300/25 blur-3xl" aria-hidden />
+
+              <div className="relative px-6 py-12 sm:px-10 sm:py-14 lg:flex lg:items-center lg:justify-between lg:gap-10">
+                <div className="max-w-2xl text-center lg:text-left">
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.32em] text-emerald-100">
+                    Ready when you are
+                  </span>
+                  <h2 className="mt-5 text-3xl font-semibold tracking-tight sm:text-4xl">
+                    Ready to explore the NorthSide GTA?
+                  </h2>
+                  <p className="mt-4 text-sm text-emerald-100/90 sm:text-base">
+                    Compare towns, understand commute times, and uncover the neighbourhoods that fit your lifestyle with Finally Home Agents.
+                  </p>
+                </div>
+
+                <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row lg:mt-0 lg:items-center">
+                  <a
+                    href="/homeanalysis"
+                    className="inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 text-base font-semibold text-emerald-700 shadow-lg shadow-emerald-900/30 transition hover:bg-emerald-50"
+                  >
+                    Get Your Home Analysis
+                  </a>
+                  <a
+                    href="/contact"
+                    className="inline-flex items-center justify-center rounded-2xl border border-white/40 bg-white/10 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-white/20"
+                  >
+                    Talk to the team
+                  </a>
+                </div>
               </div>
             </div>
-            <p className="italic max-w-xs sm:max-w-md text-xs sm:text-sm">{r.quote}</p>
-            <p className="mt-1 sm:mt-2 font-semibold text-xs sm:text-sm">— {r.name}</p>
-            <p className="text-[10px] sm:text-xs text-gray-500">Verified&nbsp;Client&nbsp;Review</p>
           </div>
-        ))}
-      </div>
-    </div>
-  );
-}
+        </section>
+      </main>
 
-/* ────────────────────────────────────────────────────────────
-   Page
-   ──────────────────────────────────────────────────────────── */
-export default function HomePage() {
-  return (
-    <div className="bg-white text-gray-900 min-h-screen">
-      {/* Navigation */}
-      <Navigation />
-<Helmet>
-  <title>NorthSide GTA | Real Estate Agents for Buyers & Sellers</title>
-  <meta
-    name="description"
-    content="Find your perfect home or sell for more in the NorthSide GTA. Local experts serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
-  />
-  <meta
-    name="keywords"
-    content="NorthSide GTA real estate, homes for sale North GTA, sell my home, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog, Finally Home Agents"
-  />
-  <link rel="canonical" href="https://www.northsidegta.ca/" />
-
-  {/* Open Graph */}
-  <meta property="og:title" content="NorthSide GTA | Real Estate Agents for Buyers & Sellers" />
-  <meta property="og:description" content="Local team helping you buy and sell in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.northsidegta.ca/" />
-  <meta property="og:image" content="https://www.northsidegta.ca/Images/og-home.jpg" />
-  <meta property="og:image:width" content="1200" />
-  <meta property="og:image:height" content="630" />
-  <meta property="og:image:alt" content="NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog" />
-
-  {/* Twitter Cards */}
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="NorthSide GTA | Real Estate Agents for Buyers & Sellers" />
-  <meta name="twitter:description" content="Find your perfect home or sell for more in the NorthSide GTA with expert agents." />
-  <meta name="twitter:image" content="https://www.northsidegta.ca/Images/og-home.jpg" />
-
-  {/* JSON-LD: Organization + Website */}
-  <script type="application/ld+json">
-    {JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "RealEstateAgent",
-      name: "Finally Home Agents",
-      url: "https://www.northsidegta.ca/",
-      areaServed: [
-        "Georgina",
-        "East Gwillimbury",
-        "Newmarket",
-        "Aurora",
-        "Whitchurch-Stouffville",
-        "Uxbridge",
-        "Scugog"
-      ],
-      sameAs: [
-        "https://instagram.com/finallyhomeagents",
-        "https://facebook.com/finallyhomeagents"
-      ]
-    })}
-  </script>
-  <script type="application/ld+json">
-    {JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "WebSite",
-      name: "NorthSide GTA",
-      url: "https://www.northsidegta.ca/",
-      potentialAction: {
-        "@type": "SearchAction",
-        target: "https://www.northsidegta.ca/search?q={query}",
-        "query-input": "required name=query"
-      }
-    })}
-  </script>
-</Helmet>
-
-      {/* Map-first Hero */}
-      <MapHero />
-
-  
-
-      {/* Town Strip */}
-      <section className="mx-auto max-w-6xl px-4 mt-6 md:mt-8">
-        <TownStrip />
-      </section>
-
-      {/* Google Review Slider */}
-      <section className="py-16 px-4 text-center">
-        <ReviewSlider />
-      </section>
-
-      {/* CTA Section */}
-      <section className="bg-green-700 text-white py-16 px-4 text-center">
-        <h2 className="text-3xl md:text-5xl font-bold mb-4">
-          Ready to Explore the NorthSide GTA?
-        </h2>
-        <p className="text-lg md:text-xl max-w-xl mx-auto mb-6">
-          Let us help you find your perfect town and home.
-        </p>
-        <a
-          href="/homeanalysis"
-          className="inline-block bg-white text-green-700 font-semibold py-2 px-6 rounded hover:bg-gray-200 transition"
-        >
-          Get Your Home Analysis
-        </a>
-      </section>
-
-      {/* Footer */}
       <Footer />
     </div>
   );

--- a/src/MapHero.js
+++ b/src/MapHero.js
@@ -182,10 +182,6 @@ const Styles = () => (
     border-radius: 16px;
     box-shadow: 0 12px 28px rgba(2,44,34,.18);
   }
-  @keyframes ns-progress {
-    from { transform: scaleX(0); }
-    to   { transform: scaleX(1); }
-  }
   `}</style>
 );
 
@@ -232,20 +228,6 @@ function IconBase({ children, className = "" }) {
     </svg>
   );
 }
-function XIcon({ className = "" }) {
-  return (
-    <IconBase className={className}>
-      <path d="M6 6l12 12M18 6L6 18" />
-    </IconBase>
-  );
-}
-function CheckIcon({ className = "" }) {
-  return (
-    <IconBase className={className}>
-      <path d="M20 6L9 17l-5-5" />
-    </IconBase>
-  );
-}
 function TripleChevronIcon({ className = "" }) {
   return (
     <IconBase className={className}>
@@ -255,9 +237,9 @@ function TripleChevronIcon({ className = "" }) {
 }
 
 /* ────────────────────────────────────────────────────────────
-   LED-inspired matchup scoreboard overlay
+   Compact matchup badge (floats over the map)
    ──────────────────────────────────────────────────────────── */
-function ComparisonBar({ className = "" }) {
+function ComparisonBadge({ className = "" }) {
   const items = [
     { left: "HIGH HOME PRICES", right: "BETTER VALUE HOMES" },
     { left: "TRAFFIC GRIDLOCK", right: "EASIER COMMUTES" },
@@ -274,101 +256,43 @@ function ComparisonBar({ className = "" }) {
   const cur = items[i];
 
   return (
-    <div className={`pointer-events-none w-full ${className}`}>
-      <div
-        className="pointer-events-auto relative w-full overflow-hidden rounded-2xl border border-emerald-400/60 shadow-[0_22px_48px_-24px_rgba(16,185,129,0.85)] backdrop-blur-md"
-        style={{
-          background:
-            "linear-gradient(140deg, rgba(7,16,21,0.88) 0%, rgba(6,56,41,0.92) 45%, rgba(6,78,59,0.9) 100%)",
-        }}
-      >
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(74,222,128,0.18),transparent_65%)]" />
-        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.08)_0%,rgba(255,255,255,0)_55%,rgba(15,118,110,0.25)_100%)] mix-blend-screen opacity-80" />
+    <div className={`pointer-events-none ${className}`} aria-live="polite">
+      <div className="pointer-events-auto inline-flex min-w-[240px] max-w-[320px] flex-col gap-1 rounded-2xl border border-emerald-300/40 bg-emerald-950/80 px-4 py-3 text-white shadow-lg shadow-emerald-900/40 backdrop-blur">
+        <div className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-[0.32em] text-emerald-200">
+          <span className="inline-flex items-center gap-2">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-300" aria-hidden />
+            Live Matchup
+          </span>
+          <span className="flex items-center gap-1 text-[9px] tracking-[0.4em] text-emerald-200/70">
+            FHA
+            <TripleChevronIcon className="h-3.5 w-3.5 text-emerald-200/70" />
+          </span>
+        </div>
 
-        <div className="relative">
-          <div className="flex items-center justify-between border-b border-white/10 px-4 py-2 md:px-6">
-            <div className="flex items-center gap-2">
-              <div className="flex h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-300" />
-              <span className="text-[10px] font-semibold uppercase tracking-[0.32em] text-emerald-100/90">
-                Live Matchup
-              </span>
-            </div>
-            <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.24em] text-emerald-100/70">
-              <span>FHA</span>
-              <TripleChevronIcon className="h-4 w-4 text-emerald-200/60" />
-            </div>
-          </div>
+        <div className="flex items-center justify-between gap-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-100">
+          <span className="inline-flex items-center gap-2 text-rose-100/90">
+            <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-rose-500/80 text-[10px] font-bold tracking-[0.28em] text-white shadow-inner shadow-black/30">
+              TOR
+            </span>
+            Toronto
+          </span>
+          <span className="text-[9px] font-semibold tracking-[0.5em] text-emerald-200/80">vs</span>
+          <span className="inline-flex items-center gap-2">
+            <span className="flex h-6 w-6 items-center justify-center rounded-full border border-emerald-300/60 bg-emerald-500/20 p-1">
+              <img
+                src="/Images/northsidegta-logo.svg"
+                alt="NorthSide GTA logo"
+                className="h-full w-auto"
+                loading="lazy"
+              />
+            </span>
+            NorthSide
+          </span>
+        </div>
 
-          <div className="flex items-center justify-between px-4 py-3 md:px-6">
-            <div className="flex items-center gap-3">
-              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-rose-600/80 text-[11px] font-bold uppercase tracking-[0.24em] text-white shadow-[inset_0_0_12px_rgba(248,113,113,0.45)]">
-                TOR
-              </span>
-              <div className="leading-tight">
-                <span className="block text-[10px] uppercase tracking-[0.32em] text-white/45">
-                  City
-                </span>
-                <span className="block text-sm font-semibold uppercase tracking-wide text-white">
-                  Toronto Living
-                </span>
-              </div>
-            </div>
-
-            <div className="flex flex-col items-center justify-center px-2 text-emerald-200/80">
-              <span className="text-[10px] uppercase tracking-[0.48em]">vs</span>
-              <span className="mt-1 h-1 w-6 rounded-full bg-emerald-300/80" />
-            </div>
-
-            <div className="flex items-center gap-3 text-right">
-              <div className="leading-tight">
-                <span className="block text-[10px] uppercase tracking-[0.32em] text-emerald-100/70">
-                  Region
-                </span>
-                <span className="block text-sm font-bold uppercase tracking-wide text-emerald-50">
-                  NorthSide GTA
-                </span>
-              </div>
-              <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-emerald-300/60 bg-emerald-500/30 p-1 shadow-[inset_0_0_14px_rgba(16,185,129,0.45)]">
-                <img
-                  src="/Images/northsidegta-logo.svg"
-                  alt="NorthSide GTA logo"
-                  className="h-full w-auto"
-                  loading="lazy"
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 border-t border-white/10 text-[12px] uppercase tracking-wide">
-            <div className="flex items-center gap-3 px-4 py-3 md:px-6">
-              <span className="flex h-7 w-7 items-center justify-center rounded-full border border-rose-300/60 bg-rose-500/25">
-                <XIcon className="h-4 w-4 text-rose-200" />
-              </span>
-              <p className="text-[11px] md:text-[12px] font-semibold leading-tight text-white/80">
-                {cur.left}
-              </p>
-            </div>
-            <div className="flex items-center justify-end gap-3 px-4 py-3 text-right md:px-6">
-              <p className="text-[11px] md:text-[12px] font-bold leading-tight text-emerald-100">
-                {cur.right}
-              </p>
-              <span className="flex h-7 w-7 items-center justify-center rounded-full border border-emerald-200/70 bg-emerald-500/30">
-                <CheckIcon className="h-4 w-4 text-emerald-100" />
-              </span>
-            </div>
-          </div>
-
-          <div className="relative h-1.5 overflow-hidden border-t border-white/5 bg-white/10">
-            <div
-              className="absolute inset-0 origin-left"
-              style={{
-                background:
-                  "linear-gradient(90deg, rgba(255,255,255,0.15) 0%, rgba(255,255,255,0.75) 50%, rgba(255,255,255,0.15) 100%)",
-                animation: "ns-progress 4s linear infinite",
-              }}
-            />
-            <div className="absolute inset-x-0 bottom-0 h-[1px] bg-emerald-200/30" />
-          </div>
+        <div className="flex flex-col gap-1 text-[10px] font-semibold uppercase tracking-[0.28em]">
+          <span className="text-rose-200/85">{cur.left}</span>
+          <span className="text-emerald-100">{cur.right}</span>
         </div>
       </div>
     </div>
@@ -412,15 +336,39 @@ export default function MapHero() {
   }, [canHover]);
 
   return (
-    <section className="bg-gradient-to-b from-white to-emerald-50/40">
-      <div className="mx-auto max-w-6xl px-4 pt-8">
+    <section className="relative overflow-hidden text-white">
+      <div className="absolute inset-0 bg-[#06110d]" aria-hidden />
+      <div
+        className="absolute inset-0 bg-gradient-to-br from-emerald-950 via-emerald-900 to-emerald-700"
+        aria-hidden
+      />
+      <div
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.32),_transparent_62%)]"
+        aria-hidden
+      />
+      <div className="pointer-events-none absolute -top-24 left-[-12%] h-[22rem] w-[22rem] rounded-full bg-emerald-400/20 blur-3xl" aria-hidden />
+      <div className="pointer-events-none absolute bottom-[-30%] right-[-10%] h-[28rem] w-[28rem] rounded-full bg-emerald-300/20 blur-3xl" aria-hidden />
+
+      <div className="relative mx-auto max-w-6xl px-4 pb-16 pt-14 sm:pt-16">
+        <div className="text-center lg:text-left">
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.35em] text-emerald-100">
+            NorthsideGTA.ca
+          </div>
+          <h1 className="mt-6 text-3xl font-semibold tracking-tight text-white sm:text-4xl md:text-[2.65rem]">
+            Explore every NorthSide GTA town at a glance.
+          </h1>
+          <p className="mt-4 max-w-3xl text-sm text-emerald-100/90 sm:text-base md:text-lg">
+            Hover or tap the map to compare communities, then start your personalized match with Finally Home Agents.
+          </p>
+        </div>
+
         {/* Bordered hero box (map + inline quick-contact) */}
-        <div className="relative mx-auto mt-4 rounded-2xl bg-white/70 p-3 shadow-sm border">
+        <div className="relative mx-auto mt-10 rounded-[28px] border border-white/15 bg-white/90 p-4 text-gray-900 shadow-2xl shadow-emerald-950/40 backdrop-blur lg:mt-12">
           <Styles />
 
           {/* Map frame */}
           <div
-            className="relative rounded-xl overflow-hidden"
+            className="relative overflow-hidden rounded-2xl"
             onMouseLeave={() => canHover && setHoverId(null)}
           >
             {/* Keep natural aspect ratio so pin percentages line up EXACTLY */}
@@ -429,6 +377,8 @@ export default function MapHero() {
               alt="NorthSide GTA map with towns"
               className="block w-full h-auto"
             />
+
+            <ComparisonBadge className="absolute left-3 top-3 sm:left-4 sm:top-4" />
 
             {/* Pins */}
             {TOWNS.map((t) => (
@@ -506,8 +456,6 @@ export default function MapHero() {
             )}
           </div>
 
-          <ComparisonBar className="mt-4 lg:mt-5" />
-
           {/* MOBILE: panel below the map when a pin is tapped */}
           {!canHover && activeTown && (
             <div className="mt-3 panel p-4">
@@ -566,7 +514,7 @@ export default function MapHero() {
           )}
 
           {/* Divider + Inline Quick Contact (unchanged) */}
-          <div className="mt-4 md:mt-5 border-t border-emerald-100 pt-4 md:pt-5">
+          <div className="mt-6 border-t border-emerald-100/60 pt-5 md:mt-8 md:pt-6">
             <QuickContactCard
               heading="Find Where You Truly Belong in the NorthSide GTA"
               subheading="Finally Home Agents will guide you beyond the listings — helping you compare communities and uncover the right fit."

--- a/src/QuickContactCard.js
+++ b/src/QuickContactCard.js
@@ -1,3 +1,4 @@
+
 // src/QuickContactCard.js
 import React, { useMemo, useState } from "react";
 import { FaWhatsapp } from "react-icons/fa";
@@ -16,10 +17,7 @@ const WHATSAPP_NUMBER_E164 = "16476684646"; // no '+' for wa.me
 const WHATSAPP_BASE = `https://wa.me/${WHATSAPP_NUMBER_E164}`;
 
 export default function QuickContactCard({ formspreeId = "xanbzajw" }) {
-  // collapsed/expanded
   const [open, setOpen] = useState(false);
-
-  // form state
   const [name, setName] = useState("");
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
@@ -38,10 +36,10 @@ export default function QuickContactCard({ formspreeId = "xanbzajw" }) {
 
   const canSubmit = emailValid && towns.length > 0 && notUnderContract && !submitting;
 
-  const toggleTown = (t) => {
+  const toggleTown = (town) => {
     setTowns((prev) => {
-      const exists = prev.includes(t);
-      const next = exists ? prev.filter((x) => x !== t) : [...prev, t];
+      const exists = prev.includes(town);
+      const next = exists ? prev.filter((item) => item !== town) : [...prev, town];
       setAllChecked(next.length === TOWNS.length);
       return next;
     });
@@ -64,6 +62,7 @@ export default function QuickContactCard({ formspreeId = "xanbzajw" }) {
       setErr("Please complete the required fields.");
       return;
     }
+
     setSubmitting(true);
     try {
       const payload = new FormData();
@@ -74,11 +73,10 @@ export default function QuickContactCard({ formspreeId = "xanbzajw" }) {
       payload.append("contactPreference", pref);
       payload.append("notUnderContract", notUnderContract ? "Yes" : "No");
 
-      // Pass basic UTM through if present
       const params = new URLSearchParams(window.location.search);
-      ["utm_source", "utm_medium", "utm_campaign", "utm_content"].forEach((k) => {
-        const v = params.get(k);
-        if (v) payload.append(k, v);
+      ["utm_source", "utm_medium", "utm_campaign", "utm_content"].forEach((key) => {
+        const value = params.get(key);
+        if (value) payload.append(key, value);
       });
 
       const res = await fetch(`https://formspree.io/f/${formspreeId}`, {
@@ -89,7 +87,7 @@ export default function QuickContactCard({ formspreeId = "xanbzajw" }) {
 
       if (!res.ok) throw new Error("Network error");
       setDone(true);
-    } catch (e2) {
+    } catch (error) {
       setErr("Something went wrong. Please try again.");
     } finally {
       setSubmitting(false);
@@ -103,27 +101,41 @@ export default function QuickContactCard({ formspreeId = "xanbzajw" }) {
     return `${WHATSAPP_BASE}?text=${encodeURIComponent(msg)}`;
   }, [towns]);
 
+  const baseInputClass =
+    "mt-1 w-full rounded-2xl border border-emerald-200/70 bg-white px-3 py-2.5 text-sm text-slate-900 shadow-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60";
+  const chipBaseClass =
+    "rounded-full border border-emerald-200/70 bg-white/90 px-4 py-2 text-sm font-medium text-emerald-700 shadow-sm transition hover:border-emerald-300 hover:bg-emerald-50";
+  const chipActiveClass =
+    "border-transparent bg-gradient-to-r from-emerald-600 to-emerald-500 text-white shadow-lg shadow-emerald-900/20 hover:from-emerald-500 hover:to-emerald-400";
+
   if (done) {
     return (
-      <div className="rounded-2xl border border-emerald-200 bg-emerald-50/70 shadow-sm p-5 md:p-6">
-        <h3 className="text-xl font-semibold">Thanks — you’re one step closer.</h3>
-        <p className="mt-1 text-gray-700">
-          We’ll send hand-picked insights for{" "}
-          <span className="font-medium">
-            {towns.length ? towns.join(", ") : "the NorthSide GTA"}
-          </span>{" "}
-          to <span className="font-medium">{email}</span>. For the fastest reply, message us on
-          WhatsApp.
-        </p>
-        <a
-          href={whatsappHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 mt-4 px-4 py-2 rounded-lg border-2 border-emerald-300 text-emerald-700 bg-white hover:border-emerald-400 hover:bg-emerald-50 transition font-semibold"
-        >
-          <FaWhatsapp className="h-5 w-5" style={{ color: "#25D366" }} />
-          Continue on WhatsApp
-        </a>
+      <div className="relative overflow-hidden rounded-3xl border border-emerald-100/70 bg-white/95 p-6 text-slate-900 shadow-xl shadow-emerald-900/10 ring-1 ring-emerald-100/60">
+        <div
+          className="pointer-events-none absolute inset-x-10 top-0 h-[2px] bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600"
+          aria-hidden
+        />
+        <div className="pointer-events-none absolute -top-16 right-[-18%] h-44 w-44 rounded-full bg-emerald-200/35 blur-3xl" aria-hidden />
+        <div className="pointer-events-none absolute -bottom-20 left-[-22%] h-48 w-48 rounded-full bg-emerald-300/20 blur-3xl" aria-hidden />
+        <div className="relative space-y-4">
+          <h3 className="text-2xl font-semibold tracking-tight">Thanks — you’re one step closer.</h3>
+          <p className="text-sm leading-relaxed text-slate-700 sm:text-base">
+            We’ll send hand-picked insights for{' '}
+            <span className="font-semibold text-slate-900">
+              {towns.length ? towns.join(', ') : 'the NorthSide GTA'}
+            </span>{' '}
+            to <span className="font-semibold text-slate-900">{email}</span>. For the fastest reply, continue the conversation on WhatsApp.
+          </p>
+          <a
+            href={whatsappHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-emerald-200 bg-white/80 px-5 py-3 text-sm font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-300 hover:bg-white focus:outline-none focus:ring-2 focus:ring-emerald-400/60 sm:w-auto"
+          >
+            <FaWhatsapp className="h-5 w-5" style={{ color: "#25D366" }} />
+            Continue on WhatsApp
+          </a>
+        </div>
       </div>
     );
   }
@@ -131,270 +143,253 @@ export default function QuickContactCard({ formspreeId = "xanbzajw" }) {
   return (
     <div
       className={[
-        "rounded-2xl border border-emerald-200 bg-emerald-50/70",
-        "shadow-sm transition-all duration-300",
-        open ? "p-5 md:p-6" : "p-4 md:p-5",
+        "relative overflow-hidden rounded-3xl border border-emerald-100/70 bg-white/95",
+        "shadow-xl shadow-emerald-900/10 ring-1 ring-emerald-100/60 backdrop-blur",
+        "transition-all duration-300",
+        open ? "p-6 sm:p-7" : "p-5 sm:p-6",
       ].join(" ")}
     >
-      {/* Collapsed = premium “Match” block */}
-      {!open && (
-        <div className="space-y-3">
-          <div>
-            <h3 className="text-2xl md:text-[28px] font-extrabold tracking-tight text-slate-900">
-              Your NorthSide GTA Match
-            </h3>
-            <p className="text-slate-700">
-              Get a personalized shortlist of towns with insider notes, commute times, and
-              price ranges — built by Finally Home Agents.
-            </p>
-          </div>
+      <div
+        className="pointer-events-none absolute inset-x-10 top-0 h-[2px] bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600"
+        aria-hidden
+      />
+      <div className="pointer-events-none absolute -top-24 left-[-18%] h-48 w-48 rounded-full bg-emerald-300/25 blur-3xl" aria-hidden />
+      <div className="pointer-events-none absolute -bottom-28 right-[-22%] h-56 w-56 rounded-full bg-emerald-200/30 blur-3xl" aria-hidden />
 
-          <div className="flex flex-col sm:flex-row sm:items-center gap-3">
-            {/* START HERE (primary) */}
-            <button
-              type="button"
-              onClick={() => setOpen(true)}
-              className="
-                px-5 py-3 rounded-xl font-bold tracking-wide
-                bg-emerald-700 text-white hover:bg-emerald-800
-                shadow-[0_4px_12px_rgba(16,185,129,0.35)]
-                transition
-              "
-            >
-              START HERE
-            </button>
-
-            {/* WhatsApp (fast) — brand look + logo */}
-            <a
-              href={whatsappHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="
-                inline-flex items-center gap-2 px-5 py-3 rounded-xl
-                border-2 text-emerald-700 border-emerald-300 bg-white
-                hover:border-emerald-400 hover:bg-emerald-50
-                font-semibold transition
-              "
-              title="WhatsApp (fast)"
-            >
-              <FaWhatsapp className="h-5 w-5" style={{ color: "#25D366" }} />
-              WhatsApp <span className="opacity-70">(fast)</span>
-            </a>
-
-            {/* small time badge */}
-            <span className="inline-flex items-center self-start sm:self-auto px-2 py-1 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-800">
-              2 min
-            </span>
-          </div>
-
-          {/* Value bullets */}
-          <ul className="text-sm text-gray-800 space-y-1">
-            {[
-              "Top-3 towns matched to your lifestyle & budget",
-              "Scorecard: prices, commute, schools, vibe",
-              "VIP alerts for good-fit listings & off-market talk",
-            ].map((line) => (
-              <li key={line} className="flex items-start gap-2">
-                <span className="mt-1 inline-block h-4 w-4 rounded-full bg-emerald-600 text-white text-[10px] leading-4 text-center">✓</span>
-                <span>{line}</span>
-              </li>
-            ))}
-          </ul>
-
-          {/* Trust & footnote */}
-          <div className="text-xs text-gray-600">
-            ★★★★★ Google reviews • As seen on Instagram & Facebook
-          </div>
-          <div className="text-xs text-gray-500">No spam. Unsubscribe anytime.</div>
-        </div>
-      )}
-
-      {/* Expanded = full form */}
-      {open && (
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
-            <div>
-              <h3 className="text-xl md:text-2xl font-semibold">
+      <div className="relative">
+        {!open && (
+          <div className="space-y-5 text-slate-900">
+            <div className="space-y-3">
+              <span className="inline-flex items-center gap-2 rounded-full bg-emerald-100/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-emerald-700">
+                Concierge Match
+              </span>
+              <h3 className="text-2xl font-semibold tracking-tight sm:text-[28px]">
                 Your NorthSide GTA Match
               </h3>
-              <p className="text-gray-700">
-                Tell us where you’re looking — we’ll build your shortlist. Or tap WhatsApp for a faster response.
+              <p className="text-sm leading-relaxed text-slate-700 sm:text-base">
+                Get a personalized shortlist of towns with insider notes, commute times, and price ranges — built by Finally Home Agents.
               </p>
             </div>
 
-            <a
-              href={whatsappHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="
-                inline-flex items-center gap-2 px-4 py-2 rounded-lg
-                border-2 border-emerald-300 text-emerald-700 bg-white
-                hover:border-emerald-400 hover:bg-emerald-50 transition font-semibold
-              "
-              title="WhatsApp (fast)"
-            >
-              <FaWhatsapp className="h-5 w-5" style={{ color: "#25D366" }} />
-              WhatsApp (fast)
-            </a>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <button
+                type="button"
+                onClick={() => setOpen(true)}
+                className="inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-emerald-600 to-emerald-500 px-5 py-3 text-base font-semibold text-white shadow-lg shadow-emerald-900/30 transition hover:from-emerald-500 hover:to-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300"
+              >
+                START HERE
+              </button>
+
+              <a
+                href={whatsappHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-2xl border border-emerald-200 bg-white/80 px-5 py-3 text-base font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-300 hover:bg-white focus:outline-none focus:ring-2 focus:ring-emerald-300"
+                title="WhatsApp (fast)"
+              >
+                <FaWhatsapp className="h-5 w-5" style={{ color: "#25D366" }} />
+                WhatsApp <span className="text-emerald-500/80">(fast)</span>
+              </a>
+
+              <span className="inline-flex items-center self-start rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-emerald-700 sm:self-auto">
+                ≈2 min
+              </span>
+            </div>
+
+            <ul className="space-y-2 text-sm text-slate-700">
+              {[
+                "Top-3 towns matched to your lifestyle & budget",
+                "Scorecard: prices, commute, schools, vibe",
+                "VIP alerts for good-fit listings & off-market talk",
+              ].map((line) => (
+                <li key={line} className="flex items-start gap-3">
+                  <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-gradient-to-br from-emerald-600 to-emerald-500 text-[11px] font-semibold text-white shadow-sm">
+                    ✓
+                  </span>
+                  <span>{line}</span>
+                </li>
+              ))}
+            </ul>
+
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] font-semibold uppercase tracking-[0.28em] text-emerald-500/80">
+              <span>★★★★★ Google reviews</span>
+              <span>No spam — unsubscribe anytime</span>
+            </div>
           </div>
+        )}
 
-          <div className="grid md:grid-cols-3 gap-4">
-            <div className="md:col-span-1 space-y-3">
-              {/* Email with live validation message */}
-              <label className="block">
-                <span className="text-sm font-medium">
-                  Email<span className="text-rose-600"> *</span>
+        {open && (
+          <form onSubmit={handleSubmit} className="space-y-6 text-slate-900">
+            <div className="flex flex-col gap-3 border-b border-emerald-100/60 pb-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-2">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.32em] text-emerald-600">
+                  Your Match
                 </span>
-                <input
-                  type="email"
-                  required
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className={[
-                    "mt-1 w-full rounded-lg border focus:ring-emerald-500",
-                    email && !emailValid
-                      ? "border-rose-500 focus:border-rose-500"
-                      : "border-emerald-300 focus:border-emerald-500",
-                  ].join(" ")}
-                  placeholder="you@example.com"
-                />
-                {email && !emailValid && (
-                  <p className="mt-1 text-sm text-rose-600">
-                    Please enter a valid email address (e.g. name@example.com).
-                  </p>
-                )}
-              </label>
+                <h3 className="text-2xl font-semibold tracking-tight sm:text-[28px]">
+                  Your NorthSide GTA Match
+                </h3>
+                <p className="text-sm leading-relaxed text-slate-600">
+                  Tell us where you’re looking — we’ll build your shortlist. Prefer WhatsApp? Tap the concierge button.
+                </p>
+              </div>
 
-              <label className="block">
-                <span className="text-sm font-medium">Name (optional)</span>
-                <input
-                  type="text"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  className="mt-1 w-full rounded-lg border border-emerald-300 focus:border-emerald-500 focus:ring-emerald-500"
-                  placeholder="Jane Doe"
-                />
-              </label>
+              <a
+                href={whatsappHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-2xl border border-emerald-200 bg-white/80 px-4 py-2 text-sm font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-300 hover:bg-white focus:outline-none focus:ring-2 focus:ring-emerald-300"
+                title="WhatsApp (fast)"
+              >
+                <FaWhatsapp className="h-5 w-5" style={{ color: "#25D366" }} />
+                WhatsApp (fast)
+              </a>
+            </div>
 
-              <label className="block">
-                <span className="text-sm font-medium">Phone (optional)</span>
-                <input
-                  type="tel"
-                  value={phone}
-                  onChange={(e) => setPhone(e.target.value)}
-                  className="mt-1 w-full rounded-lg border border-emerald-300 focus:border-emerald-500 focus:ring-emerald-500"
-                  placeholder="(555) 555-5555"
-                />
-              </label>
+            <div className="grid gap-5 md:grid-cols-3">
+              <div className="space-y-4 md:col-span-1">
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-700">
+                    Email<span className="text-rose-500"> *</span>
+                  </span>
+                  <input
+                    type="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className={[
+                      baseInputClass,
+                      email && !emailValid
+                        ? "border-rose-400 focus:border-rose-500 focus:ring-rose-300/70"
+                        : "",
+                    ].join(" ")}
+                    placeholder="you@example.com"
+                  />
+                  {email && !emailValid && (
+                    <p className="mt-2 text-xs font-semibold text-rose-500">
+                      Please enter a valid email (name@example.com).
+                    </p>
+                  )}
+                </label>
 
-              <div className="block">
-                <span className="text-sm font-medium">Contact preference</span>
-                <div className="mt-1 inline-flex rounded-lg border border-emerald-300 bg-white p-1">
-                  {["Email", "WhatsApp", "Either"].map((opt) => (
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-700">Name (optional)</span>
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className={baseInputClass}
+                    placeholder="Jane Doe"
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-700">Phone (optional)</span>
+                  <input
+                    type="tel"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                    className={baseInputClass}
+                    placeholder="(647) 555-1234"
+                  />
+                </label>
+
+                <div>
+                  <span className="text-sm font-medium text-slate-700">Contact preference</span>
+                  <div className="mt-2 inline-flex rounded-full border border-emerald-200/70 bg-white/70 p-1 shadow-inner shadow-emerald-100">
+                    {["Email", "WhatsApp", "Either"].map((option) => (
+                      <button
+                        key={option}
+                        type="button"
+                        className={[
+                          "rounded-full px-3 py-1.5 text-sm font-semibold transition",
+                          pref === option
+                            ? "bg-gradient-to-r from-emerald-600 to-emerald-500 text-white shadow"
+                            : "text-emerald-700 hover:bg-emerald-50",
+                        ].join(" ")}
+                        onClick={() => setPref(option)}
+                      >
+                        {option}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-4 md:col-span-2">
+                <div>
+                  <span className="text-sm font-medium text-slate-700">
+                    Areas of interest<span className="text-rose-500"> *</span>
+                  </span>
+                  <div className="mt-3 flex flex-wrap gap-2">
                     <button
-                      key={opt}
                       type="button"
-                      className={[
-                        "px-3 py-1.5 rounded-md text-sm font-medium transition",
-                        pref === opt
-                          ? "bg-emerald-600 text-white"
-                          : "text-gray-700 hover:bg-gray-50",
-                      ].join(" ")}
-                      onClick={() => setPref(opt)}
+                      onClick={toggleAll}
+                      className={[chipBaseClass, allChecked ? chipActiveClass : ""].join(" ")}
                     >
-                      {opt}
+                      All of them
                     </button>
-                  ))}
+                    {TOWNS.map((town) => {
+                      const selected = towns.includes(town);
+                      return (
+                        <button
+                          key={town}
+                          type="button"
+                          onClick={() => toggleTown(town)}
+                          className={[chipBaseClass, selected ? chipActiveClass : ""].join(" ")}
+                        >
+                          {town}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="space-y-3 rounded-2xl border border-emerald-100/70 bg-emerald-50/50 p-4">
+                  <label className="flex items-start gap-3 text-sm text-slate-800">
+                    <input
+                      type="checkbox"
+                      checked={notUnderContract}
+                      onChange={(e) => setNotUnderContract(e.target.checked)}
+                      className="mt-1 rounded-md border-emerald-300 text-emerald-600 focus:ring-emerald-500/70"
+                    />
+                    <span>
+                      I confirm I’m <strong>not currently under contract</strong> with another real estate brokerage.
+                    </span>
+                  </label>
+                  <p className="text-xs text-emerald-700/80">
+                    By submitting, you agree to receive information from Finally Home Agents. You can unsubscribe anytime.
+                  </p>
                 </div>
               </div>
             </div>
 
-            <div className="md:col-span-2">
-              <span className="text-sm font-medium">
-                Areas of interest<span className="text-rose-600"> *</span>
-              </span>
+            {err && <p className="text-sm font-semibold text-rose-500">{err}</p>}
 
-              <div className="mt-2 flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={toggleAll}
-                  className={[
-                    "px-3 py-1.5 rounded-full border text-sm transition",
-                    allChecked
-                      ? "bg-emerald-600 text-white border-emerald-600"
-                      : "border-emerald-300 hover:bg-gray-50",
-                  ].join(" ")}
-                >
-                  All of them
-                </button>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                className={[
+                  "inline-flex items-center justify-center rounded-2xl px-5 py-3 text-base font-semibold transition focus:outline-none focus:ring-2 focus:ring-emerald-300",
+                  canSubmit
+                    ? "bg-gradient-to-r from-emerald-600 to-emerald-500 text-white shadow-lg shadow-emerald-900/25 hover:from-emerald-500 hover:to-emerald-400"
+                    : "cursor-not-allowed bg-emerald-200 text-emerald-800/60",
+                ].join(" ")}
+              >
+                {submitting ? "Sending…" : "Send me updates"}
+              </button>
 
-                {TOWNS.map((t) => {
-                  const on = towns.includes(t);
-                  return (
-                    <button
-                      key={t}
-                      type="button"
-                      onClick={() => toggleTown(t)}
-                      className={[
-                        "px-3 py-1.5 rounded-full border text-sm transition",
-                        on
-                          ? "bg-emerald-600 text-white border-emerald-600"
-                          : "border-emerald-300 hover:bg-gray-50",
-                      ].join(" ")}
-                    >
-                      {t}
-                    </button>
-                  );
-                })}
-              </div>
-
-              <div className="mt-4 space-y-2">
-                <label className="flex items-start gap-2">
-                  <input
-                    type="checkbox"
-                    checked={notUnderContract}
-                    onChange={(e) => setNotUnderContract(e.target.checked)}
-                    className="mt-1 rounded border-emerald-400 text-emerald-600 focus:ring-emerald-500"
-                  />
-                  <span className="text-sm text-gray-800">
-                    I confirm I’m <strong>not currently under contract</strong> with another real
-                    estate brokerage.
-                  </span>
-                </label>
-                <p className="text-xs text-gray-600">
-                  By submitting, you agree to receive information from Finally Home Agents. You can
-                  unsubscribe anytime.
-                </p>
-              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="inline-flex items-center justify-center rounded-2xl border border-emerald-100 bg-white px-4 py-2.5 text-sm font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-200 hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+              >
+                Collapse
+              </button>
             </div>
-          </div>
-
-          {err && <p className="text-sm text-rose-600">{err}</p>}
-
-          <div className="flex items-center gap-2">
-            <button
-              type="submit"
-              disabled={!canSubmit}
-              className={[
-                "px-4 py-2 rounded-lg font-semibold transition",
-                canSubmit
-                  ? "bg-emerald-700 text-white hover:bg-emerald-800"
-                  : "bg-emerald-200 text-emerald-900/60 cursor-not-allowed",
-              ].join(" ")}
-            >
-              {submitting ? "Sending…" : "Send me updates"}
-            </button>
-
-            <button
-              type="button"
-              onClick={() => setOpen(false)}
-              className="px-3 py-2 rounded-lg border border-emerald-300 text-gray-800 bg-white hover:bg-emerald-50 transition"
-            >
-              Collapse
-            </button>
-          </div>
-        </form>
-      )}
+          </form>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/TownStrip.js
+++ b/src/TownStrip.js
@@ -60,7 +60,7 @@ export default function TownStrip() {
     <section aria-label="Closest to Toronto → Furthest">
       {/* Ribbon (text tweak requested) */}
       <div className="flex items-center justify-between mb-2 md:mb-3">
-        <div className="relative inline-flex items-center gap-2 px-3 py-1 rounded-full bg-gradient-to-r from-emerald-700 to-emerald-500 text-white shadow">
+        <div className="relative inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-700 to-emerald-500 px-3 py-1 text-white shadow-lg shadow-emerald-900/30">
           <span className="text-[10px] font-semibold tracking-wide uppercase opacity-90">
             Closest to Toronto → Furthest
           </span>
@@ -74,7 +74,7 @@ export default function TownStrip() {
           <button
             type="button"
             onClick={() => scrollByAmount(-360)}
-            className="h-8 w-8 rounded-full border bg-white/90 hover:bg-white shadow-sm hover:shadow transition flex items-center justify-center"
+            className="h-9 w-9 rounded-full border border-emerald-100 bg-white/90 text-emerald-700 shadow-sm transition hover:border-emerald-200 hover:text-emerald-900 flex items-center justify-center"
             aria-label="Scroll left"
             title="Scroll left"
           >
@@ -83,7 +83,7 @@ export default function TownStrip() {
           <button
             type="button"
             onClick={() => scrollByAmount(360)}
-            className="h-8 w-8 rounded-full border bg-white/90 hover:bg-white shadow-sm hover:shadow transition flex items-center justify-center"
+            className="h-9 w-9 rounded-full border border-emerald-100 bg-white/90 text-emerald-700 shadow-sm transition hover:border-emerald-200 hover:text-emerald-900 flex items-center justify-center"
             aria-label="Scroll right"
             title="Scroll right"
           >
@@ -95,8 +95,8 @@ export default function TownStrip() {
       {/* Scroll container — smaller cards + padding guards so nothing is clipped */}
       <div className="relative">
         {/* Subtle fades on edges */}
-        <div className="pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-white to-transparent rounded-l-2xl" />
-        <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-white to-transparent rounded-r-2xl" />
+        <div className="pointer-events-none absolute inset-y-0 left-0 w-6 rounded-l-2xl bg-gradient-to-r from-white/95 to-transparent" />
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-6 rounded-r-2xl bg-gradient-to-l from-white/95 to-transparent" />
 
         <div
           ref={railRef}
@@ -117,10 +117,9 @@ export default function TownStrip() {
               className="snap-start shrink-0 w-[210px] md:w-[230px] group"
               aria-label={`Explore ${t.name}`}
             >
-              <div className="h-full rounded-2xl border bg-white/85 backdrop-blur-sm shadow-sm ring-1 ring-black/5 overflow-hidden transition
-                              group-hover:shadow-lg group-hover:-translate-y-0.5">
+              <div className="h-full rounded-3xl border border-emerald-100/60 bg-white/95 backdrop-blur-sm shadow-lg shadow-emerald-900/5 overflow-hidden transition group-hover:-translate-y-1 group-hover:shadow-xl">
                 {/* Image area (smaller heights) */}
-                <div className="aspect-[4/3] bg-emerald-50/40 flex items-center justify-center">
+                <div className="aspect-[4/3] bg-emerald-50/60 flex items-center justify-center">
                   <img
                     src={t.img}
                     alt={t.name}
@@ -133,12 +132,12 @@ export default function TownStrip() {
                 {/* Body */}
                 <div className="p-3">
                   <div className="flex items-center justify-between">
-                    <h3 className="text-[13px] font-semibold text-gray-900">{t.name}</h3>
+                    <h3 className="text-[13px] font-semibold text-slate-900">{t.name}</h3>
                     <span className="text-[10px] px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700 font-semibold tracking-wide">
                       {ordinal(idx + 1)}
                     </span>
                   </div>
-                  <p className="mt-1 text-[11px] text-gray-600 leading-5">{t.blurb}</p>
+                  <p className="mt-1 text-[11px] leading-5 text-slate-600">{t.blurb}</p>
                 </div>
               </div>
             </a>


### PR DESCRIPTION
## Summary
- Restyled the map hero with emerald gradient overlays, floating matchup badge, and updated copy to match the contact page tone.
- Rebuilt the "Your NorthSide GTA Match" quick contact card with elevated card styling and refined form controls for consistency with contact visuals.
- Updated the home page layout to wrap key sections in soft cards, reuse the contact reviews carousel, and introduce a gradient CTA band echoing the contact footer.
- Polished the Closest to Toronto rail cards with refreshed borders, typography, and control buttons.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e92e201e208324930c3b65ac76fe90