### PR TITLE
chore(ci): enforce write flag for events sync

### DIFF
--- a/.github/workflows/events-sync.yml
+++ b/.github/workflows/events-sync.yml
@@ -71,6 +71,12 @@ jobs:
             WRITE_FLAG="true"
           fi
 
+          if [ "$WRITE_FLAG" != "true" ]; then
+            echo "::error::events-sync requires write=true; manual dispatches must set write: true."
+            echo "Resolved write flag: '$WRITE_FLAG'. Aborting before sync."
+            exit 1
+          fi
+
           MODE_CHOICE="${INPUT_MODE:-}"
           if [ -z "$MODE_CHOICE" ]; then
             MODE_CHOICE="${PAYLOAD_MODE:-}"


### PR DESCRIPTION
## Summary
- fail the events sync workflow early when the resolved write flag is not exactly true
- add logging that clarifies manual dispatches must pass write: true

## Testing
- bash -c 'set -euo pipefail; INPUT_WRITE=false; WRITE_FLAG="${INPUT_WRITE:-}"; if [ "$WRITE_FLAG" != "true" ]; then echo "::error::events-sync requires write=true; manual dispatches must set write: true."; echo "Resolved write flag: $WRITE_FLAG. Aborting before sync."; exit 1; fi'


------
https://chatgpt.com/codex/tasks/task_e_68efc16a51788324b6a6c6534f2a0cc1