### PR TITLE
chore(ci): harden events sync workflow

### DIFF
--- a/.github/workflows/events-sync.yml
+++ b/.github/workflows/events-sync.yml
@@ -27,7 +27,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: events-sync-main
+  group: events-sync-${{ github.ref || github.run_id }}-${{ github.event.inputs.feed || github.event.client_payload.feed || 'all' }}
   cancel-in-progress: true
 
 jobs:
@@ -68,8 +68,21 @@ jobs:
             WRITE_FLAG="${PAYLOAD_WRITE:-}"
           fi
           if [ -z "$WRITE_FLAG" ]; then
-            WRITE_FLAG="true"
+            if [ "${GITHUB_EVENT_NAME}" = "schedule" ] || [ "${GITHUB_EVENT_NAME}" = "repository_dispatch" ]; then
+              WRITE_FLAG="true"
+            else
+              echo "::error::You must explicitly set the write flag when running this workflow manually."
+              exit 1
+            fi
           fi
+
+          case "$WRITE_FLAG" in
+            true|false) ;;
+            *)
+              echo "::error::Write flag must be either 'true' or 'false' (received: $WRITE_FLAG)"
+              exit 1
+              ;;
+          esac
 
           MODE_CHOICE="${INPUT_MODE:-}"
           if [ -z "$MODE_CHOICE" ]; then
@@ -81,6 +94,11 @@ jobs:
             else
               MODE_CHOICE="pr"
             fi
+          fi
+
+          if [ "$MODE_CHOICE" = "direct" ] && [ "$WRITE_FLAG" != "true" ]; then
+            echo "::error::Direct mode requires write=true."
+            exit 1
           fi
 
           FEED_CHOICE="${INPUT_FEED:-}"
@@ -103,6 +121,54 @@ jobs:
           EVENTS_SYNC_WRITE: ${{ steps.options.outputs.write_flag }}
         run: node scripts/sync-events.mjs
 
+      - name: Publish sync summary
+        if: always()
+        run: |
+          set -euo pipefail
+
+          SUMMARY="public/data/events/_sync-summary.json"
+          if [ ! -f "$SUMMARY" ]; then
+            echo "No sync summary file generated."
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+              echo "No sync summary file generated." >> "$GITHUB_STEP_SUMMARY"
+            fi
+            exit 0
+          fi
+
+          node <<'NODE' "$SUMMARY"
+const fs = require('fs')
+const summaryPath = process.argv[1]
+const summaryTarget = process.env.GITHUB_STEP_SUMMARY
+
+try {
+  const raw = fs.readFileSync(summaryPath, 'utf8')
+  const data = JSON.parse(raw)
+  const lines = [
+    '### Events sync summary',
+    '',
+    `- Last change at: ${data.lastChangeAt ?? 'n/a'}`,
+    `- Created: ${data.created ?? 0}`,
+    `- Updated: ${data.updated ?? 0}`,
+    `- Unchanged: ${data.unchanged ?? 0}`,
+    `- Errors: ${data.errors ?? 0}`,
+    `- Total after: ${data.totalAfter ?? 0}`,
+  ]
+
+  const payload = `${lines.join('\n')}\n`
+  if (summaryTarget) {
+    fs.appendFileSync(summaryTarget, payload, 'utf8')
+  }
+  process.stdout.write(payload)
+} catch (error) {
+  const message = `Failed to publish sync summary: ${error.message}`
+  if (summaryTarget) {
+    fs.appendFileSync(summaryTarget, `${message}\n`, 'utf8')
+  }
+  process.stderr.write(`${message}\n`)
+  process.exitCode = 1
+}
+NODE
+
       - name: "Debug: show repo status after sync"
         run: |
           echo "=== git status (porcelain) ==="
@@ -111,6 +177,7 @@ jobs:
           git ls-files -m -o --exclude-standard public/data/events | sed 's/^/- /' || true
 
       - name: Commit generated artifacts
+        if: steps.options.outputs.write_flag == 'true'
         id: commit
         run: |
           set -euo pipefail
@@ -147,7 +214,7 @@ jobs:
             fi
           fi
       - name: Push branch & open/update PR
-        if: steps.options.outputs.mode == 'pr' && steps.commit.outputs.did_commit == 'true'
+        if: steps.options.outputs.write_flag == 'true' && steps.options.outputs.mode == 'pr' && steps.commit.outputs.did_commit == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
@@ -163,18 +230,18 @@ jobs:
             --label automation \
             || gh pr edit --head ci/events-sync --add-label automation --title "Automated events sync"
       - name: Guard dirty tree for rebase (generated paths only)
-        if: steps.options.outputs.mode == 'direct' && steps.commit.outputs.did_commit == 'true'
+        if: steps.options.outputs.write_flag == 'true' && steps.options.outputs.mode == 'direct' && steps.commit.outputs.did_commit == 'true'
         run: |
           set -euo pipefail
           git add -A public/data/events public/sitemap.xml 2>/dev/null || true
           git stash push -m "pre-rebase (generated)" || echo "Nothing to stash"
       - name: Rebase safely with autostash
-        if: steps.options.outputs.mode == 'direct' && steps.commit.outputs.did_commit == 'true'
+        if: steps.options.outputs.write_flag == 'true' && steps.options.outputs.mode == 'direct' && steps.commit.outputs.did_commit == 'true'
         run: |
           set -euo pipefail
           git pull --rebase --autostash origin main
       - name: Re-stage & commit after rebase
-        if: steps.options.outputs.mode == 'direct' && steps.commit.outputs.did_commit == 'true'
+        if: steps.options.outputs.write_flag == 'true' && steps.options.outputs.mode == 'direct' && steps.commit.outputs.did_commit == 'true'
         run: |
           set -euo pipefail
 
@@ -184,7 +251,7 @@ jobs:
           git add -A public/data/events public/sitemap.xml 2>/dev/null || true
           git commit -m "chore(events): sync & normalize" || echo "No changes to commit"
       - name: Push to main with retry and lease
-        if: steps.options.outputs.mode == 'direct' && steps.commit.outputs.did_commit == 'true'
+        if: steps.options.outputs.write_flag == 'true' && steps.options.outputs.mode == 'direct' && steps.commit.outputs.did_commit == 'true'
         run: |
           set -euo pipefail
           for i in 1 2 3; do


### PR DESCRIPTION
## Summary
- scope the events sync concurrency group by ref and feed so parallel runs no longer clobber each other
- require an explicit true/false write flag and block direct publishes without write access
- publish the sync summary to the job log and GitHub step summary while skipping publish steps in read-only runs

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68efc560e4e483249cf438a817b08aff