### PR TITLE
Keep town insight ratings single column in panel

### DIFF
--- a/src/MapHero.js
+++ b/src/MapHero.js
@@ -1053,7 +1053,11 @@ function TownInsightCard({
           </p>
         )}
 
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div
+          className={`grid grid-cols-1 gap-3 ${
+            isPanel ? "" : "sm:grid-cols-2"
+          }`}
+        >
           {CATEGORY_ORDER.filter(
             (k) => town.ratings && town.ratings[k] != null
           ).map((k) => (


### PR DESCRIPTION
## Summary
- keep the town insight ratings grid to a single column when rendered inside the right-hand panel to avoid cramped layout

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68fa30f934a083249734ca5796db0349