### PR TITLE
Restyle buyers page to match homepage aesthetic

### DIFF
--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -1,6 +1,5 @@
 // src/BuyersPage.js
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import Navigation from "./Navigation";
 import Footer from "./Footer";
@@ -20,52 +19,95 @@ const TOWNS = [
   "None",
 ];
 
-/* ───────── Google-style review slider (kept) ───────── */
+/* ───────── Review slider ───────── */
 function ReviewSlider() {
   const reviews = [
-    { name: "Susan Booth", quote: "“Finally Home Agents exceeded our expectations when selling our home in Holland Landing. Their professionalism and personal attention set them apart.”" },
-    { name: "Logan Abernethy", quote: "“As a first-time buyer I had plenty of questions. Landon was patient and made my experience fantastic.”" },
-    { name: "Jessica Le", quote: "“Landon made renting stress-free. Really nice to work with and very easy to communicate with.”" },
-    { name: "Tessa Conway", quote: "“Landon took all the stress out of renting in a brand-new city — I am forever thankful!”" },
-    { name: "Olivia Oprea", quote: "“Matthew found me my dream home during a crazy market. Wouldn’t have got it without him.”" },
-    { name: "Arron Breen", quote: "“Matt sold our house above market and negotiated our forever home for less. Highly recommend.”" },
+    {
+      name: "Susan Booth",
+      quote:
+        "“Finally Home Agents exceeded our expectations when selling our home in Holland Landing. Their professionalism and personal attention set them apart.”",
+    },
+    {
+      name: "Logan Abernethy",
+      quote:
+        "“As a first-time buyer I had plenty of questions. Landon was patient and made my experience fantastic.”",
+    },
+    {
+      name: "Jessica Le",
+      quote:
+        "“Landon made renting stress-free. Really nice to work with and very easy to communicate with.”",
+    },
+    {
+      name: "Tessa Conway",
+      quote:
+        "“Landon took all the stress out of renting in a brand-new city — I am forever thankful!”",
+    },
+    {
+      name: "Olivia Oprea",
+      quote:
+        "“Matthew found me my dream home during a crazy market. Wouldn’t have got it without him.”",
+    },
+    {
+      name: "Arron Breen",
+      quote:
+        "“Matt sold our house above market and negotiated our forever home for less. Highly recommend.”",
+    },
   ];
-  const [i, setI] = useState(0);
+  const [index, setIndex] = useState(0);
+
   useEffect(() => {
-    const id = setInterval(() => setI((x) => (x + 1) % reviews.length), 6000);
+    const id = setInterval(() => setIndex((x) => (x + 1) % reviews.length), 6000);
     return () => clearInterval(id);
-  }, []);
+  }, [reviews.length]);
+
   return (
-    <div className="rounded-xl border border-gray-200 shadow-sm bg-gray-50 overflow-hidden">
-      <div className="bg-[#4285F4] h-1" />
-      <div className="relative px-4 sm:px-8 py-6 min-h-[180px] sm:min-h-[150px]">
-        {reviews.map((r, idx) => (
-          <div
-            key={idx}
-            className={`absolute inset-0 flex flex-col items-center justify-center text-center transition-opacity duration-700 ${
-              idx === i ? "opacity-100" : "opacity-0"
-            }`}
-          >
-            <div className="flex flex-wrap items-center justify-center gap-2 mb-2">
-              <img
-                src="/Images/google-logo.png"
-                alt="Google"
-                className="h-5 w-5 sm:h-6 sm:w-6 object-contain"
-              />
-              <span className="font-semibold text-xs sm:text-sm text-gray-700 whitespace-nowrap">
-                Finally&nbsp;Home&nbsp;Agents
+    <div className="relative mx-auto max-w-2xl">
+      <div className="pointer-events-none absolute -left-16 top-[-30%] h-40 w-40 rounded-full bg-emerald-400/20 blur-3xl sm:-left-24 sm:h-56 sm:w-56" aria-hidden />
+      <div className="pointer-events-none absolute -right-10 bottom-[-45%] h-48 w-48 rounded-full bg-emerald-500/20 blur-3xl sm:-right-16 sm:h-64 sm:w-64" aria-hidden />
+
+      <div className="relative rounded-[36px] bg-gradient-to-br from-emerald-300/70 via-emerald-400/50 to-emerald-600/60 p-[1.5px] shadow-[0_45px_120px_rgba(4,47,35,0.55)]">
+        <div className="relative overflow-hidden rounded-[32px] border border-white/10 bg-slate-950/80 px-6 py-8 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.25),_transparent_60%)]" aria-hidden />
+
+          <div className="relative z-10">
+            <div className="mb-4 flex flex-wrap items-center justify-center gap-2 text-xs font-semibold uppercase tracking-[0.32em] text-emerald-100">
+              <span className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-3 py-1 text-[11px]">
+                ★★★★★ Google Reviews
               </span>
-              <div className="flex text-[#FBBC05] text-xs sm:text-sm leading-none">
-                {"★★★★★".split("").map((_, s) => (
-                  <span key={s}>★</span>
-                ))}
-              </div>
+              <span className="hidden text-[11px] text-emerald-100/70 sm:inline">NorthSide GTA Buyers</span>
             </div>
-            <p className="italic max-w-xs sm:max-w-md text-xs sm:text-sm">{r.quote}</p>
-            <p className="mt-1 sm:mt-2 font-semibold text-xs sm:text-sm">— {r.name}</p>
-            <p className="text-[10px] sm:text-xs text-gray-500">Verified&nbsp;Client&nbsp;Review</p>
+
+            <div className="relative h-40 sm:h-36">
+              {reviews.map((review, i) => (
+                <div
+                  key={review.name}
+                  className={`absolute inset-0 flex flex-col items-center justify-center gap-3 px-2 transition-opacity duration-700 ease-out ${
+                    i === index ? "opacity-100" : "opacity-0"
+                  }`}
+                >
+                  <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.28em] text-emerald-100/80">
+                    <img src="/Images/google-logo.png" alt="Google" className="h-5 w-5" />
+                    <span>Finally Home Agents</span>
+                  </div>
+                  <p className="max-w-xl text-sm text-emerald-100/90 sm:text-base">{review.quote}</p>
+                  <p className="text-sm font-semibold text-white/90">— {review.name}</p>
+                  <p className="text-[11px] uppercase tracking-[0.3em] text-emerald-100/60">Verified Client Review</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-6 flex items-center justify-center gap-2">
+              {reviews.map((review, i) => (
+                <span
+                  key={review.name}
+                  className={`h-1.5 w-6 rounded-full transition ${
+                    i === index ? "bg-emerald-300" : "bg-white/20"
+                  }`}
+                />
+              ))}
+            </div>
           </div>
-        ))}
+        </div>
       </div>
     </div>
   );
@@ -120,42 +162,36 @@ function ComparisonGrid() {
     "AI-assisted insights tailored to your criteria",
   ];
   return (
-    <div className="rounded-2xl border border-emerald-100 overflow-hidden shadow-sm">
-      <div className="grid md:grid-cols-2">
+    <div className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/5 shadow-[0_45px_130px_rgba(4,47,35,0.5)]">
+      <div className="absolute inset-0 bg-gradient-to-br from-emerald-400/15 via-emerald-500/10 to-emerald-700/5" aria-hidden />
+      <div className="relative z-10 grid overflow-hidden md:grid-cols-2">
         {/* Left: On your own */}
-        <div className="bg-white">
-          <div className="px-5 py-3 border-b flex items-center gap-2">
-            <XIcon className="h-5 w-5 text-rose-600" />
-            <h3 className="uppercase text-[12px] font-semibold tracking-wider text-gray-700">
-              Buying On Your Own
-            </h3>
+        <div className="border-b border-white/10 bg-slate-900/60 backdrop-blur-sm md:border-b-0 md:border-r">
+          <div className="flex items-center gap-2 border-b border-white/10 px-5 py-4 text-rose-200/90">
+            <XIcon className="h-5 w-5" />
+            <h3 className="text-[12px] font-semibold uppercase tracking-[0.28em]">Buying On Your Own</h3>
           </div>
-          <ul className="p-5 space-y-3">
+          <ul className="space-y-3 px-5 py-6">
             {solo.map((t, i) => (
-              <li key={i} className="flex items-start gap-2 text-gray-800">
-                <span className="mt-[6px] h-1.5 w-1.5 rounded-full bg-rose-500/70" />
-                <span className="text-[15px] leading-6">{t}</span>
+              <li key={i} className="flex items-start gap-3 text-sm text-emerald-100/80">
+                <span className="mt-[6px] h-1.5 w-1.5 rounded-full bg-rose-400/80" />
+                <span className="leading-6">{t}</span>
               </li>
             ))}
           </ul>
         </div>
 
         {/* Right: With Finally Home Agents */}
-        <div
-          className="text-white"
-          style={{ background: "linear-gradient(135deg,#31610d 0%, #23470a 100%)" }}
-        >
-          <div className="px-5 py-3 border-b border-white/20 flex items-center gap-2">
-            <CheckIcon className="h-5 w-5 text-white" />
-            <h3 className="uppercase text-[12px] font-semibold tracking-wider">
-              Buying With Finally Home Agents
-            </h3>
+        <div className="bg-gradient-to-br from-emerald-500/40 via-emerald-500/20 to-emerald-600/30">
+          <div className="flex items-center gap-2 border-b border-white/20 px-5 py-4 text-white">
+            <CheckIcon className="h-5 w-5" />
+            <h3 className="text-[12px] font-semibold uppercase tracking-[0.28em]">Buying With Finally Home Agents</h3>
           </div>
-          <ul className="p-5 space-y-3">
+          <ul className="space-y-3 px-5 py-6">
             {withUs.map((t, i) => (
-              <li key={i} className="flex items-start gap-2">
+              <li key={i} className="flex items-start gap-3 text-sm text-white">
                 <span className="mt-[6px] h-1.5 w-1.5 rounded-full bg-white/70" />
-                <span className="text-[15px] leading-6 text-white">{t}</span>
+                <span className="leading-6">{t}</span>
               </li>
             ))}
           </ul>
@@ -199,7 +235,6 @@ function BuyerSignupForm() {
   const utm = useMemo(() => new URLSearchParams(window.location.search), []);
   const device = useMemo(() => (/Mobi/i.test(navigator.userAgent) ? "mobile" : "desktop"), []);
 
-  // Formspree endpoint (use env var if set, fallback to your existing buyers form)
   const formspreeId = useMemo(() => {
     const fromEnv = (process.env.REACT_APP_FORMSPREE_BUYERS_ID || "").trim();
     return fromEnv || "xanbzajw";
@@ -265,19 +300,17 @@ function BuyerSignupForm() {
       setTimeout(() => errorRef.current?.focus(), 0);
       return;
     }
-    if (form.nickname) return; // honeypot
+    if (form.nickname) return;
 
     try {
       setSending(true);
       const endpoint = `https://formspree.io/f/${formspreeId}`;
 
       const payload = {
-        // contact
         first_name: form.firstName.trim(),
         last_name: form.lastName.trim(),
         email: form.email.trim(),
         phone: form.phone.trim(),
-        // buyer basics
         budget_min: form.budgetMin,
         budget_max: form.budgetMax,
         desired_bedrooms: form.bedrooms,
@@ -289,7 +322,6 @@ function BuyerSignupForm() {
         nice_to_haves: form.niceToHaves,
         not_under_contract: form.notUnderContract ? "Yes" : "No",
         consent: form.consent ? "Yes" : "No",
-        // tracking
         utm_source: utm.get("utm_source") || "",
         utm_campaign: utm.get("utm_campaign") || "",
         device,
@@ -329,15 +361,22 @@ function BuyerSignupForm() {
 
   if (done) {
     return (
-      <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-6 shadow-sm">
-        <div className="flex items-center gap-2 text-emerald-800">
-          <CheckIcon className="h-5 w-5" />
-          <h3 className="text-xl font-bold">You’re in — we’ll reach out within 24 hours</h3>
+      <div className="relative overflow-hidden rounded-[36px] border border-white/15 bg-emerald-500/20 p-8 text-white shadow-[0_40px_120px_rgba(4,47,35,0.55)]">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.4),_transparent_65%)]" aria-hidden />
+        <div className="relative z-10 flex flex-col gap-3 text-center sm:text-left">
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-center">
+            <span className="flex h-11 w-11 items-center justify-center rounded-full border border-white/30 bg-white/20">
+              <CheckIcon className="h-6 w-6 text-white" />
+            </span>
+            <h3 className="text-2xl font-semibold tracking-tight">
+              You’re in — we’ll reach out within 24 hours
+            </h3>
+          </div>
+          <p className="text-sm text-emerald-100/90">
+            Thanks! A NorthSide GTA specialist will contact you via email or phone within 24 hours to kick off your personalized town match and search plan.
+          </p>
+          <p className="text-xs uppercase tracking-[0.28em] text-emerald-100/70">No spam. You can unsubscribe anytime.</p>
         </div>
-        <p className="mt-2 text-emerald-900/90">
-          Thanks! A NorthSide GTA specialist will contact you via email or phone within 24 hours to kick off your personalized town match and search plan.
-        </p>
-        <p className="mt-2 text-xs text-emerald-900/80">No spam. You can unsubscribe anytime.</p>
       </div>
     );
   }
@@ -345,346 +384,362 @@ function BuyerSignupForm() {
   return (
     <div
       id="buyers-registration"
-      className="relative overflow-hidden rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-slate-100 p-6 shadow-xl md:p-8"
+      className="relative overflow-hidden rounded-[40px] bg-gradient-to-br from-emerald-400/50 via-emerald-500/35 to-emerald-600/45 p-[1.5px] shadow-[0_55px_140px_rgba(4,47,35,0.55)]"
     >
-      <div className="relative z-10">
-        {/* header strip */}
-        <div className="mb-2 flex items-center gap-2 text-slate-900">
-          <ShieldIcon className="h-5 w-5" />
-          <span className="uppercase tracking-wider text-[11px] font-semibold">
-            Exclusive Buyer Access
-          </span>
-        </div>
-        <h3 className="text-2xl md:text-3xl font-extrabold tracking-tight text-slate-900">
-          Unlock Your Secret Weapon for Buying in the NorthSide GTA
-        </h3>
-        <p className="mt-1 text-slate-800">
-          Tell us a bit more and we’ll tailor your NorthSide GTA Match, strategy, and tours.
-        </p>
+      <div className="relative overflow-hidden rounded-[38px] border border-white/10 bg-slate-900/85 p-6 backdrop-blur-xl md:p-8">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.28),_transparent_65%)]" aria-hidden />
+        <div className="pointer-events-none absolute inset-0 opacity-30 mix-blend-screen" style={{ backgroundImage: "url('/Images/northside-map-grid.png')", backgroundSize: "cover" }} aria-hidden />
 
-        {/* pills */}
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          {[
-            { icon: "⏱️", text: "Takes ~1 minute" },
-            { icon: "✅", text: "No spam, no obligation" },
-            { icon: "🔒", text: "Secure & private" },
-            { icon: "📍", text: "Local market experts" },
-          ].map((p) => (
-            <span
-              key={p.text}
-              className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-[12px] font-semibold text-slate-900 shadow-sm"
-            >
-              <span>{p.icon}</span> {p.text}
+        <div className="relative z-10">
+          <div className="mb-2 flex items-center gap-2 text-emerald-100">
+            <ShieldIcon className="h-5 w-5" />
+            <span className="text-[11px] font-semibold uppercase tracking-[0.34em]">
+              Exclusive Buyer Access
             </span>
-          ))}
-        </div>
+          </div>
+          <h3 className="text-2xl font-extrabold tracking-tight text-white md:text-3xl">
+            Unlock Your Secret Weapon for Buying in the NorthSide GTA
+          </h3>
+          <p className="mt-1 max-w-2xl text-sm text-emerald-100/80 md:text-base">
+            Tell us a bit more and we’ll tailor your NorthSide GTA Match, strategy, and tours.
+          </p>
 
-        {/* progress */}
-        <div className="mt-4">
-          <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200">
-            <div
-              className="h-full bg-slate-900 transition-all"
-              style={{ width: `${progressPct}%` }}
-            />
-          </div>
-          <div className="mt-1 text-right text-[11px] font-medium text-slate-600">
-            {progressPct}% complete
-          </div>
-        </div>
-
-        {/* error */}
-        {error && (
-          <div
-            ref={errorRef}
-            tabIndex={-1}
-            role="alert"
-            aria-live="assertive"
-            className="mt-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700"
-          >
-            {error}
-          </div>
-        )}
-
-        {/* form */}
-        <form onSubmit={onSubmit} className="mt-4 grid grid-cols-1 gap-4">
-          {/* Contact */}
-          <div className="grid md:grid-cols-2 gap-3">
-            <label className="block">
-              <span className="text-sm font-medium">First Name <span className="text-red-500">*</span></span>
-              <input
-                name="firstName"
-                value={form.firstName}
-                onChange={update}
-                className="mt-1 w-full rounded-lg border px-3 py-2 bg-white text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900/20 focus:border-slate-900 border-slate-300"
-                autoComplete="given-name"
-                required
-              />
-            </label>
-            <label className="block">
-              <span className="text-sm font-medium">Last Name <span className="text-red-500">*</span></span>
-              <input
-                name="lastName"
-                value={form.lastName}
-                onChange={update}
-                className="mt-1 w-full rounded-lg border px-3 py-2 bg-white text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900/20 focus:border-slate-900 border-slate-300"
-                autoComplete="family-name"
-                required
-              />
-            </label>
-          </div>
-          <div className="grid md:grid-cols-2 gap-3">
-            <label className="block">
-              <span className="text-sm font-medium">Email <span className="text-red-500">*</span></span>
-              <input
-                name="email"
-                type="email"
-                value={form.email}
-                onChange={update}
-                className={`mt-1 w-full rounded-lg border px-3 py-2 bg-white text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:ring-2 ${
-                  fieldErrors.email
-                    ? "border-red-500 focus:border-red-500 focus:ring-red-400/60"
-                    : "border-slate-300 focus:border-slate-900 focus:ring-slate-900/20"
-                }`}
-                placeholder="you@example.com"
-                autoComplete="email"
-                required
-              />
-              {fieldErrors.email && <p className="mt-1 text-xs text-red-600">{fieldErrors.email}</p>}
-            </label>
-            <label className="block">
-              <span className="text-sm font-medium">Phone <span className="text-red-500">*</span></span>
-              <input
-                name="phone"
-                value={form.phone}
-                onChange={update}
-                className={`mt-1 w-full rounded-lg border px-3 py-2 bg-white text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:ring-2 ${
-                  fieldErrors.phone
-                    ? "border-red-500 focus:border-red-500 focus:ring-red-400/60"
-                    : "border-slate-300 focus:border-slate-900 focus:ring-slate-900/20"
-                }`}
-                placeholder="(###) ###-####"
-                inputMode="tel"
-                autoComplete="tel"
-                required
-              />
-              {fieldErrors.phone && <p className="mt-1 text-xs text-red-600">{fieldErrors.phone}</p>}
-            </label>
-          </div>
-
-          {/* Budget + timeline */}
-          <div className="grid md:grid-cols-[1fr_1fr] gap-3">
-            <label className="block">
-              <span className="text-sm font-medium">Budget (min)</span>
-              <input
-                name="budgetMin"
-                value={form.budgetMin}
-                onChange={update}
-                className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:border-slate-900 focus:ring-2 focus:ring-slate-900/20"
-                placeholder="$800,000"
-                inputMode="decimal"
-                autoComplete="off"
-              />
-            </label>
-            <label className="block">
-              <span className="text-sm font-medium">Budget (max)</span>
-              <input
-                name="budgetMax"
-                value={form.budgetMax}
-                onChange={update}
-                className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:border-slate-900 focus:ring-2 focus:ring-slate-900/20"
-                placeholder="$1,200,000"
-                inputMode="decimal"
-                autoComplete="off"
-              />
-            </label>
-          </div>
-
-          {/* Bedrooms / Bathrooms / Property type */}
-          <div className="grid md:grid-cols-3 gap-3">
-            <label className="block">
-              <span className="text-sm font-medium">Bedrooms (desired)</span>
-              <select
-                name="bedrooms"
-                value={form.bedrooms}
-                onChange={update}
-                className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm focus:outline-none focus:border-slate-900 focus:ring-2 focus:ring-slate-900/20"
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            {[
+              { icon: "⏱️", text: "Takes ~1 minute" },
+              { icon: "✅", text: "No spam, no obligation" },
+              { icon: "🔒", text: "Secure & private" },
+              { icon: "📍", text: "Local market experts" },
+            ].map((p) => (
+              <span
+                key={p.text}
+                className="inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[12px] font-semibold text-white shadow-sm backdrop-blur"
               >
-                <option value="">Select…</option>
-                <option>1</option><option>2</option><option>3</option><option>4</option><option>5+</option>
-              </select>
-            </label>
-            <label className="block">
-              <span className="text-sm font-medium">Bathrooms (desired)</span>
-              <select
-                name="bathrooms"
-                value={form.bathrooms}
-                onChange={update}
-                className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm focus:outline-none focus:border-slate-900 focus:ring-2 focus:ring-slate-900/20"
-              >
-                <option value="">Select…</option>
-                <option>1</option><option>2</option><option>3</option><option>4</option><option>5+</option>
-              </select>
-            </label>
-            <label className="block">
-              <span className="text-sm font-medium">Property type</span>
-              <select
-                name="propertyType"
-                value={form.propertyType}
-                onChange={update}
-                className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm focus:outline-none focus:border-slate-900 focus:ring-2 focus:ring-slate-900/20"
-              >
-                <option value="">Any</option>
-                <option>Detached</option>
-                <option>Semi-Detached</option>
-                <option>Townhouse</option>
-                <option>Condo</option>
-                <option>Rural</option>
-              </select>
-            </label>
+                <span>{p.icon}</span> {p.text}
+              </span>
+            ))}
           </div>
 
-          {/* Timeline */}
-          <div>
-            <span className="block text-sm font-medium">When are you hoping to buy? <span className="text-red-500">*</span></span>
-            <div className="mt-2 grid grid-cols-2 gap-2 text-sm sm:grid-cols-3 md:grid-cols-5">
-              {["Now", "1–3 Months", "4–6 Months", "7–12 Months", "Longer"].map((label) => (
-                <label
-                  key={label}
-                  className={`flex items-center gap-2 rounded-xl border px-3 py-2 whitespace-normal transition ${
-                    form.timeline === label
-                      ? "border-slate-900 bg-white text-slate-900 shadow-sm"
-                      : "border-slate-200 bg-white text-slate-700 hover:border-slate-400"
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="timeline"
-                    value={label}
-                    checked={form.timeline === label}
-                    onChange={update}
-                    className="h-4 w-4 border-slate-300 text-slate-900 focus:ring-slate-900/30"
-                  />
-                  <span className="leading-snug">{label}</span>
-                </label>
-              ))}
+          <div className="mt-4">
+            <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full bg-gradient-to-r from-emerald-300 via-emerald-400 to-emerald-500 transition-all"
+                style={{ width: `${progressPct}%` }}
+              />
+            </div>
+            <div className="mt-1 text-right text-[11px] font-medium text-emerald-100/70">
+              {progressPct}% complete
             </div>
           </div>
 
-          {/* Towns */}
-          <div>
-            <label className="block text-sm font-medium">Which NorthSide GTA towns interest you most?</label>
-            <p className="text-xs text-gray-600 mt-1">Select up to 7.</p>
-            <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
-              {TOWNS.map((town) => {
-                const checked = form.towns.includes(town);
-                return (
+          {error && (
+            <div
+              ref={errorRef}
+              tabIndex={-1}
+              role="alert"
+              aria-live="assertive"
+              className="mt-4 rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100"
+            >
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={onSubmit} className="mt-4 grid grid-cols-1 gap-5">
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="block">
+                <span className="text-sm font-medium text-white">
+                  First Name <span className="text-red-300">*</span>
+                </span>
+                <input
+                  name="firstName"
+                  value={form.firstName}
+                  onChange={update}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-white/95 px-3 py-2 text-slate-900 shadow-lg shadow-emerald-900/10 placeholder-slate-400 focus:outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                  autoComplete="given-name"
+                  required
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-white">
+                  Last Name <span className="text-red-300">*</span>
+                </span>
+                <input
+                  name="lastName"
+                  value={form.lastName}
+                  onChange={update}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-white/95 px-3 py-2 text-slate-900 shadow-lg shadow-emerald-900/10 placeholder-slate-400 focus:outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                  autoComplete="family-name"
+                  required
+                />
+              </label>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="block">
+                <span className="text-sm font-medium text-white">
+                  Email <span className="text-red-300">*</span>
+                </span>
+                <input
+                  name="email"
+                  type="email"
+                  value={form.email}
+                  onChange={update}
+                  className={`mt-1 w-full rounded-lg border px-3 py-2 bg-white text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:ring-2 ${
+                    fieldErrors.email
+                      ? "border-red-400 focus:border-red-400 focus:ring-red-400/60"
+                      : "border-white/10 focus:border-emerald-400 focus:ring-emerald-400/40"
+                  }`}
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  required
+                />
+                {fieldErrors.email && <p className="mt-1 text-xs text-red-200">{fieldErrors.email}</p>}
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-white">
+                  Phone <span className="text-red-300">*</span>
+                </span>
+                <input
+                  name="phone"
+                  value={form.phone}
+                  onChange={update}
+                  className={`mt-1 w-full rounded-lg border px-3 py-2 bg-white text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:ring-2 ${
+                    fieldErrors.phone
+                      ? "border-red-400 focus:border-red-400 focus:ring-red-400/60"
+                      : "border-white/10 focus:border-emerald-400 focus:ring-emerald-400/40"
+                  }`}
+                  placeholder="(###) ###-####"
+                  inputMode="tel"
+                  autoComplete="tel"
+                  required
+                />
+                {fieldErrors.phone && <p className="mt-1 text-xs text-red-200">{fieldErrors.phone}</p>}
+              </label>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="block">
+                <span className="text-sm font-medium text-white">Budget (min)</span>
+                <input
+                  name="budgetMin"
+                  value={form.budgetMin}
+                  onChange={update}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-white/90 px-3 py-2 text-slate-900 shadow-lg shadow-emerald-900/10 placeholder-slate-400 focus:outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                  placeholder="$800,000"
+                  inputMode="decimal"
+                  autoComplete="off"
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-white">Budget (max)</span>
+                <input
+                  name="budgetMax"
+                  value={form.budgetMax}
+                  onChange={update}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-white/90 px-3 py-2 text-slate-900 shadow-lg shadow-emerald-900/10 placeholder-slate-400 focus:outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                  placeholder="$1,200,000"
+                  inputMode="decimal"
+                  autoComplete="off"
+                />
+              </label>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-3">
+              <label className="block">
+                <span className="text-sm font-medium text-white">Bedrooms (desired)</span>
+                <select
+                  name="bedrooms"
+                  value={form.bedrooms}
+                  onChange={update}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-white/95 px-3 py-2 text-slate-900 shadow-lg shadow-emerald-900/10 focus:outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                >
+                  <option value="">Select…</option>
+                  <option>1</option>
+                  <option>2</option>
+                  <option>3</option>
+                  <option>4</option>
+                  <option>5+</option>
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-white">Bathrooms (desired)</span>
+                <select
+                  name="bathrooms"
+                  value={form.bathrooms}
+                  onChange={update}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-white/95 px-3 py-2 text-slate-900 shadow-lg shadow-emerald-900/10 focus:outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                >
+                  <option value="">Select…</option>
+                  <option>1</option>
+                  <option>2</option>
+                  <option>3</option>
+                  <option>4</option>
+                  <option>5+</option>
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-white">Property type</span>
+                <select
+                  name="propertyType"
+                  value={form.propertyType}
+                  onChange={update}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-white/95 px-3 py-2 text-slate-900 shadow-lg shadow-emerald-900/10 focus:outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                >
+                  <option value="">Any</option>
+                  <option>Detached</option>
+                  <option>Semi-Detached</option>
+                  <option>Townhouse</option>
+                  <option>Condo</option>
+                  <option>Rural</option>
+                </select>
+              </label>
+            </div>
+
+            <div>
+              <span className="block text-sm font-medium text-white">
+                When are you hoping to buy? <span className="text-red-300">*</span>
+              </span>
+              <div className="mt-3 grid grid-cols-2 gap-2 text-sm sm:grid-cols-3 md:grid-cols-5">
+                {["Now", "1–3 Months", "4–6 Months", "7–12 Months", "Longer"].map((label, idx) => (
                   <label
-                    key={town}
-                    className={`flex items-center gap-2 rounded-xl border px-3 py-2 text-sm transition ${
-                      checked
-                        ? "border-slate-900 bg-white text-slate-900 shadow-sm"
-                        : "border-slate-200 bg-white text-slate-700 hover:border-slate-400"
+                    key={label}
+                    className={`group flex cursor-pointer items-center gap-2 rounded-2xl border px-3 py-2 transition ${
+                      form.timeline === label
+                        ? "border-white/30 bg-white/15 text-white shadow-lg shadow-emerald-900/30"
+                        : "border-white/10 bg-white/5 text-emerald-100/80 hover:border-white/20 hover:bg-white/10 hover:text-white"
                     }`}
                   >
                     <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={() => toggleTown(town)}
-                      className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900/30"
+                      type="radio"
+                      name="timeline"
+                      value={label}
+                      checked={form.timeline === label}
+                      onChange={update}
+                      required={idx === 0}
+                      className="h-4 w-4 border-white/40 text-emerald-400 focus:ring-emerald-400/60"
                     />
-                    <span>{town}</span>
+                    <span className="leading-snug">{label}</span>
                   </label>
-                );
-              })}
+                ))}
+              </div>
             </div>
-          </div>
 
-          {/* Notes */}
-          <div className="grid md:grid-cols-2 gap-3">
-            <label className="block">
-              <span className="text-sm font-medium">Must-haves <span className="text-gray-400">(optional)</span></span>
-              <textarea
-                name="mustHaves"
-                value={form.mustHaves}
-                onChange={update}
-                rows={3}
-                className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:border-slate-900 focus:ring-2 focus:ring-slate-900/20"
-                placeholder="E.g., garage, yard, quiet street, near GO Station…"
-              />
-            </label>
-            <label className="block">
-              <span className="text-sm font-medium">Nice-to-haves <span className="text-gray-400">(optional)</span></span>
-              <textarea
-                name="niceToHaves"
-                value={form.niceToHaves}
-                onChange={update}
-                rows={3}
-                className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 shadow-sm placeholder-slate-400 focus:outline-none focus:border-slate-900 focus:ring-2 focus:ring-slate-900/20"
-                placeholder="E.g., finished basement, newer roof, south-facing yard…"
-              />
-            </label>
-          </div>
+            <div>
+              <span className="text-sm font-medium text-white">Which NorthSide GTA towns interest you most?</span>
+              <p className="mt-1 text-xs text-emerald-100/70">Select up to 7.</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {TOWNS.map((town) => {
+                  const active = form.towns.includes(town);
+                  return (
+                    <button
+                      type="button"
+                      key={town}
+                      className={`rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] transition backdrop-blur ${
+                        active
+                          ? "border-white/25 bg-white/15 text-white shadow-lg shadow-emerald-900/20"
+                          : "border-white/15 bg-white/5 text-emerald-100/80 hover:border-white/25 hover:bg-white/10 hover:text-white"
+                      }`}
+                      onClick={() => toggleTown(town)}
+                    >
+                      {town}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
 
-          {/* confirmations */}
-          <label className="flex items-start gap-2 text-sm">
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="block">
+                <span className="text-sm font-medium text-white">
+                  Must-haves <span className="text-emerald-100/70">(optional)</span>
+                </span>
+                <textarea
+                  name="mustHaves"
+                  value={form.mustHaves}
+                  onChange={update}
+                  rows={3}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-white/90 px-3 py-2 text-slate-900 shadow-lg shadow-emerald-900/10 placeholder-slate-400 focus:outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                  placeholder="E.g., garage, yard, quiet street, near GO Station…"
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-white">
+                  Nice-to-haves <span className="text-emerald-100/70">(optional)</span>
+                </span>
+                <textarea
+                  name="niceToHaves"
+                  value={form.niceToHaves}
+                  onChange={update}
+                  rows={3}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-white/90 px-3 py-2 text-slate-900 shadow-lg shadow-emerald-900/10 placeholder-slate-400 focus:outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
+                  placeholder="E.g., finished basement, newer roof, south-facing yard…"
+                />
+              </label>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-lg shadow-emerald-900/30 backdrop-blur">
+              <h4 className="text-sm font-semibold text-white">Before You Submit</h4>
+              <p className="text-xs text-emerald-100/80">Please confirm the following to help us respond faster.</p>
+              <div className="mt-3 space-y-2 text-sm">
+                <label className="flex items-start gap-2 text-emerald-100/80">
+                  <input
+                    type="checkbox"
+                    name="notUnderContract"
+                    checked={form.notUnderContract}
+                    onChange={update}
+                    className="mt-1 h-4 w-4 rounded border border-white/40 text-emerald-500 focus:ring-emerald-400/80"
+                    required
+                  />
+                  <span>
+                    I confirm that I am <span className="underline">not</span> currently under contract with another Real Estate Brokerage.
+                  </span>
+                </label>
+                <label className="flex items-start gap-2 text-emerald-100/80">
+                  <input
+                    type="checkbox"
+                    name="consent"
+                    checked={form.consent}
+                    onChange={update}
+                    className="mt-1 h-4 w-4 rounded border border-white/40 text-emerald-500 focus:ring-emerald-400/80"
+                    required
+                  />
+                  <span>
+                    I agree to be contacted by Finally Home Agents about my buyer match and search plan.
+                    <span className="block text-emerald-100/60 text-xs">You can unsubscribe anytime. We respect your privacy.</span>
+                  </span>
+                </label>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <button
+                type="submit"
+                disabled={!requiredOk || sending}
+                className="inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 text-base font-semibold text-emerald-900 shadow-xl shadow-emerald-900/40 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {sending ? "Sending…" : "Start Here"}
+              </button>
+
+              <p className="text-xs text-emerald-100/70">No spam. Unsubscribe anytime.</p>
+            </div>
+
             <input
-              type="checkbox"
-              name="notUnderContract"
-              checked={form.notUnderContract}
+              type="text"
+              name="nickname"
+              value={form.nickname}
               onChange={update}
-              className="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900/30"
-              required
+              className="hidden"
+              tabIndex={-1}
+              autoComplete="off"
             />
-            <span>
-              I confirm that I am <span className="underline">not</span> currently under contract with another Real Estate Brokerage.
-            </span>
-          </label>
-          <label className="flex items-start gap-2 text-sm">
-            <input
-              type="checkbox"
-              name="consent"
-              checked={form.consent}
-              onChange={update}
-              className="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900/30"
-              required
-            />
-            <span>
-              I agree to be contacted by Finally Home Agents about my buyer match and search plan.
-              <span className="block text-gray-500 text-xs">You can unsubscribe anytime. We respect your privacy.</span>
-            </span>
-          </label>
+          </form>
 
-          {/* submit (gradient green) */}
-          <button
-            type="submit"
-            disabled={!requiredOk || sending}
-            className="mt-1 inline-flex items-center justify-center rounded-lg border border-slate-900/70 bg-slate-900 px-5 py-3 font-semibold text-white shadow-sm transition focus:outline-none focus:ring-2 focus:ring-slate-900/30 focus:ring-offset-1 disabled:cursor-not-allowed disabled:border-slate-400 disabled:bg-slate-400 disabled:text-white/80 hover:bg-black"
-          >
-            {sending ? "Submitting…" : "Start Here"}
-          </button>
-
-          <p className="text-[11px] text-slate-700 mt-1">
-            No spam. Unsubscribe anytime.
-          </p>
-
-          {/* Honeypot */}
-          <input
-            name="nickname"
-            value={form.nickname}
-            onChange={update}
-            className="hidden"
-            tabIndex="-1"
-            autoComplete="off"
-          />
-        </form>
-
-        {/* micro line */}
-        <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-700">
-          <span>★★★★★ Google reviews</span>
-          <span>•</span>
-          <span>AI-assisted town matching & VIP listing alerts</span>
-          <span>•</span>
-          <span>Local team. Personal guidance.</span>
+          <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-emerald-100/70">
+            <span>★★★★★ Google reviews</span>
+            <span>•</span>
+            <span>AI-assisted town matching &amp; VIP listing alerts</span>
+            <span>•</span>
+            <span>Local team. Personal guidance.</span>
+          </div>
         </div>
       </div>
     </div>
@@ -694,123 +749,110 @@ function BuyerSignupForm() {
 /* ───────── Page ───────── */
 export default function BuyersPage() {
   return (
-    <>
+    <div className="min-h-screen overflow-hidden bg-[#04110c] text-white">
       <Navigation />
-<Helmet>
-  <title>Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents</title>
-  <meta
-    name="description"
-    content="Ready to buy in the NorthSide GTA? Get a personalized town match, VIP listing alerts, and expert guidance from Finally Home Agents in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog."
-  />
-  <link rel="canonical" href="https://www.northsidegta.ca/buyers" />
-  <meta name="robots" content="index,follow" />
+      <Helmet>
+        <title>Buy a Home in the NorthSide GTA | Town Match, VIP Alerts &amp; Expert Agents</title>
+        <meta
+          name="description"
+          content="Ready to buy in the NorthSide GTA? Get a personalized town match, VIP listing alerts, and expert guidance from Finally Home Agents in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog."
+        />
+        <link rel="canonical" href="https://www.northsidegta.ca/buyers" />
+        <meta name="robots" content="index,follow" />
+        <meta
+          name="keywords"
+          content="NorthSide GTA homes for sale, buy a home Georgina, buy a home East Gwillimbury, buy a home Newmarket, buy a home Aurora, buy a home Stouffville, buy a home Uxbridge, buy a home Scugog, town match, VIP listing alerts, Finally Home Agents"
+        />
+        <meta property="og:title" content="Buy a Home in the NorthSide GTA | Town Match, VIP Alerts &amp; Expert Agents" />
+        <meta
+          property="og:description"
+          content="Find the right town—and the right home—across Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog with Finally Home Agents."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://www.northsidegta.ca/buyers" />
+        <meta property="og:image" content="https://www.northsidegta.ca/Images/northsidegta-map-bg.jpg" />
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "WebPage",
+            name: "Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents",
+            url: "https://www.northsidegta.ca/buyers",
+            description:
+              "Personalized town match, VIP listing alerts, and expert guidance for buyers in the NorthSide GTA.",
+            about: {
+              "@type": "RealEstateAgent",
+              name: "Finally Home Agents",
+              areaServed: [
+                "Georgina",
+                "East Gwillimbury",
+                "Newmarket",
+                "Aurora",
+                "Stouffville",
+                "Uxbridge",
+                "Scugog",
+              ],
+              url: "https://www.northsidegta.ca",
+              brand: "Finally Home Agents",
+            },
+          })}
+        </script>
+      </Helmet>
 
-  {/* Keywords (nice-to-have) */}
-  <meta
-    name="keywords"
-    content="NorthSide GTA homes for sale, buy a home Georgina, buy a home East Gwillimbury, buy a home Newmarket, buy a home Aurora, buy a home Stouffville, buy a home Uxbridge, buy a home Scugog, town match, VIP listing alerts, Finally Home Agents"
-  />
+      <main className="relative">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.25),_transparent_65%)]" aria-hidden />
+        <div className="pointer-events-none absolute -top-32 left-[-10%] h-[26rem] w-[26rem] rounded-full bg-emerald-400/20 blur-3xl" aria-hidden />
+        <div className="pointer-events-none absolute bottom-[-40%] right-[-20%] h-[32rem] w-[32rem] rounded-full bg-emerald-300/20 blur-3xl" aria-hidden />
 
-  {/* Open Graph */}
-  <meta property="og:title" content="Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents" />
-  <meta
-    property="og:description"
-    content="Find the right town—and the right home—across Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog with Finally Home Agents."
-  />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.northsidegta.ca/buyers" />
-  <meta property="og:image" content="https://www.northsidegta.ca/Images/northsidegta-map-bg.jpg" />
-
-  {/* JSON-LD */}
-  <script type="application/ld+json">
-    {JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents",
-      "url": "https://www.northsidegta.ca/buyers",
-      "description":
-        "Personalized town match, VIP listing alerts, and expert guidance for buyers in the NorthSide GTA.",
-      "about": {
-        "@type": "RealEstateAgent",
-        "name": "Finally Home Agents",
-        "areaServed": [
-          "Georgina",
-          "East Gwillimbury",
-          "Newmarket",
-          "Aurora",
-          "Stouffville",
-          "Uxbridge",
-          "Scugog"
-        ],
-        "url": "https://www.northsidegta.ca",
-        "brand": "Finally Home Agents"
-      }
-    })}
-  </script>
-</Helmet>
-
-      <main className="px-4">
-        {/* HERO: feels like a registration gateway */}
-        <section className="mx-auto max-w-6xl pt-10">
-          <div className="text-center">
-            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-emerald-200 text-emerald-800 bg-emerald-50">
+        <div className="relative z-10 mx-auto w-full max-w-6xl px-4 pb-20 pt-16 sm:px-6 lg:px-8">
+          <section className="text-center">
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-emerald-100">
               <LockIcon className="h-4 w-4" />
-              <span className="uppercase text-[11px] font-semibold tracking-wider">
-                Exclusive Buyer Portal
-              </span>
+              Exclusive Buyer Portal
             </div>
-
-            <h1 className="mt-4 text-3xl md:text-5xl font-extrabold tracking-tight">
+            <h1 className="mt-6 text-3xl font-semibold tracking-tight sm:text-4xl md:text-[2.75rem]">
               Unlock Your Secret Weapon for Buying in the NorthSide GTA
             </h1>
-            <p className="mt-2 text-lg md:text-xl text-slate-700 max-w-3xl mx-auto">
-              Register to get your NorthSide GTA Match, insider strategies, and VIP alerts —
-              the unfair advantage other buyers don’t have.
+            <p className="mt-4 text-base text-emerald-100/85 sm:text-lg">
+              Register to get your NorthSide GTA Match, insider strategies, and VIP alerts — the unfair advantage other buyers don’t have.
             </p>
-          </div>
+          </section>
 
-          {/* Detailed Buyer Sign-Up (map background + gradient button) */}
-          <div className="mt-6">
+          <section className="mt-10">
             <BuyerSignupForm />
-          </div>
-        </section> 
+          </section>
 
-        {/* COMPARISON: shows what you unlock by registering (kept) */}
-        <section className="mx-auto max-w-6xl mt-10">
-          <ComparisonGrid />
-        </section>
+          <section className="mt-16">
+            <ComparisonGrid />
+          </section>
 
-        {/* Micro social proof line (kept) */}
-        <section className="mx-auto max-w-6xl mt-6">
-          <p className="text-center text-sm text-gray-600">
+          <section className="mt-10 text-center text-sm text-emerald-100/80">
             Join NorthSide GTA buyers who found the right town — and won the right home — with Finally Home Agents.
-          </p>
-        </section>
+          </section>
 
-        {/* Reviews (kept) */}
-        <section className="mx-auto max-w-3xl py-12">
-          <h2 className="text-2xl md:text-3xl font-bold text-center mb-6">
-            What Our Clients Are Saying
-          </h2>
-          <ReviewSlider />
-        </section>
+          <section className="mt-16">
+            <div className="mx-auto max-w-3xl text-center">
+              <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">What Our Clients Are Saying</h2>
+            </div>
+            <div className="mt-8">
+              <ReviewSlider />
+            </div>
+          </section>
 
-        {/* Final CTA (kept) */}
-        <section className="mx-auto max-w-6xl mb-16">
-          <div
-            className="rounded-2xl px-6 py-10 text-center text-white shadow-lg"
-            style={{ background: "linear-gradient(135deg,#31610d 0%, #23470a 100%)" }}
-          >
-            <h3 className="text-3xl md:text-4xl font-extrabold mb-2">Don’t Leave Power on the Table</h3>
-            <p className="text-lg md:text-xl opacity-90">
-              Register now to unlock your Match and move forward with confidence.
-            </p>
-           
-          </div>
-        </section>
+          <section className="mt-20">
+            <div className="relative overflow-hidden rounded-[32px] border border-white/15 bg-gradient-to-br from-emerald-500 via-emerald-500/70 to-emerald-600 px-6 py-10 text-center shadow-[0_45px_130px_rgba(4,47,35,0.6)]">
+              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.15),_transparent_70%)]" aria-hidden />
+              <div className="relative z-10 space-y-4">
+                <h3 className="text-3xl font-semibold md:text-4xl">Don’t Leave Power on the Table</h3>
+                <p className="text-lg text-emerald-100/90 md:text-xl">
+                  Register now to unlock your Match and move forward with confidence.
+                </p>
+              </div>
+            </div>
+          </section>
+        </div>
       </main>
 
       <Footer />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the buyers hero, layout, and CTA sections to mirror the homepage gradients and typography
- rebuild the buyer registration form and success state with the darker gradient treatment while keeping all existing fields and copy
- refresh the review slider styling so testimonials fit the new aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa520ad38c832497493900c7c4b0f2