### PR TITLE
Ensure events sync commits new data

### DIFF
--- a/.github/workflows/events-sync.yml
+++ b/.github/workflows/events-sync.yml
@@ -49,23 +49,27 @@ jobs:
           set -euo pipefail
           git fetch origin
           git checkout -B ci/events-sync origin/main
-      - name: Run sync script
+      - name: Run events sync (force write mode)
+        env:
+          EVENTS_SYNC_WRITE: "true"
         run: node scripts/sync-events.mjs
+
+      - name: Debug: show repo status after sync
+        run: |
+          echo "=== git status (porcelain) ==="
+          git status --porcelain || true
+          echo "=== changed or new under public/data/events ==="
+          git ls-files -m -o --exclude-standard public/data/events | sed 's/^/• /' || true
+
       - name: Commit generated artifacts
-        shell: bash
         run: |
           set -euo pipefail
-
           git config user.name  "northside-ci-bot"
           git config user.email "ci@northsidegta.local"
-
-          git add public/data/events public/sitemap.xml scripts/generated 2>/dev/null || true
-
+          git add -A public/data/events public/sitemap.xml scripts/generated 2>/dev/null || true
           if git diff --cached --quiet; then
-            echo "No generated changes to commit"
-            exit 0
+            echo "No generated changes to commit"; exit 0
           fi
-
           MSG="chore(events-sync): update events"
           if [ -f public/data/events/_sync-summary.json ]; then
             CREATED=$(node -e "console.log(require('./public/data/events/_sync-summary.json').created ?? 0)")
@@ -73,8 +77,21 @@ jobs:
             ERRORS=$(node -e "console.log(require('./public/data/events/_sync-summary.json').errors ?? 0)")
             MSG="chore(events-sync): +${CREATED} new, ${UPDATED} updated, ${ERRORS} errors"
           fi
-
           git commit -m "$MSG"
+
+      - name: Sanity check: summary vs commit
+        run: |
+          set -euo pipefail
+          S=public/data/events/_sync-summary.json
+          if [ -f "$S" ]; then
+            CREATED=$(node -e "console.log(require('./'$S'').created ?? 0)")
+            UPDATED=$(node -e "console.log(require('./'$S'').updated ?? 0)")
+            if [ $((CREATED+UPDATED)) -gt 0 ] && git diff --quiet HEAD^ HEAD 2>/dev/null; then
+              echo "::error::Sync reported $CREATED created and $UPDATED updated, but no diffs were committed."
+              echo "::error::Likely cause: dry-run or writing outside public/data/events."
+              exit 1
+            fi
+          fi
       - name: Push branch & open/update PR
         if: steps.mode.outputs.mode == 'pr'
         env:

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -27,6 +27,7 @@ const DEFAULT_RETRY_ATTEMPTS = 3
 const DEFAULT_RETRY_DELAY_MS = 400
 const MAX_RETRY_DELAY_MS = 5000
 const parser = new Parser()
+const WRITE_MODE = process.env.EVENTS_SYNC_WRITE === 'true'
 
 async function main() {
   const { feeds } = await loadConfig(configPath)
@@ -36,8 +37,10 @@ async function main() {
     return
   }
 
-  await fs.mkdir(eventsDir, { recursive: true })
-  await fs.mkdir(reportsDir, { recursive: true }).catch(() => {})
+  if (WRITE_MODE) {
+    await fs.mkdir(eventsDir, { recursive: true })
+    await fs.mkdir(reportsDir, { recursive: true }).catch(() => {})
+  }
   const existing = await loadExistingEvents(eventsDir)
   const now = new Date()
   const summary = { created: 0, updated: 0, unchanged: 0, errors: 0 }
@@ -110,7 +113,7 @@ async function main() {
 
   const totalChanged = summary.created + summary.updated + summary.errors
 
-  if (totalChanged > 0) {
+  if (totalChanged > 0 && WRITE_MODE) {
     const totalAfter = await fs
       .readdir(eventsDir)
       .then((list) =>
@@ -132,12 +135,21 @@ async function main() {
     await fs.writeFile(summaryPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
   }
 
-  if (syncState.configChanged) {
+  if (WRITE_MODE && syncState.configChanged) {
     await persistConfigUpdates(configPath, feeds)
     await writeUrlUpdateLog(syncState.urlUpdates)
   }
 
-  await writeSyncReports(reportsDir, now, summary, feedReports, syncState.urlUpdates, syncState.fallbacks)
+  if (WRITE_MODE) {
+    await writeSyncReports(
+      reportsDir,
+      now,
+      summary,
+      feedReports,
+      syncState.urlUpdates,
+      syncState.fallbacks
+    )
+  }
 
   console.log(
     `Created: ${summary.created}, Updated: ${summary.updated}, Unchanged: ${summary.unchanged}, Errors: ${summary.errors}`
@@ -778,12 +790,14 @@ function createFeedReport(feed) {
 }
 
 async function persistConfigUpdates(filePath, feeds) {
+  if (!WRITE_MODE) return
   if (!Array.isArray(feeds) || !feeds.length) return
   const serialized = `${JSON.stringify(feeds, null, 2)}\n`
   await fs.writeFile(filePath, serialized, 'utf8')
 }
 
 async function writeUrlUpdateLog(updates = []) {
+  if (!WRITE_MODE) return
   if (!Array.isArray(updates) || updates.length === 0) return
   await fs.mkdir(path.dirname(urlUpdateLogPath), { recursive: true })
   const lines = updates.map((entry) => JSON.stringify(entry))
@@ -791,6 +805,7 @@ async function writeUrlUpdateLog(updates = []) {
 }
 
 async function writeSyncReports(dir, now, summary, feedReports, urlUpdates, fallbacks = []) {
+  if (!WRITE_MODE) return
   await fs.mkdir(dir, { recursive: true })
   const timestamp = DateTime.fromJSDate(now).setZone('America/Toronto')
   const stamp = timestamp.toFormat('yyyyLLdd-HHmmss')
@@ -1473,7 +1488,9 @@ async function mergeEvent(event, existingMaps, now) {
     return 'unchanged'
   }
 
-  await fs.writeFile(filePath, serialized, 'utf8')
+  if (WRITE_MODE) {
+    await fs.writeFile(filePath, serialized, 'utf8')
+  }
   const entry = { data: merged, filePath }
   bySlug.set(event.slug, entry)
   if (sourceId) bySourceId.set(sourceId, entry)


### PR DESCRIPTION
## Summary
- run the events sync workflow in forced write mode, add debug output, and fail the job if reported changes were not committed
- gate the sync script's write operations behind the EVENTS_SYNC_WRITE flag so real runs publish JSON updates while dry runs stay read-only

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee6e88a3d48324873e395ef294fe0f