### PR TITLE
Adjust events sync concurrency to avoid canceling runs

### DIFF
--- a/.github/workflows/events-sync.yml
+++ b/.github/workflows/events-sync.yml
@@ -28,7 +28,7 @@ permissions:
 
 concurrency:
   group: events-sync-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary
- update the events sync workflow concurrency settings so new dispatches do not cancel in-progress runs

## Testing
- not run (workflow behavior change only)


------
https://chatgpt.com/codex/tasks/task_e_68efc086f8848324a18acb983e156d90