### PR TITLE
Add event sync recovery tooling and IPv4 networking shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If the GitHub variables are missing, publish/unpublish buttons will be disabled 
 - Outputs to `public/data/events/`.
 - Preserves `status`, `hidden`, and `archived`; does not delete files.
 - Commits only when changes exist (which triggers a redeploy).
+- Recovery workflow: see [`docs/events-sync-recovery.md`](docs/events-sync-recovery.md) for the connectivity probe, audit, and end-to-end backfill instructions.
 - To change the time, edit `.github/workflows/daily-events-sync.yml`.
 - When changes occur, the sync writes `public/data/events/_sync-summary.json` so the admin page and commit messages can surface
   +new/updated counts.

--- a/docs/events-sync-recovery.md
+++ b/docs/events-sync-recovery.md
@@ -1,0 +1,70 @@
+# Event sync recovery runbook
+
+This runbook coordinates the steps required to restore the daily event ingestion pipeline after an outage. It is designed to be executed as a single task so that we can validate connectivity, audit sources, and repopulate the CMS in one pass.
+
+## Overview of the recovery workflow
+
+1. **Connectivity probe** – Confirms that GitHub Actions (or any automation runner) can reach every configured feed and records the responses under `logs/connectivity_*.json`.
+2. **Source audit** – Re-runs the existing `events-cli` audit to capture detailed fetch/parse diagnostics for each source.
+3. **Event sync** – Invokes `scripts/sync-events.mjs` with `EVENTS_SYNC_WRITE=true` to backfill missing events once connectivity is restored.
+4. **Normalization** – Runs the JSON normalization pass to ensure all event payloads follow the latest formatting rules.
+
+All four stages are orchestrated by `scripts/events-recover.mjs`, which accepts flags to opt-in/out of individual steps.
+
+## Quick start
+
+```sh
+# Dry run: connectivity + audit only
+npm run events:recover
+
+# Full recovery against all feeds (writes to public/data/events)
+npm run events:recover -- --sync
+
+# Restrict to a single feed id
+npm run events:recover -- --feed aurora-special-events --sync
+```
+
+By default the recovery script runs the connectivity probe and the audit. Passing `--sync` enables the write-mode sync and automatically follows up with normalization. Use `--normalize` to force the last step without re-syncing, and `--connectivity-only` if you just want to validate access without touching any other stage.
+
+## Connectivity diagnostics
+
+`scripts/events-connectivity.mjs` powers the first step. It performs lightweight HEAD/GET checks against every configured feed (and HTML fallback where defined) and exits non-zero if any primary feed URL fails. Results are printed as a table and optionally written to JSON when `--json <path>` is supplied – the recovery script handles this automatically.
+
+Key flags:
+
+- `--feed <id>` – Limit the probe to a specific `event-feeds.json` entry (repeatable).
+- `--timeout <ms>` – Override the per-request timeout (defaults to 12 seconds).
+- `--concurrency <n>` – Control how many feeds are checked in parallel.
+
+If you only need the probe you can run it directly:
+
+```sh
+npm run events:connectivity -- --timeout 8000
+```
+
+## Networking safeguards
+
+The sync, ingest, and HTTP helper modules now share a runtime shim (`lib/events/runtime.js`) that:
+
+- Forces Node’s resolver to prefer IPv4 addresses (`dns.setDefaultResultOrder('ipv4first')`) to avoid `ENETUNREACH` failures on environments that expose IPv6 without routing.
+- Installs a global Undici agent pinned to IPv4 with keep-alive enabled so repeated fetches reuse sockets.
+
+This configuration is loaded automatically by the long-running scripts (`sync-events.mjs`, `ingest-events.js`, `lib/events/http-client.js`, and transitively anything using the HTTP client), so no manual action is required before running the recovery workflow.
+
+## Environment checks before syncing
+
+Before executing `npm run events:recover -- --sync` ensure the following secrets are present in GitHub Actions and the Vercel project:
+
+- `SYNC_SECRET`
+- `NEXT_PUBLIC_SYNC_SECRET`
+- `GH_TOKEN`
+- `GITHUB_REPO`
+
+If any secret is missing or rotated, update it in both locations so the daily automation and the `/api/sync-now` endpoint stay in sync.
+
+## After the run
+
+1. Inspect the generated connectivity JSON and the latest audit log under `logs/` for any lingering failures.
+2. Spot check a handful of regenerated files in `public/data/events/` and verify `_sync-summary.json` reflects the expected counts.
+3. Commit any URL discoveries recorded in `logs/events-url-updates.log` if the sync rewrote feed endpoints.
+4. Monitor the next scheduled workflow run – consider wiring the connectivity probe into a scheduled check so network regressions surface before the main sync fails again.

