### PR TITLE
Handle sync workflow fallback for missing branch

### DIFF
--- a/api/sync-now.js
+++ b/api/sync-now.js
@@ -2,11 +2,13 @@
 const crypto = require('node:crypto')
 
 const {
+  DEFAULT_SYNC_REF,
   getGithubEnvConfig,
   getGithubSyncCapability,
 } = require('../lib/github-admin.js')
 
 const WORKFLOW_FILE = '.github/workflows/events-sync.yml'
+const DEFAULT_DISPATCH_REF = DEFAULT_SYNC_REF || 'main'
 const CSRF_COOKIE = 'sync_now_csrf' // SYNC WIRING
 const SUCCESS_STATUSES = new Set([200, 201, 202, 204])
 
@@ -102,6 +104,56 @@ function buildHintFromStatus(workflowStatus, repoDispatchStatus) {
 }
 
 // SYNC WIRING
+async function fetchDefaultBranch(owner, repo, headers) {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+      method: 'GET',
+      headers: { ...headers },
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const data = await response.json().catch(() => null)
+    const branch = typeof data?.default_branch === 'string' ? data.default_branch.trim() : ''
+    return branch || null
+  } catch (error) {
+    console.warn('[sync-now] failed to resolve repository default branch', error)
+    return null
+  }
+}
+
+function summarizeDispatch(workflowResponse, repoDispatchResponse) {
+  const workflowStatus = workflowResponse.status
+  const repoDispatchStatus = repoDispatchResponse.status
+  const ok =
+    SUCCESS_STATUSES.has(workflowStatus) || SUCCESS_STATUSES.has(repoDispatchStatus)
+  const hint = buildHintFromStatus(workflowStatus, repoDispatchStatus)
+
+  return { workflowStatus, repoDispatchStatus, ok, hint }
+}
+
+async function performDispatch({ owner, repo, ref, headers }) {
+  const workflowUrl = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${WORKFLOW_FILE}/dispatches`
+  const dispatchUrl = `https://api.github.com/repos/${owner}/${repo}/dispatches`
+
+  const [workflowResponse, repoDispatchResponse] = await Promise.all([
+    fetch(workflowUrl, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ref }),
+    }),
+    fetch(dispatchUrl, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event_type: 'sync_now' }),
+    }),
+  ])
+
+  return { workflowResponse, repoDispatchResponse }
+}
+
 async function triggerSync() {
   const envConfig = getGithubEnvConfig()
   const capability = getGithubSyncCapability()
@@ -139,34 +191,47 @@ async function triggerSync() {
     }
   }
 
-  const headers = {
+  const authHeaders = {
     Authorization: `Bearer ${token}`,
     Accept: 'application/vnd.github+json',
     'X-GitHub-Api-Version': '2022-11-28',
-    'Content-Type': 'application/json',
   }
 
-  const workflowUrl = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${WORKFLOW_FILE}/dispatches`
-  const dispatchUrl = `https://api.github.com/repos/${owner}/${repo}/dispatches`
+  let activeRef = ref
 
   try {
-    const [workflowResponse, repoDispatchResponse] = await Promise.all([
-      fetch(workflowUrl, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({ ref }),
-      }),
-      fetch(dispatchUrl, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({ event_type: 'sync_now' }),
-      }),
-    ])
+    let { workflowResponse, repoDispatchResponse } = await performDispatch({
+      owner,
+      repo,
+      ref: activeRef,
+      headers: authHeaders,
+    })
 
-    const workflowStatus = workflowResponse.status
-    const repoDispatchStatus = repoDispatchResponse.status
-    const ok = SUCCESS_STATUSES.has(workflowStatus) || SUCCESS_STATUSES.has(repoDispatchStatus)
-    const hint = buildHintFromStatus(workflowStatus, repoDispatchStatus)
+    let { workflowStatus, repoDispatchStatus, ok, hint } = summarizeDispatch(
+      workflowResponse,
+      repoDispatchResponse
+    )
+
+    if (workflowStatus === 404) {
+      const repoDefaultBranch =
+        (await fetchDefaultBranch(owner, repo, authHeaders)) || DEFAULT_DISPATCH_REF
+      if (repoDefaultBranch && repoDefaultBranch !== activeRef) {
+        console.info(
+          `[sync-now] workflow not found on ${activeRef}, retrying with ${repoDefaultBranch}`
+        )
+        activeRef = repoDefaultBranch
+        ;({ workflowResponse, repoDispatchResponse } = await performDispatch({
+          owner,
+          repo,
+          ref: activeRef,
+          headers: authHeaders,
+        }))
+        ;({ workflowStatus, repoDispatchStatus, ok, hint } = summarizeDispatch(
+          workflowResponse,
+          repoDispatchResponse
+        ))
+      }
+    }
 
     if (!ok) {
       const workflowError = await workflowResponse.text().catch(() => '')
@@ -187,7 +252,7 @@ async function triggerSync() {
           repoDispatchStatus,
           owner,
           repo,
-          ref,
+          ref: activeRef,
         },
       }
     }
