### PR TITLE
Fix event sync failures and auto publish feed items

### DIFF
--- a/lib/events/status-utils.js
+++ b/lib/events/status-utils.js
@@ -1,0 +1,97 @@
+'use strict'
+
+const ALLOWED_STATUSES = new Set(['draft', 'pending', 'approved', 'published', 'archived'])
+
+function normalizeStatusValue(value) {
+  if (value === undefined || value === null) return ''
+  const text = String(value).trim().toLowerCase()
+  if (!text) return ''
+  if (ALLOWED_STATUSES.has(text)) {
+    return text
+  }
+  return ''
+}
+
+function normalizeSourceValue(value) {
+  if (!value) return ''
+  if (typeof value === 'string') {
+    const text = value.trim().toLowerCase()
+    if (!text) return ''
+    if (text === 'feed' || text.endsWith('feed')) return 'feed'
+    if (text === 'manual' || text === 'user' || text.includes('submission')) return 'manual'
+    return ''
+  }
+  if (typeof value === 'object') return 'feed'
+  return ''
+}
+
+function resolveSourceType(preservedEvent = {}, incomingEvent = {}) {
+  const incomingSource = normalizeSourceValue(incomingEvent?.source)
+  if (incomingSource) return incomingSource
+  const preservedSource = normalizeSourceValue(preservedEvent?.source)
+  if (preservedSource) return preservedSource
+  if (incomingEvent && typeof incomingEvent === 'object') {
+    if (incomingEvent.sourceDomain || incomingEvent.sourceUrl) return 'feed'
+  }
+  if (preservedEvent && typeof preservedEvent === 'object') {
+    if (preservedEvent.sourceDomain || preservedEvent.sourceUrl) return 'feed'
+  }
+  return 'feed'
+}
+
+function resolveStatusForSync({
+  preservedEvent = {},
+  incomingEvent = {},
+  archived = false,
+  defaultStatus = 'pending',
+} = {}) {
+  const preservedStatus = normalizeStatusValue(preservedEvent?.status)
+  const incomingStatus = normalizeStatusValue(incomingEvent?.status)
+  const defaultNormalized = normalizeStatusValue(defaultStatus) || 'pending'
+
+  const isArchived =
+    archived || preservedStatus === 'archived' || incomingStatus === 'archived' ||
+    normalizeBoolean(preservedEvent?.archived) ||
+    normalizeBoolean(incomingEvent?.archived)
+  if (isArchived) {
+    return 'archived'
+  }
+
+  if (preservedStatus && preservedStatus !== 'pending') {
+    return preservedStatus
+  }
+
+  if (incomingStatus && incomingStatus !== 'pending') {
+    return incomingStatus
+  }
+
+  const sourceType = resolveSourceType(preservedEvent, incomingEvent)
+  if (sourceType === 'feed') {
+    return 'approved'
+  }
+
+  if (preservedStatus) return preservedStatus
+  if (incomingStatus) return incomingStatus
+
+  return defaultNormalized
+}
+
+function normalizeBoolean(value) {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) return true
+    if (['false', '0', 'no', 'n', 'off', ''].includes(normalized)) return false
+  }
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) return false
+    return value !== 0
+  }
+  return Boolean(value)
+}
+
+module.exports = {
+  resolveStatusForSync,
+  resolveSourceType,
+  normalizeStatusValue,
+}

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -11,6 +11,10 @@ const ical = require('node-ical')
 const { getAdapter } = require('../lib/event-source-adapters.js')
 const { expandIcsEvents } = require('../lib/events/ics.js')
 const { normalizeCmsEvent } = require('../lib/events/cms-normalizer.js')
+const {
+  resolveStatusForSync,
+  resolveSourceType,
+} = require('../lib/events/status-utils.js')
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -158,6 +162,20 @@ async function main() {
       syncState.urlUpdates,
       syncState.fallbacks
     )
