### PR TITLE
Align about page styling with homepage aesthetic

### DIFF
--- a/src/AboutPage.js
+++ b/src/AboutPage.js
@@ -124,7 +124,7 @@ const testimonials = [
 
 export default function AboutPage() {
   return (
-    <div className="bg-white text-gray-900">
+    <div className="min-h-screen bg-slate-50 text-slate-900">
       <Navigation />
       <Helmet>
         <title>About Finally Home Agents | Local NorthSide GTA Realtors®</title>
@@ -151,174 +151,205 @@ export default function AboutPage() {
         <meta property="og:image" content="/Images/northsidegta-map-bg.jpg" />
       </Helmet>
 
-      {/* ───────── Hero Banner ───────── */}
-      <section className="relative h-[60vh] md:h-[70vh] overflow-hidden">
-        <img
-          src="/Images/hero-about.jpg"
-          alt="NorthSide GTA scenic"
-          className="absolute inset-0 h-full w-full object-cover"
-        />
-        <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
-          <div className="px-4 text-center text-white">
-            <h1 className="text-4xl md:text-6xl font-semibold tracking-tight">
-              Meet the NorthSide Experts
-            </h1>
-            <p className="mt-6 text-lg md:text-2xl text-gray-200">
-              Knowledge&nbsp;&bull;&nbsp;Passion&nbsp;&bull;&nbsp;Community
-            </p>
-          </div>
-        </div>
-      </section>
+      <main className="pb-16">
+        {/* ───────── Hero Banner ───────── */}
+        <section className="relative overflow-hidden bg-[#04110c] pb-20 pt-12 text-white">
+          <div className="absolute inset-0 bg-gradient-to-br from-emerald-950 via-emerald-900 to-emerald-700" aria-hidden />
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.4),_transparent_65%)]" aria-hidden />
+          <div className="pointer-events-none absolute -top-24 left-[-10%] h-[22rem] w-[22rem] rounded-full bg-emerald-400/25 blur-3xl" />
+          <div className="pointer-events-none absolute bottom-[-35%] right-[-15%] h-[28rem] w-[28rem] rounded-full bg-emerald-300/25 blur-3xl" />
 
-      {/* ───────── Metrics Strip ───────── */}
-      <section className="bg-white px-6 py-16">
-        <div className="mx-auto grid max-w-6xl grid-cols-1 gap-10 border-y border-gray-200 py-10 text-center sm:grid-cols-2 lg:grid-cols-4 lg:text-left">
-          {metrics.map((metric, index) => (
-            <div
-              key={metric.title}
-              className={`flex flex-col gap-3 ${
-                index !== 0 ? "lg:border-l lg:border-gray-200 lg:pl-10" : ""
-              }`}
-            >
-              <span className="text-xl font-semibold md:text-2xl">
-                {metric.title}
+          <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 lg:flex-row lg:items-center lg:px-6">
+            <div className="flex-1 space-y-6 text-center lg:text-left">
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-emerald-100">
+                NorthSide GTA • Finally Home Agents
               </span>
-              <p className="text-sm text-gray-600 md:text-base">
-                {metric.description}
+              <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-[2.75rem]">
+                Meet the NorthSide Experts
+              </h1>
+              <p className="text-base text-emerald-100/90 sm:text-lg">
+                Knowledge • Passion • Community
               </p>
             </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ───────── Why We're Different ───────── */}
-      <section className="bg-gray-50 px-6 py-24">
-        <div className="mx-auto max-w-5xl space-y-10 text-center md:text-left">
-          <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
-            Why We’re Different
-          </h2>
-          <div className="grid grid-cols-1 gap-12 md:grid-cols-2">
-            {differentiators.map((item) => (
-              <div key={item.headline} className="space-y-3">
-                <h3 className="text-xl font-semibold">{item.headline}</h3>
-                <p className="text-gray-600">{item.copy}</p>
+            <div className="flex flex-1 justify-center">
+              <div className="relative w-full max-w-xl rounded-[40px] bg-gradient-to-tr from-emerald-300 via-emerald-400 to-emerald-500 p-[1.5px] shadow-[0_55px_110px_rgba(2,26,20,0.55)]">
+                <div className="rounded-[36px] border border-white/15 bg-black/50 p-4 backdrop-blur">
+                  <div className="overflow-hidden rounded-[28px] border border-white/10">
+                    <img
+                      src="/Images/hero-about.jpg"
+                      alt="NorthSide GTA scenic"
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
+                </div>
               </div>
-            ))}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* ───────── Team Bios ───────── */}
-      <section className="bg-white px-6 py-24">
-        <div className="mx-auto flex max-w-6xl flex-col gap-20">
-          {teamMembers.map((member, idx) => (
-            <article
-              key={member.name}
-              className={`grid grid-cols-1 items-center gap-12 lg:grid-cols-2 ${
-                idx % 2 === 1 ? "lg:[&>*:first-child]:order-2" : ""
-              }`}
-            >
-              <div className="flex justify-center">
-                <img
-                  src={member.image}
-                  alt={member.name}
-                  className="h-auto w-full max-w-sm rounded-3xl object-cover shadow-lg"
-                />
-              </div>
-              <div className="space-y-6">
-                <div className="space-y-2">
-                  <h3 className="text-3xl font-semibold tracking-tight">
-                    {member.name}
-                  </h3>
-                  <p className="text-sm uppercase tracking-[0.28em] text-gray-500">
-                    {member.title}
+        {/* ───────── Metrics Strip ───────── */}
+        <section className="relative -mt-12 px-4">
+          <div className="mx-auto w-full max-w-6xl rounded-[36px] border border-emerald-100 bg-white/90 p-8 shadow-2xl shadow-emerald-100/70 backdrop-blur">
+            <div className="grid grid-cols-1 gap-8 text-center sm:grid-cols-2 lg:grid-cols-4 lg:text-left">
+              {metrics.map((metric) => (
+                <div key={metric.title} className="flex flex-col gap-2">
+                  <span className="text-lg font-semibold text-emerald-900 sm:text-xl md:text-2xl">
+                    {metric.title}
+                  </span>
+                  <p className="text-sm text-slate-600 md:text-base">
+                    {metric.description}
                   </p>
                 </div>
-                <p className="text-gray-700 leading-relaxed">
-                  {member.bio}
-                </p>
-                <p className="text-sm font-medium text-gray-900">
-                  {member.awards}
-                </p>
-                <div>
-                  <a
-                    href={member.email}
-                    className="inline-flex items-center gap-2 rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:border-gray-400 hover:text-gray-900"
-                  >
-                    <Mail className="h-4 w-4" /> Email {member.name.split(" ")[0]}
-                  </a>
-                </div>
-              </div>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      {/* ───────── Core Values ───────── */}
-      <section className="bg-gray-50 px-6 py-24">
-        <div className="mx-auto max-w-6xl text-center lg:text-left">
-          <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
-            Core Values
-          </h2>
-          <div className="mt-16 grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-5">
-            {values.map(({ icon: Icon, title, description }) => (
-              <div key={title} className="flex flex-col items-center gap-4 text-center lg:items-start lg:text-left">
-                <span className="flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-sm">
-                  <Icon className="h-6 w-6 text-green-700" />
-                </span>
-                <h3 className="text-lg font-semibold">{title}</h3>
-                <p className="text-sm text-gray-600">{description}</p>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* ───────── Testimonials ───────── */}
-      <section className="bg-white px-6 py-24">
-        <div className="mx-auto max-w-6xl">
-          <p className="text-center text-xs font-semibold uppercase tracking-[0.4em] text-gray-500">
-            Trusted by Families Across the GTA
-          </p>
-          <div className="mt-12 grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-4">
-            {testimonials.map((testimonial) => (
-              <div
-                key={testimonial.name}
-                className="flex h-full flex-col justify-between rounded-3xl border border-gray-200 bg-gray-50 p-8 text-left shadow-sm"
+        {/* ───────── Why We're Different ───────── */}
+        <section className="relative mt-24 overflow-hidden py-24">
+          <div className="absolute inset-0 bg-[#06110d]" aria-hidden />
+          <div className="absolute inset-0 bg-gradient-to-br from-emerald-950 via-emerald-900 to-emerald-700" aria-hidden />
+          <div className="pointer-events-none absolute left-[-18%] top-[-18%] h-[26rem] w-[26rem] rounded-full bg-emerald-400/25 blur-3xl" />
+          <div className="pointer-events-none absolute right-[-12%] bottom-[-24%] h-[30rem] w-[30rem] rounded-full bg-emerald-300/25 blur-3xl" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(16,185,129,0.15),_transparent_70%)]" aria-hidden />
+
+          <div className="relative z-10 mx-auto max-w-6xl space-y-10 px-4 text-center text-white md:text-left">
+            <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+              Why We’re Different
+            </h2>
+            <div className="grid grid-cols-1 gap-10 md:grid-cols-2">
+              {differentiators.map((item) => (
+                <div key={item.headline} className="rounded-3xl border border-white/10 bg-white/10 p-6 text-left shadow-[0_25px_60px_rgba(4,47,35,0.45)] backdrop-blur">
+                  <h3 className="text-xl font-semibold text-white">{item.headline}</h3>
+                  <p className="mt-3 text-sm text-emerald-100/85 md:text-base">{item.copy}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ───────── Team Bios ───────── */}
+        <section className="px-4 py-24">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-20">
+            {teamMembers.map((member, idx) => (
+              <article
+                key={member.name}
+                className={`grid grid-cols-1 items-center gap-12 rounded-[32px] border border-emerald-100 bg-white/90 p-6 shadow-2xl shadow-emerald-100/60 backdrop-blur-sm lg:grid-cols-2 ${
+                  idx % 2 === 1 ? "lg:[&>*:first-child]:order-2" : ""
+                }`}
               >
-                <div className="flex items-center gap-3 text-sm font-semibold text-[#FBBC04]">
-                  {"★★★★★"}
-                  <img
-                    src="/Images/google-logo.png"
-                    alt="Google reviews"
-                    className="h-4 w-auto"
-                  />
+                <div className="flex justify-center">
+                  <div className="relative w-full max-w-xs rounded-[30px] bg-gradient-to-tr from-emerald-300 via-emerald-400 to-emerald-500 p-[1.5px] shadow-lg shadow-emerald-200/60">
+                    <div className="rounded-[24px] border border-emerald-100 bg-white p-3">
+                      <img
+                        src={member.image}
+                        alt={member.name}
+                        className="h-auto w-full rounded-[20px] object-cover"
+                      />
+                    </div>
+                  </div>
                 </div>
-                <p className="mt-6 text-sm text-gray-700">{testimonial.quote}</p>
-                <p className="mt-6 text-sm font-semibold text-gray-900">
-                  — {testimonial.name}
-                </p>
-              </div>
+                <div className="space-y-6">
+                  <div className="space-y-2">
+                    <h3 className="text-3xl font-semibold tracking-tight text-emerald-900">
+                      {member.name}
+                    </h3>
+                    <p className="text-xs font-semibold uppercase tracking-[0.28em] text-emerald-600">
+                      {member.title}
+                    </p>
+                  </div>
+                  <p className="leading-relaxed text-slate-700">
+                    {member.bio}
+                  </p>
+                  <p className="text-sm font-medium text-emerald-900">
+                    {member.awards}
+                  </p>
+                  <div>
+                    <a
+                      href={member.email}
+                      className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-5 py-2 text-sm font-semibold text-emerald-700 transition hover:border-emerald-300 hover:bg-emerald-100 hover:text-emerald-900"
+                    >
+                      <Mail className="h-4 w-4" /> Email {member.name.split(" ")[0]}
+                    </a>
+                  </div>
+                </div>
+              </article>
             ))}
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* ───────── CTA Footer ───────── */}
-      <section className="bg-green-700 px-4 py-16 text-center text-white">
-        <h2 className="text-3xl font-semibold md:text-4xl">
-          Ready to make your move?
-        </h2>
-        <p className="mx-auto mt-4 max-w-2xl text-lg text-white/90">
-          Let’s talk about your goals and create your NorthSide GTA success story.
-        </p>
-        <Link
-          to="/contact"
-          className="mt-8 inline-block rounded-full bg-white px-8 py-3 font-semibold text-green-700 shadow hover:bg-gray-100 transition"
-        >
-          Contact Matthew &amp; Landon
-        </Link>
-      </section>
+        {/* ───────── Core Values ───────── */}
+        <section className="relative overflow-hidden py-24">
+          <div className="absolute inset-0 bg-[#06110d]" aria-hidden />
+          <div className="absolute inset-0 bg-gradient-to-br from-emerald-950 via-emerald-900 to-emerald-700" aria-hidden />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(16,185,129,0.2),_transparent_70%)]" aria-hidden />
+
+          <div className="relative z-10 mx-auto max-w-6xl px-4 text-center text-white lg:text-left">
+            <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+              Core Values
+            </h2>
+            <div className="mt-16 grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-5">
+              {values.map(({ icon: Icon, title, description }) => (
+                <div key={title} className="flex flex-col items-center gap-4 rounded-3xl border border-white/10 bg-white/10 p-6 text-center shadow-[0_25px_60px_rgba(4,47,35,0.45)] backdrop-blur lg:items-start lg:text-left">
+                  <span className="flex h-12 w-12 items-center justify-center rounded-full bg-white/20 text-white">
+                    <Icon className="h-6 w-6" />
+                  </span>
+                  <h3 className="text-lg font-semibold text-white">{title}</h3>
+                  <p className="text-sm text-emerald-100/85">{description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ───────── Testimonials ───────── */}
+        <section className="px-4 py-24">
+          <div className="mx-auto max-w-6xl">
+            <p className="text-center text-xs font-semibold uppercase tracking-[0.4em] text-emerald-600">
+              Trusted by Families Across the GTA
+            </p>
+            <div className="mt-12 grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-4">
+              {testimonials.map((testimonial) => (
+                <div
+                  key={testimonial.name}
+                  className="flex h-full flex-col justify-between rounded-3xl border border-emerald-100 bg-white/90 p-8 text-left shadow-2xl shadow-emerald-100/60"
+                >
+                  <div className="flex items-center gap-3 text-sm font-semibold text-[#FBBC04]">
+                    {"★★★★★"}
+                    <img
+                      src="/Images/google-logo.png"
+                      alt="Google reviews"
+                      className="h-4 w-auto"
+                    />
+                  </div>
+                  <p className="mt-6 text-sm text-slate-700">{testimonial.quote}</p>
+                  <p className="mt-6 text-sm font-semibold text-emerald-900">
+                    — {testimonial.name}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ───────── CTA Footer ───────── */}
+        <section className="relative overflow-hidden rounded-[36px] px-4">
+          <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-6 rounded-[32px] border border-emerald-200 bg-gradient-to-r from-emerald-500 via-emerald-600 to-emerald-700 px-6 py-16 text-center text-white shadow-[0_35px_90px_rgba(16,185,129,0.45)]">
+            <h2 className="text-3xl font-semibold sm:text-4xl">
+              Ready to make your move?
+            </h2>
+            <p className="mx-auto max-w-2xl text-lg text-white/90">
+              Let’s talk about your goals and create your NorthSide GTA success story.
+            </p>
+            <Link
+              to="/contact"
+              className="inline-flex items-center justify-center rounded-2xl bg-white px-8 py-3 text-base font-semibold text-emerald-700 shadow-xl shadow-emerald-900/30 transition hover:bg-emerald-50"
+            >
+              Contact Matthew & Landon
+            </Link>
+          </div>
+        </section>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the about page with the same emerald gradient motif and layout patterns used on the homepage
- wrap the hero image in a gradient card and adjust section cards for metrics, differentiators, team, values, and testimonials to match the refreshed design
- retain all original copy while tightening spacing and visual hierarchy for better readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa657df150832480ba0d8d049b8921