@@ -200,7 +265,7 @@ async function triggerSync() {
         repoDispatchStatus,
         owner,
         repo,
-        ref,
+        ref: activeRef,
         hint,
       },
     }
@@ -214,7 +279,7 @@ async function triggerSync() {
         hint: 'Network error while contacting GitHub. Try again in a moment.',
         owner,
         repo,
-        ref,
+        ref: activeRef,
       },
     }
   }

--- a/lib/github-admin.js
+++ b/lib/github-admin.js
@@ -607,6 +607,7 @@ async function deleteEventsFromGithub(slugs) {
 }
 
 module.exports = {
+  DEFAULT_SYNC_REF,
   getGithubEnvConfig,
   getGithubSyncCapability,
   isGithubConfigured,

--- a/tests/sync-now.test.cjs
+++ b/tests/sync-now.test.cjs
@@ -63,6 +63,29 @@ function createMockRes() {
   }
 }
 
+function createMockResponse(status, body) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    async text() {
+      if (body === undefined) return ''
+      if (typeof body === 'string') return body
+      return JSON.stringify(body)
+    },
+    async json() {
+      if (body === undefined) return undefined
+      if (typeof body === 'string') {
+        try {
+          return JSON.parse(body)
+        } catch (error) {
+          return undefined
+        }
+      }
+      return body
+    },
+  }
+}
+
 test('sync-now handler exists and is a function', async () => {
   const handler = await loadSyncHandler()
   assert.equal(typeof handler, 'function')
@@ -125,4 +148,77 @@ test('POST /api/sync-now fails fast when repository metadata is missing', async 
       assert.match(res.body?.hint || '', /owner|repo|token/i)
     }
   )
+})
+
+test('POST /api/sync-now retries using the default branch when workflow is missing on ref', async () => {
+  const secret = 'sync-secret'
+  const originalFetch = global.fetch
+
+  try {
+    await withEnv(
+      {
+        SYNC_SECRET: secret,
+        GITHUB_REPO: 'FinallyHomeAgents/northsidegta-site',
+        GITHUB_TOKEN: 'gh-token',
+        VERCEL_GIT_COMMIT_REF: 'preview-branch',
+      },
+      async () => {
+        let workflowDispatchCalls = 0
+        let repoDispatchCalls = 0
+        let repoInfoCalls = 0
+
+        global.fetch = async (url, options = {}) => {
+          if (
+            url ===
+            'https://api.github.com/repos/FinallyHomeAgents/northsidegta-site/actions/workflows/.github/workflows/events-sync.yml/dispatches'
+          ) {
+            workflowDispatchCalls += 1
+            if (workflowDispatchCalls === 1) {
+              return createMockResponse(404, { message: 'Not Found' })
+            }
+            return createMockResponse(204)
+          }
+
+          if (url === 'https://api.github.com/repos/FinallyHomeAgents/northsidegta-site/dispatches') {
+            repoDispatchCalls += 1
+            return createMockResponse(204)
+          }
+
+          if (url === 'https://api.github.com/repos/FinallyHomeAgents/northsidegta-site') {
+            repoInfoCalls += 1
+            return createMockResponse(200, { default_branch: 'main' })
+          }
+
+          throw new Error(`Unexpected fetch call to ${url}`)
+        }
+
+        const handler = await loadSyncHandler()
+
+        const csrfToken = 'csrf-token'
+        const signature = crypto.createHmac('sha256', secret).update(csrfToken).digest('hex')
+
+        const req = {
+          method: 'POST',
+          headers: {
+            host: 'admin.local',
+            origin: 'https://admin.local',
+            'x-sync-csrf': csrfToken,
+            cookie: `sync_now_csrf=${csrfToken}.${signature}`,
+          },
+        }
+
+        const res = createMockRes()
+        await handler(req, res)
+
+        assert.equal(res.statusCode, 200)
+        assert.equal(res.body?.ok, true)
+        assert.equal(res.body?.ref, 'main')
+        assert.equal(workflowDispatchCalls, 2)
+        assert.equal(repoDispatchCalls, 2)
+        assert.equal(repoInfoCalls, 1)
+      }
+    )
+  } finally {
+    global.fetch = originalFetch
+  }
 })


### PR DESCRIPTION
## Summary
- add a default-branch fallback when triggering the sync workflow so preview refs without the workflow still dispatch
- expose the library default sync ref and reuse it in the API endpoint
- add regression coverage for the fallback logic in the sync-now handler tests

## Testing
- node --test tests/sync-now.test.cjs

------
https://chatgpt.com/codex/tasks/task_e_68f13eacced88324914116916a86d581