--- a/lib/events/http-client.js
+++ b/lib/events/http-client.js
@@ -1,3 +1,5 @@
+require('./runtime')
+
 const { setTimeout: sleep } = require('timers/promises')
 const { DEFAULT_USER_AGENT, MAX_RESPONSE_BYTES, MAX_HTTP_RETRIES, HTTP_TIMEOUT_MS } = require('./constants')
 

--- a/lib/events/runtime.js
+++ b/lib/events/runtime.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const dns = require('node:dns')
+const { Agent, getGlobalDispatcher, setGlobalDispatcher } = require('undici')
+
+let configured = false
+
+function configureNetworking() {
+  if (configured) return
+
+  if (typeof dns.setDefaultResultOrder === 'function') {
+    try {
+      dns.setDefaultResultOrder('ipv4first')
+    } catch (error) {
+      if (process.env.DEBUG?.includes('events-runtime')) {
+        console.warn('[events:runtime] Failed to set default DNS result order:', error.message)
+      }
+    }
+  }
+
+  try {
+    const previous = getGlobalDispatcher()
+    const agent = new Agent({
+      keepAliveTimeout: 15_000,
+      keepAliveMaxTimeout: 30_000,
+      connections: 50,
+      connect: {
+        family: 4,
+        lookup: dns.lookup,
+      },
+    })
+
+    if (previous !== agent) {
+      setGlobalDispatcher(agent)
+    }
+  } catch (error) {
+    if (process.env.DEBUG?.includes('events-runtime')) {
+      console.warn('[events:runtime] Failed to configure global dispatcher:', error.message)
+    }
+  }
+
+  configured = true
+}
+
+configureNetworking()
+
+module.exports = {
+  configureNetworking,
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "generate:curated": "node scripts/generate-curated-html.js",
     "ingest:events": "node scripts/ingest-events.js",
     "events:backfill-daily": "node scripts/backfill-daily-schedule.mjs",
+    "events:connectivity": "node scripts/events-connectivity.mjs",
     "events:audit": "node scripts/events-cli.mjs --audit",
+    "events:recover": "node scripts/events-recover.mjs",
     "events:normalize": "node scripts/events-normalize.mjs",
     "test": "node --test"
   },

