### PR TITLE
Harden sync-now dispatch configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,19 @@ With KV available, deletions from Events Admin are reversible and the “Show de
 Publishing, unpublishing, and hard-delete fallbacks use the GitHub Content API. Provide these environment variables so the API routes can commit directly to the default branch (or raise a PR when requested):
 
 - `GITHUB_REPO` – target repository in `owner/name` format.
-- `GITHUB_TOKEN` – personal access token with `contents:write` on the repo.
+- `GITHUB_TOKEN` (or `GH_TOKEN`) – personal access token with `contents:write` on the repo.
 - `EVENTS_ADMIN_USE_PR` – optional. Set to `true` to open a pull request instead of committing straight to the default branch.
 
 If the GitHub variables are missing, publish/unpublish buttons will be disabled and hard deletes are unavailable.
+
+### Manual “Sync now” button
+
+The sync button on `/community/events-admin` triggers the `events-sync.yml` GitHub Action. Make sure these are present before testing:
+
+- `GITHUB_REPO` and `GITHUB_TOKEN`/`GH_TOKEN` as listed above. The API accepts either variable name for the token.
+- `SYNC_SECRET` – used to sign the anti-CSRF cookie that the admin page sends back with the sync request. Without it, the button is disabled and the API rejects requests.
+
+When the API receives a sync request it calls both `workflow_dispatch` on `events-sync.yml` and a generic repository dispatch (`event_type: sync_now`). Check the API response toast for quick hints when GitHub rejects either request.
 
 ## Daily Events Auto-Sync
 

--- a/api/sync-now.js
+++ b/api/sync-now.js
@@ -1,12 +1,61 @@
 // /api/sync-now.js
-import crypto from 'crypto'
+const crypto = require('crypto')
 
-const OWNER = process.env.GITHUB_REPO_OWNER || process.env.VERCEL_GIT_REPO_OWNER
-const REPO = process.env.GITHUB_REPO_NAME || process.env.VERCEL_GIT_REPO_SLUG
 const WORKFLOW_FILE = 'events-sync.yml'
 const CSRF_COOKIE = 'sync_now_csrf' // SYNC WIRING