+  }
+
+  const feedsWithResults = feedReports.filter(
+    (report) => (report.created || 0) + (report.updated || 0) + (report.unchanged || 0) > 0
+  )
+  const feedsWithErrors = feedReports.filter(
+    (report) => report.status === 'error' || (Array.isArray(report.errors) && report.errors.length > 0)
+  )
+
+  if (!feedsWithResults.length && feedsWithErrors.length && feedReports.length) {
+    console.error(
+      '[sync-events] No feeds produced any events and one or more feeds failed. Marking sync as failed.'
+    )
+    process.exitCode = 1
   }
 
   console.log(
@@ -531,6 +549,7 @@ function shouldAttemptDiscovery(error, feed, options = {}) {
   const status = Number(error?.status || error?.response?.status)
   if (status === 404 || status === 410) return true
   if (status === 301 || status === 302 || status === 307 || status === 308) return true
+  if (status === 401 || status === 403) return true
   if (!Number.isFinite(status)) {
     const code = error?.code
     if (code && (code === 'ENOTFOUND' || code === 'ECONNREFUSED' || code === 'EAI_AGAIN')) {
@@ -1440,9 +1459,14 @@ async function mergeEvent(event, existingMaps, now) {
 
   const preserved = existingEntry?.data || {}
   const isUpdate = Boolean(existingEntry)
-  const status = typeof preserved.status === 'string' ? preserved.status : 'pending'
   const hidden = Boolean(preserved.hidden)
   const archived = Boolean(preserved.archived)
+  const sourceType = resolveSourceType(preserved, event)
+  const status = resolveStatusForSync({
+    preservedEvent: preserved,
+    incomingEvent: event,
+    archived,
+  })
   const notes = preserved.notes !== undefined ? preserved.notes : ''
   const preservedFirstSeen =
     typeof preserved.firstSeenAt === 'string' && preserved.firstSeenAt ? preserved.firstSeenAt : null
@@ -1471,7 +1495,7 @@ async function mergeEvent(event, existingMaps, now) {
     hidden,
     archived,
     notes,
-    source: typeof preserved.source === 'string' ? preserved.source : 'feed',
+    source: sourceType,
     sourceName: cleanText(event.sourceName || preserved.sourceName || ''),
     sourceUrl: cleanText(event.sourceUrl || preserved.sourceUrl || ''),
     sourceDomain: cleanText(event.sourceDomain || preserved.sourceDomain || ''),

--- a/tests/events-status-utils.test.js
+++ b/tests/events-status-utils.test.js
@@ -1,0 +1,59 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  resolveStatusForSync,
+  resolveSourceType,
+  normalizeStatusValue,
+} = require('../lib/events/status-utils.js')
+
+test('normalizeStatusValue keeps allowed statuses', () => {
+  assert.equal(normalizeStatusValue('Published'), 'published')
+  assert.equal(normalizeStatusValue('pending'), 'pending')
+  assert.equal(normalizeStatusValue('ARCHIVED'), 'archived')
+})
+
+test('normalizeStatusValue strips unknown statuses', () => {
+  assert.equal(normalizeStatusValue('cancelled'), '')
+  assert.equal(normalizeStatusValue(''), '')
+  assert.equal(normalizeStatusValue(null), '')
+})
+
+test('resolveSourceType prefers incoming source objects', () => {
+  const source = resolveSourceType({}, { source: { id: 'abc' } })
+  assert.equal(source, 'feed')
+})
+
+test('resolveSourceType respects manual preserved source', () => {
+  const source = resolveSourceType({ source: 'manual' }, {})
+  assert.equal(source, 'manual')
+})
+
+test('resolveStatusForSync auto-approves new feed events', () => {
+  const status = resolveStatusForSync({ incomingEvent: { source: { id: 'abc' } } })
+  assert.equal(status, 'approved')
+})
+
+test('resolveStatusForSync upgrades previously pending feed events', () => {
+  const status = resolveStatusForSync({
+    preservedEvent: { status: 'pending', source: 'feed' },
+    incomingEvent: { source: { id: 'abc' } },
+  })
+  assert.equal(status, 'approved')
+})
+
+test('resolveStatusForSync keeps manual pending events pending', () => {
+  const status = resolveStatusForSync({
+    preservedEvent: { status: 'pending', source: 'manual' },
+    incomingEvent: { source: 'manual' },
+  })
+  assert.equal(status, 'pending')
+})
+
+test('resolveStatusForSync preserves archived state', () => {
+  const status = resolveStatusForSync({
+    preservedEvent: { status: 'archived', source: 'feed' },
+    incomingEvent: { source: { id: 'abc' } },
+  })
+  assert.equal(status, 'archived')
+})


### PR DESCRIPTION
## Summary
- add shared helpers to normalize feed status/source and use them to auto-approve synced events while respecting manual overrides
- harden the sync workflow by failing when every feed errors and expanding discovery to retry on 401/403 responses
- cover the new status utilities with unit tests for feed, manual, and archived scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ef8a1998c48324990bbdac2c367cbc