### PR TITLE
chore: enable manual runs for events sync workflow

### DIFF
--- a/.github/workflows/events-sync.yml
+++ b/.github/workflows/events-sync.yml
@@ -2,9 +2,23 @@ name: Daily Events Sync
 
 on:
   schedule:
-    # 6:00 AM America/Toronto ≈ 10:00 UTC (DST aware enough for our needs)
-    - cron: "0 10 * * *"
-  workflow_dispatch: {}
+    # keep your existing cron; if none exists, this runs daily at 7:05am Toronto time
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+    inputs:
+      write:
+        description: 'Write changes to public/data/events (recommended: true)'
+        type: boolean
+        default: true
+      mode:
+        description: 'Publish mode'
+        type: choice
+        options: [pr, direct]
+        default: pr
+      feed:
+        description: 'Optional: run a single feed id'
+        required: false
+        type: string
   repository_dispatch:
     types: [sync_now]
 


### PR DESCRIPTION
## Summary
- add manual dispatch inputs so the events sync workflow can be triggered from the UI
- keep the scheduled cron and concurrency settings to avoid overlapping runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee75c42f2083249e8e0555997316c0