--- a/scripts/events-connectivity.mjs
+++ b/scripts/events-connectivity.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+import '../lib/events/runtime.js'
+
+import fs from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDir = path.resolve(__dirname, '..')
+const configPath = path.join(rootDir, 'config', 'event-feeds.json')
+const logsDir = path.join(rootDir, 'logs')
+
+const DEFAULT_TIMEOUT_MS = 12000
+const DEFAULT_CONCURRENCY = 4
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2))
+  const feeds = await loadFeeds(options)
+  if (!feeds.length) {
+    console.log('[events-connectivity] No feeds matched the requested filters.')
+    return
+  }
+
+  const results = await runWithConcurrency(feeds, options.concurrency, async (feed) => {
+    return probeFeed(feed, options)
+  })
+
+  const summaryRows = results.map((record) => toSummaryRow(record))
+  if (summaryRows.length) {
+    console.table(summaryRows)
+  }
+
+  if (options.outputPath) {
+    await persistResults(options.outputPath, results)
+  }
+
+  const failed = results.filter((record) => record.primary.ok !== true)
+  if (failed.length) {
+    console.error(`\n[events-connectivity] ${failed.length} feed(s) failed connectivity checks.`)
+    process.exitCode = 1
+  } else {
+    console.log('\n[events-connectivity] All feeds responded successfully.')
+  }
+}
+
+function parseArguments(args) {
+  const feeds = new Set()
+  const options = {
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    concurrency: DEFAULT_CONCURRENCY,
+    outputPath: null,
+    feeds,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    }
+    if (arg.startsWith('--timeout=')) {
+      options.timeoutMs = parseInt(arg.split('=')[1], 10) || DEFAULT_TIMEOUT_MS
+      continue
+    }
+    if (arg === '--timeout') {
+      options.timeoutMs = parseInt(args[index + 1], 10) || DEFAULT_TIMEOUT_MS
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--concurrency=')) {
+      options.concurrency = Math.max(1, parseInt(arg.split('=')[1], 10) || DEFAULT_CONCURRENCY)
+      continue
+    }
+    if (arg === '--concurrency') {
+      options.concurrency = Math.max(1, parseInt(args[index + 1], 10) || DEFAULT_CONCURRENCY)
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--json=')) {
+      options.outputPath = resolveOutputPath(arg.split('=')[1])
+      continue
+    }
+    if (arg === '--json') {
+      options.outputPath = resolveOutputPath(args[index + 1])
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--feed=')) {
+      feeds.add(arg.split('=')[1])
+      continue
+    }
+    if (arg === '--feed') {
+      feeds.add(args[index + 1])
+      index += 1
+      continue
+    }
+  }
+
+  if (process.env.EVENTS_CONNECTIVITY_TIMEOUT) {
+    options.timeoutMs = parseInt(process.env.EVENTS_CONNECTIVITY_TIMEOUT, 10) || options.timeoutMs
+  }
+  if (process.env.EVENTS_CONNECTIVITY_CONCURRENCY) {
+    options.concurrency = Math.max(
+      1,
+      parseInt(process.env.EVENTS_CONNECTIVITY_CONCURRENCY, 10) || options.concurrency
+    )
+  }
+
+  return options
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/events-connectivity.mjs [options]\n\n` +
+    `Options:\n` +
+    `  --feed <id>           Restrict checks to a specific feed (can be repeated)\n` +
+    `  --timeout <ms>        Override the per-request timeout (default ${DEFAULT_TIMEOUT_MS}ms)\n` +
+    `  --concurrency <n>     Number of parallel requests (default ${DEFAULT_CONCURRENCY})\n` +
+    `  --json <path>         Write the raw results to a JSON file\n` +
+    `  -h, --help            Show this help message\n`)
+}
+
+function resolveOutputPath(value) {
+  if (!value) return null
+  if (path.isAbsolute(value)) return value
+  return path.join(logsDir, value)
+}
+
+async function loadFeeds(options) {
+  const raw = await fs.readFile(configPath, 'utf8').catch(() => '[]')
+  const feeds = JSON.parse(raw)
+  const requested = Array.from(options.feeds).filter(Boolean)
+  if (!requested.length) return feeds
+  return feeds.filter((feed) => {
+    if (!feed) return false
+    if (requested.includes(feed.id)) return true
+    if (requested.includes(feed.url)) return true
+    return false
+  })
+}
+
+async function runWithConcurrency(items, concurrency, worker) {
+  const results = new Array(items.length)
+  let cursor = 0
+
+  async function runNext() {
+    const current = cursor
+    cursor += 1
+    if (current >= items.length) {
+      return
+    }
+    try {
+      results[current] = await worker(items[current], current)
+    } catch (error) {
+      results[current] = { error: error.message || String(error) }
+    }
+    await runNext()
+  }
+
+  const runners = []
+  const limit = Math.min(concurrency || 1, items.length || 0)
+  for (let index = 0; index < limit; index += 1) {
+    runners.push(runNext())
+  }
+
+  await Promise.all(runners)
+  return results
+}
+
+async function probeFeed(feed, options) {
+  const candidates = buildCandidateUrls(feed)
+  const checks = []
+  for (const candidate of candidates) {
+    const result = await checkUrl(candidate.url, {
+      timeoutMs: options.timeoutMs,
+      method: candidate.method,
+    })
+    checks.push({ ...result, role: candidate.role })
+    if (candidate.role === 'primary' && result.ok) {
+      break
+    }
+  }
+
+  const primary = checks.find((entry) => entry.role === 'primary') || {
+    ok: false,
+    status: null,
+    error: 'no_primary_url',
+  }
+
+  return {
+    id: feed.id || '',
+    url: feed.url || '',
+    name: feed.sourceName || '',
+    town: feed.town || '',
+    type: (feed.type || feed.parser || '').toString(),
+    primary,
+    checks,
+  }
+}
+
+function buildCandidateUrls(feed) {
+  const urls = []
+  if (feed?.url) {
+    urls.push({ role: 'primary', url: resolveUrl(feed.url, feed), method: 'HEAD' })
+  }
+  const fallback = feed?.html?.url || feed?.sourceUrl
+  if (fallback) {
+    urls.push({ role: 'fallback', url: resolveUrl(fallback, feed), method: 'HEAD' })
+  }
+  return urls.filter((entry, index, list) => {
+    const key = `${entry.role}:${entry.url}`
+    return list.findIndex((item) => `${item.role}:${item.url}` === key) === index
+  })
+}
+
+function resolveUrl(value, feed) {
+  if (!value) return ''
+  if (/^https?:/i.test(value)) return value
+  if (feed && feed.url && /^https?:/i.test(feed.url)) {
+    try {
+      const resolved = new URL(value, feed.url)
+      return resolved.toString()
+    } catch (error) {
+      return value
+    }
+  }
+  return value
+}
+
+async function checkUrl(url, options = {}) {
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS
+  const method = options.method || 'HEAD'
+  const startedAt = Date.now()
+  const result = {
+    url,
+    method,
+    ok: false,
+    status: null,
+    elapsedMs: 0,
+    error: null,
+    headers: {},
+  }
+
+  if (!url) {
+    result.error = 'missing_url'
+    return result
+  }
+
+  const controller = createAbortController(timeoutMs)
+  const init = {
+    method,
+    redirect: 'follow',
+    signal: controller.signal,
+  }
+
+  try {
+    const response = await fetch(url, init)
+    result.status = response.status
+    result.ok = response.ok || (response.status >= 200 && response.status < 400)
+    result.headers = captureHeaders(response.headers)
+    result.elapsedMs = Date.now() - startedAt
+
+    if (!result.ok && method === 'HEAD' && response.status === 405) {
+      return checkUrl(url, { ...options, method: 'GET' })
+    }
+
+    if (response.body && typeof response.body.cancel === 'function') {
+      try {
+        await response.body.cancel()
+      } catch (error) {
+        // ignore cancellation errors
+      }
+    }
+  } catch (error) {
+    result.ok = false
+    result.status = null
+    result.error = error.code || error.name || error.message || 'fetch_failed'
+    result.elapsedMs = Date.now() - startedAt
+    if (method === 'HEAD') {
+      return checkUrl(url, { ...options, method: 'GET' })
+    }
+  } finally {
+    controller.cleanup?.()
+  }
+
+  return result
+}
+
+function createAbortController(timeoutMs) {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    const timeoutSignal = AbortSignal.timeout(timeoutMs)
+    const controller = { signal: timeoutSignal, cleanup: () => {} }
+    return controller
+  }
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timer),
+  }
+}
+
+function captureHeaders(headers) {
+  const result = {}
+  if (!headers || typeof headers.forEach !== 'function') {
+    return result
+  }
+  headers.forEach((value, key) => {
+    result[key] = value
+  })
+  return result
+}
+
+function toSummaryRow(record) {
+  const primary = record.primary || {}
+  return {
+    feed: record.id || record.url || '(unknown)',
+    town: record.town || '',
+    status: primary.status ?? 'ERR',
+    ok: primary.ok === true ? 'yes' : 'no',
+    ms: primary.elapsedMs || 0,
+    error: primary.error || '',
+  }
+}
+
+async function persistResults(outputPath, results) {
+  const target = outputPath.endsWith('.json') ? outputPath : `${outputPath}.json`
+  await fs.mkdir(path.dirname(target), { recursive: true })
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    results,
+  }
+  await fs.writeFile(target, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+  console.log(`[events-connectivity] Wrote results to ${path.relative(process.cwd(), target)}`)
+}
+
+main().catch((error) => {
+  console.error('[events-connectivity] Unhandled error:', error)
+  process.exit(1)
+})

--- a/scripts/events-recover.mjs
+++ b/scripts/events-recover.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import '../lib/events/runtime.js'
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { spawn } from 'child_process'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDir = path.resolve(__dirname, '..')
+const logsDir = path.join(rootDir, 'logs')
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2))
+  const steps = []
+
+  if (options.runConnectivity) {
+    const jsonPath = path.join(logsDir, `connectivity_${timestamp()}.json`)
+    const args = [path.join('scripts', 'events-connectivity.mjs'), '--json', jsonPath]
+    for (const feed of options.feeds) {
+      args.push('--feed', feed)
+    }
+    steps.push({
+      name: 'Connectivity probe',
+      command: process.execPath,
+      args,
+      env: {},
+    })
+  }
+
+  if (options.runAudit) {
+    steps.push({
+      name: 'Source audit',
+      command: process.execPath,
+      args: [path.join('scripts', 'events-cli.mjs'), '--audit'],
+      env: {},
+    })
+  }
+
+  if (options.runSync) {
+    const env = {
+      EVENTS_SYNC_WRITE: 'true',
+    }
+    if (options.feedForSync) {
+      env.EVENTS_SYNC_FEED = options.feedForSync
+    }
+    steps.push({
+      name: 'Event sync',
+      command: process.execPath,
+      args: [path.join('scripts', 'sync-events.mjs')],
+      env,
+    })
+  }
+
+  if (options.runNormalize) {
+    steps.push({
+      name: 'Normalization',
+      command: process.execPath,
+      args: [path.join('scripts', 'events-normalize.mjs')],
+      env: {},
+    })
+  }
+
+  if (!steps.length) {
+    console.log('[events-recover] Nothing to do. Use --connectivity, --audit, or --sync to enable steps.')
+    return
+  }
+
+  for (const step of steps) {
+    console.log(`\n[events-recover] Running step: ${step.name}`)
+    await runStep(step)
+  }
+
+  console.log('\n[events-recover] All requested steps completed.')
+}
+
+function parseArguments(args) {
+  const options = {
+    runConnectivity: true,
+    runAudit: true,
+    runSync: false,
+    runNormalize: false,
+    feeds: [],
+    feedForSync: null,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    }
+    if (arg === '--connectivity-only') {
+      options.runAudit = false
+      options.runSync = false
+      options.runNormalize = false
+      continue
+    }
+    if (arg === '--skip-connectivity') {
+      options.runConnectivity = false
+      continue
+    }
+    if (arg === '--skip-audit') {
+      options.runAudit = false
+      continue
+    }
+    if (arg === '--sync' || arg === '--execute-sync') {
+      options.runSync = true
+      continue
+    }
+    if (arg === '--normalize') {
+      options.runNormalize = true
+      continue
+    }
+    if (arg.startsWith('--feed=')) {
+      options.feeds.push(arg.split('=')[1])
+      continue
+    }
+    if (arg === '--feed') {
+      options.feeds.push(args[index + 1])
+      index += 1
+      continue
+    }
+  }
+
+  if (options.runSync) {
+    options.feedForSync = options.feeds[0] || null
+    if (!options.runNormalize) {
+      options.runNormalize = true
+    }
+  }
+
+  return options
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/events-recover.mjs [options]\n\n` +
+    `Options:\n` +
+    `  --connectivity-only   Only run the connectivity probe\n` +
+    `  --skip-connectivity   Skip the connectivity probe\n` +
+    `  --skip-audit          Skip the source audit\n` +
+    `  --sync                Run the event sync with write mode enabled\n` +
+    `  --normalize           Force normalization even without --sync\n` +
+    `  --feed <id>           Restrict connectivity (and sync) to a specific feed\n` +
+    `  -h, --help            Show this help message\n`)
+}
+
+async function runStep(step) {
+  const mergedEnv = { ...process.env, ...step.env }
+  await new Promise((resolve, reject) => {
+    const child = spawn(step.command, step.args, {
+      cwd: rootDir,
+      stdio: 'inherit',
+      env: mergedEnv,
+    })
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`${step.name || 'Step'} failed with exit code ${code}`))
+      }
+    })
+    child.on('error', (error) => reject(error))
+  })
+}
+
+function timestamp() {
+  const now = new Date()
+  const pad = (value) => String(value).padStart(2, '0')
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}`
+}
+
+main().catch((error) => {
+  console.error('[events-recover] Unhandled error:', error.message || error)
+  process.exit(1)
+})

--- a/scripts/ingest-events.js
+++ b/scripts/ingest-events.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+require('../lib/events/runtime')
+
 const fs = require('fs')
 const path = require('path')
 const Parser = require('rss-parser')

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import '../lib/events/runtime.js'
+
 import fs from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'


### PR DESCRIPTION
## Summary
- add a shared runtime shim that pins Undici to IPv4 and loads it in the sync, ingest, and HTTP helper paths to avoid ENETUNREACH failures
- add connectivity probe and recovery orchestration scripts with npm shortcuts so the whole remediation plan can run as one task
- document the recovery workflow and link it from the README for easy discovery

## Testing
- node scripts/events-connectivity.mjs --help
- node scripts/events-recover.mjs --help

------
https://chatgpt.com/codex/tasks/task_e_68f0d2495cac8324916b5493543e116e