### PR TITLE
chore(ci): harden events sync workflow

### DIFF
--- a/.github/workflows/events-sync.yml
+++ b/.github/workflows/events-sync.yml
@@ -87,7 +87,7 @@ jobs:
             exit 0
           fi
 
-          git push -u origin ci/events-sync
+          git push --force-with-lease=refs/heads/ci/events-sync -u origin ci/events-sync
 
           gh pr create \
             --title "Automated events sync" \


### PR DESCRIPTION
## Summary
- force-push the regenerated `ci/events-sync` branch with a lease so prior automation runs are safely updated

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ee65ca8e94832498f7dd924ed352af