### PR TITLE
Add proxy support to events sync runtime

### DIFF
--- a/docs/events-sync-recovery.md
+++ b/docs/events-sync-recovery.md
@@ -48,8 +48,9 @@ The sync, ingest, and HTTP helper modules now share a runtime shim (`lib/events/
 
 - Forces Node’s resolver to prefer IPv4 addresses (`dns.setDefaultResultOrder('ipv4first')`) to avoid `ENETUNREACH` failures on environments that expose IPv6 without routing.
 - Installs a global Undici agent pinned to IPv4 with keep-alive enabled so repeated fetches reuse sockets.
+- Detects standard proxy variables (`HTTPS_PROXY`, `HTTP_PROXY`, or `ALL_PROXY`) and automatically routes requests through the configured proxy. Supply `NO_PROXY` to list domains that should continue to bypass the proxy.
 
-This configuration is loaded automatically by the long-running scripts (`sync-events.mjs`, `ingest-events.js`, `lib/events/http-client.js`, and transitively anything using the HTTP client), so no manual action is required before running the recovery workflow.
+This configuration is loaded automatically by the long-running scripts (`sync-events.mjs`, `ingest-events.js`, `lib/events/http-client.js`, and transitively anything using the HTTP client), so no manual action is required beyond exporting the desired proxy variables before running the recovery workflow.
 
 ## Environment checks before syncing
 

--- a/lib/events/runtime.js
+++ b/lib/events/runtime.js
@@ -1,7 +1,13 @@
 'use strict'
 
 const dns = require('node:dns')
-const { Agent, getGlobalDispatcher, setGlobalDispatcher } = require('undici')
+const {
+  Agent,
+  ProxyAgent,
+  Dispatcher,
+  getGlobalDispatcher,
+  setGlobalDispatcher,
+} = require('undici')
 
 let configured = false
 
@@ -20,18 +26,10 @@ function configureNetworking() {
 
   try {
     const previous = getGlobalDispatcher()
-    const agent = new Agent({
-      keepAliveTimeout: 15_000,
-      keepAliveMaxTimeout: 30_000,
-      connections: 50,
-      connect: {
-        family: 4,
-        lookup: dns.lookup,
-      },
-    })
+    const dispatcher = buildDispatcher()
 
-    if (previous !== agent) {
-      setGlobalDispatcher(agent)
+    if (dispatcher && previous !== dispatcher) {
+      setGlobalDispatcher(dispatcher)
     }
   } catch (error) {
     if (process.env.DEBUG?.includes('events-runtime')) {
@@ -46,4 +44,135 @@ configureNetworking()
 
 module.exports = {
   configureNetworking,
+}
+
+function buildDispatcher() {
+  const directAgent = new Agent({
+    keepAliveTimeout: 15_000,
+    keepAliveMaxTimeout: 30_000,
+    connections: 50,
+    connect: {
+      family: 4,
+      lookup: dns.lookup,
+    },
+  })
+
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy ||
+    process.env.ALL_PROXY ||
+    process.env.all_proxy
+
+  if (!proxyUrl) {
+    return directAgent
+  }
+
+  let proxyAgent
+  try {
+    proxyAgent = new ProxyAgent({
+      uri: proxyUrl,
+      keepAliveTimeout: 15_000,
+      keepAliveMaxTimeout: 30_000,
+      connections: 50,
+    })
+  } catch (error) {
+    if (process.env.DEBUG?.includes('events-runtime')) {
+      console.warn('[events:runtime] Failed to configure proxy agent:', error.message)
+    }
+    return directAgent
+  }
+
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy
+  if (!noProxy) {
+    return proxyAgent
+  }
+
+  return new SelectiveProxyAgent({ proxyAgent, directAgent, noProxy })
+}
+
+class SelectiveProxyAgent extends Dispatcher {
+  constructor({ proxyAgent, directAgent, noProxy }) {
+    super()
+    this.proxyAgent = proxyAgent
+    this.directAgent = directAgent
+    this.rules = parseNoProxy(noProxy)
+  }
+
+  dispatch(options, handler) {
+    const target = extractHostname(options?.origin)
+    if (target && shouldBypassProxy(target, this.rules)) {
+      return this.directAgent.dispatch(options, handler)
+    }
+    return this.proxyAgent.dispatch(options, handler)
+  }
+
+  close() {
+    return Promise.allSettled([this.proxyAgent.close(), this.directAgent.close()]).then(() => undefined)
+  }
+
+  destroy(err) {
+    return Promise.allSettled([this.proxyAgent.destroy(err), this.directAgent.destroy(err)]).then(
+      () => undefined
+    )
+  }
+}
+
+function parseNoProxy(value) {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function shouldBypassProxy(hostname, rules) {
+  if (!rules || !rules.length) return false
+
+  const host = hostname.toLowerCase()
+
+  return rules.some((rule) => {
+    const normalized = rule.toLowerCase()
+    if (normalized === '*') return true
+
+    const [ruleHost, rulePort] = normalized.split(':')
+    const [hostOnly, hostPort] = host.split(':')
+
+    if (rulePort && rulePort !== hostPort) {
+      return false
+    }
+
+    if (ruleHost.startsWith('.')) {
+      const suffix = ruleHost.slice(1)
+      return hostOnly === suffix || hostOnly.endsWith(`.${suffix}`)
+    }
+
+    return hostOnly === ruleHost
+  })
+}
+
+function extractHostname(origin) {
+  if (!origin) return ''
+  try {
+    if (typeof origin === 'string') {
+      const parsed = new URL(origin)
+      return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname
+    }
+    if (typeof origin === 'object') {
+      const protocol = origin.protocol || 'https:'
+      const hostname = origin.hostname || origin.host || origin.servername
+      if (hostname) {
+        const port = origin.port ? `:${origin.port}` : ''
+        return `${hostname}${port}`
+      }
+      if (origin.path) {
+        return new URL(origin.path, `${protocol}//dummy`).hostname
+      }
+    }
+  } catch (error) {
+    if (process.env.DEBUG?.includes('events-runtime')) {
+      console.warn('[events:runtime] Failed to parse origin hostname:', error.message)
+    }
+  }
+  return ''
 }


### PR DESCRIPTION
## Summary
- extend the shared events runtime to honour HTTPS_PROXY/HTTP_PROXY/ALL_PROXY and respect NO_PROXY bypass rules
- document the new proxy support flow in the event sync recovery runbook so operators can export the variables before running jobs

## Testing
- npm run events:connectivity *(fails: outbound network remains blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f1b3b3e5288324808b09ac72eb47b6