-const DEFAULT_REF =
-  process.env.GITHUB_REF_NAME || process.env.VERCEL_GIT_COMMIT_REF || 'main' // SYNC WIRING
+const SUCCESS_STATUSES = new Set([200, 201, 202, 204])
+
+function resolveRepoInfo() {
+  const directOwner = process.env.GITHUB_REPO_OWNER || process.env.VERCEL_GIT_REPO_OWNER
+  const directRepo = process.env.GITHUB_REPO_NAME || process.env.VERCEL_GIT_REPO_SLUG
+
+  if (directOwner && directRepo) {
+    return { owner: directOwner, repo: directRepo }
+  }
+
+  const combined =
+    process.env.GITHUB_REPO || process.env.GITHUB_REPOSITORY || process.env.VERCEL_GIT_REPO_SLUG
+
+  if (combined && typeof combined === 'string') {
+    const [owner, repo] = combined.split('/')
+    if (owner && repo) {
+      return { owner, repo }
+    }
+  }
+
+  return { owner: directOwner || '', repo: directRepo || '' }
+}
+
+function resolveRef() {
+  const refCandidates = [
+    process.env.GITHUB_REF_NAME,
+    process.env.GITHUB_HEAD_REF,
+    process.env.VERCEL_GIT_COMMIT_REF,
+    process.env.GITHUB_REF,
+  ]
+
+  for (const candidate of refCandidates) {
+    if (!candidate || typeof candidate !== 'string') continue
+    if (candidate.startsWith('refs/heads/')) {
+      return candidate.slice('refs/heads/'.length)
+    }
+    if (candidate.trim()) {
+      return candidate.trim()
+    }
+  }
+
+  return 'main'
+}
+
+function resolveGithubToken() {
+  const token =
+    process.env.GH_TOKEN ||
+    process.env.GITHUB_TOKEN ||
+    process.env.PERSONAL_GITHUB_TOKEN ||
+    process.env.GITHUB_PERSONAL_TOKEN
+
+  return typeof token === 'string' && token.trim() ? token.trim() : ''
+}
 
 // SYNC WIRING
 function parseCookies(header = '') {
@@ -83,7 +132,7 @@ function isSameOrigin(req) {
 // SYNC WIRING
 function buildHintFromStatus(workflowStatus, repoDispatchStatus) {
   if (workflowStatus === 403 || repoDispatchStatus === 403) {
-    return 'GitHub rejected the sync — ensure GH_TOKEN has Actions: write and repo Actions permissions allow workflow_dispatch.'
+    return 'GitHub rejected the sync — ensure GH_TOKEN/GITHUB_TOKEN has Actions: write and repo Actions permissions allow workflow_dispatch.'
   }
   if (workflowStatus === 404) {
     return 'Workflow not found. Confirm events-sync.yml exists on the default branch.'
@@ -93,15 +142,22 @@ function buildHintFromStatus(workflowStatus, repoDispatchStatus) {
 
 // SYNC WIRING
 async function triggerSync() {
-  const token = process.env.GH_TOKEN
+  const token = resolveGithubToken()
+  const ref = resolveRef()
+  const { owner, repo } = resolveRepoInfo()
+
   if (!token) {
     return {
       status: 500,
-      body: { ok: false, error: 'Missing GH_TOKEN environment variable.', hint: 'Set GH_TOKEN with Actions: Read & Write access.' },
+      body: {
+        ok: false,
+        error: 'Missing GH_TOKEN environment variable.',
+        hint: 'Set GH_TOKEN or GITHUB_TOKEN with Actions: Read & Write access.',
+      },
     }
   }
 
-  if (!OWNER || !REPO) {
+  if (!owner || !repo) {
     return {
       status: 500,
       body: { ok: false, error: 'Missing repository metadata.', hint: 'Ensure repository owner/name env vars are available.' },
@@ -115,15 +171,15 @@ async function triggerSync() {
     'Content-Type': 'application/json',
   }
 
-  const workflowUrl = `https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_FILE}/dispatches`
-  const dispatchUrl = `https://api.github.com/repos/${OWNER}/${REPO}/dispatches`
+  const workflowUrl = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${WORKFLOW_FILE}/dispatches`
+  const dispatchUrl = `https://api.github.com/repos/${owner}/${repo}/dispatches`
 
   try {
     const [workflowResponse, repoDispatchResponse] = await Promise.all([
       fetch(workflowUrl, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ ref: DEFAULT_REF }),
+        body: JSON.stringify({ ref }),
       }),
       fetch(dispatchUrl, {
         method: 'POST',
@@ -135,8 +191,8 @@ async function triggerSync() {
     const workflowStatus = workflowResponse.status
     const repoDispatchStatus = repoDispatchResponse.status
 
-    const successStatuses = new Set([200, 201, 202, 204])
-    const ok = successStatuses.has(workflowStatus) || successStatuses.has(repoDispatchStatus)
+    const ok =
+      SUCCESS_STATUSES.has(workflowStatus) || SUCCESS_STATUSES.has(repoDispatchStatus)
 
     const hint = buildHintFromStatus(workflowStatus, repoDispatchStatus)
 
@@ -157,9 +213,9 @@ async function triggerSync() {
           hint,
           workflowStatus,
           repoDispatchStatus,
-          owner: OWNER,
-          repo: REPO,
-          ref: DEFAULT_REF,
+          owner,
+          repo,
+          ref,
         },
       }
     }
@@ -170,9 +226,9 @@ async function triggerSync() {
         ok: true,
         workflowStatus,
         repoDispatchStatus,
-        owner: OWNER,
-        repo: REPO,
-        ref: DEFAULT_REF,
+        owner,
+        repo,
+        ref,
         hint,
       },
     }
@@ -189,7 +245,7 @@ async function triggerSync() {
   }
 }
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST')
     res.setHeader('Cache-Control', 'no-store') // SYNC WIRING
@@ -215,4 +271,18 @@ export default async function handler(req, res) {
 
   const result = await triggerSync()
   res.status(result.status).json(result.body)
+}
+
+module.exports = handler
+module.exports.default = handler
+module.exports.triggerSync = triggerSync
+module.exports.__internals = {
+  parseCookies,
+  timingSafeEqual,
+  verifyCsrfToken,
+  isSameOrigin,
+  buildHintFromStatus,
+  resolveRepoInfo,
+  resolveRef,
+  resolveGithubToken,
 }

--- a/docs/sync-now-troubleshooting.md
+++ b/docs/sync-now-troubleshooting.md
@@ -1,0 +1,23 @@
+# Sync Now Deep Dive
+
+## Observed behaviour
+
+- Admin "Sync now" button triggered `/api/sync-now` but GitHub never received a `workflow_dispatch` event.
+- CI smoke test attempted to import the API module and failed because the file used ESM syntax without a compatible CommonJS export.
+- API responses returned `Missing GH_TOKEN environment variable.` even when `GITHUB_TOKEN` was configured in Vercel.
+
+## Root causes
+
+1. **Token lookup was too narrow.** The API only checked `GH_TOKEN`, so environments that used `GITHUB_TOKEN` never authenticated.
+2. **Repository metadata resolution was incomplete.** Only split owner/name variables were supported, but the rest of the codebase relies on the combined `GITHUB_REPO` form. As a result the manual sync silently failed to build a valid GitHub API URL.
+3. **Module format mismatch in tests.** The API file used ES module syntax while the Node.js smoke test suite runs under CommonJS. CI imported the file to unit-test `triggerSync` and crashed before executing any assertions.
+4. **Ref detection missed common CI variables.** Workflows triggered from branches exposed only `GITHUB_REF`/`GITHUB_HEAD_REF`, so the dispatch defaulted to `main` and ignored the active branch.
+
+## Fix strategy (single task)
+
+- Add resilient helpers in `/api/sync-now.js` to resolve the repo owner/name, Git ref, and GitHub token from every supported environment variable (`GH_TOKEN`, `GITHUB_TOKEN`, `GITHUB_REPO`, `GITHUB_REPOSITORY`, etc.).
+- Convert the API route to CommonJS, expose the handler as both the default export and `module.exports`, and surface `triggerSync` for tests.
+- Rework the tests to run under Node's test runner (`tests/sync-now.test.cjs`) so the smoke job can assert success paths without syntax errors.
+- Document the manual sync requirements (`GITHUB_TOKEN`/`GH_TOKEN`, `SYNC_SECRET`) in `README.md` for future deploys.
+
+With these updates the admin button immediately reaches GitHub using the configured branch and the smoke test suite exercises the new logic without import failures.

--- a/tests/sync-now.test.cjs
+++ b/tests/sync-now.test.cjs
@@ -1,0 +1,141 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+function patchEnv(overrides) {
+  const previous = {}
+  const keys = Object.keys(overrides)
+  for (const key of keys) {
+    previous[key] = Object.prototype.hasOwnProperty.call(process.env, key)
+      ? process.env[key]
+      : undefined
+    const value = overrides[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+  return () => {
+    for (const key of keys) {
+      const original = previous[key]
+      if (original === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = original
+      }
+    }
+  }
+}
+
+function loadSyncModule() {
+  const modulePath = path.join(__dirname, '..', 'api', 'sync-now.js')
+  delete require.cache[require.resolve(modulePath)]
+  return require(modulePath)
+}
+
+test('triggerSync reports missing token with hint', async (t) => {
+  const restoreEnv = patchEnv({
+    GH_TOKEN: '',
+    GITHUB_TOKEN: '',
+    PERSONAL_GITHUB_TOKEN: undefined,
+    GITHUB_PERSONAL_TOKEN: undefined,
+    GITHUB_REPO: 'northside/site',
+  })
+  t.after(restoreEnv)
+
+  const { triggerSync } = loadSyncModule()
+  const result = await triggerSync()
+
+  assert.equal(result.status, 500)
+  assert.equal(result.body.ok, false)
+  assert.match(result.body.hint, /GH_TOKEN/)
+})
+
+test('triggerSync fails fast when repo metadata missing', async (t) => {
+  const restoreEnv = patchEnv({
+    GH_TOKEN: 'abc123',
+    GITHUB_TOKEN: undefined,
+    GITHUB_REPO: undefined,
+    GITHUB_REPO_OWNER: undefined,
+    GITHUB_REPO_NAME: undefined,
+    VERCEL_GIT_REPO_OWNER: undefined,
+    VERCEL_GIT_REPO_SLUG: undefined,
+  })
+  t.after(restoreEnv)
+
+  const { triggerSync } = loadSyncModule()
+  const result = await triggerSync()
+
+  assert.equal(result.status, 500)
+  assert.equal(result.body.ok, false)
+  assert.match(result.body.hint, /owner\/name/)
+})
+
+test('triggerSync dispatches using fallback env vars', async (t) => {
+  const restoreEnv = patchEnv({
+    GH_TOKEN: '',
+    GITHUB_TOKEN: 'token-from-github',
+    GITHUB_REPO: 'northsidegta/site',
+    GITHUB_REF_NAME: '',
+    GITHUB_HEAD_REF: '',
+    GITHUB_REF: 'refs/heads/release',
+    VERCEL_GIT_COMMIT_REF: '',
+  })
+  t.after(restoreEnv)
+
+  const calls = []
+  const originalFetch = global.fetch
+  global.fetch = async (url, init = {}) => {
+    calls.push({ url, init })
+    return {
+      status: 204,
+      text: async () => '',
+    }
+  }
+  t.after(() => {
+    global.fetch = originalFetch
+  })
+
+  const { triggerSync } = loadSyncModule()
+  const result = await triggerSync()
+
+  assert.equal(result.status, 200)
+  assert.equal(result.body.ok, true)
+  assert.equal(result.body.ref, 'release')
+  assert.equal(result.body.owner, 'northsidegta')
+  assert.equal(result.body.repo, 'site')
+  assert.equal(calls.length, 2)
+
+  const workflowCall = calls[0]
+  assert.ok(workflowCall.url.includes('/actions/workflows/events-sync.yml/dispatches'))
+  const payload = JSON.parse(workflowCall.init.body)
+  assert.equal(payload.ref, 'release')
+  assert.equal(workflowCall.init.headers.Authorization, 'Bearer token-from-github')
+})
+
+test('resolveRef defaults to main when candidates empty', (t) => {
+  const restoreEnv = patchEnv({
+    GITHUB_REF: '',
+    GITHUB_REF_NAME: '',
+    GITHUB_HEAD_REF: '',
+    VERCEL_GIT_COMMIT_REF: '',
+  })
+  t.after(restoreEnv)
+
+  const { __internals } = loadSyncModule()
+  assert.equal(__internals.resolveRef(), 'main')
+})
+
+test('resolveRef strips refs/heads prefix', (t) => {
+  const restoreEnv = patchEnv({
+    GITHUB_REF: 'refs/heads/feature/test',
+    GITHUB_REF_NAME: '',
+    GITHUB_HEAD_REF: '',
+    VERCEL_GIT_COMMIT_REF: '',
+  })
+  t.after(restoreEnv)
+
+  const { __internals } = loadSyncModule()
+  assert.equal(__internals.resolveRef(), 'feature/test')
+})


### PR DESCRIPTION
## Summary
- convert /api/sync-now.js to CommonJS and add resilient helpers for repo, ref, and token resolution
- add smoke-test coverage for triggerSync and document manual sync requirements/troubleshooting
- record the deep-dive findings so future deploys can validate the setup quickly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68efeaaac9548324b28ac28b04d4a1f7