### PR TITLE
Add SendPulse live chat widget site-wide

### DIFF
--- a/public/cms/index.html
+++ b/public/cms/index.html
@@ -169,5 +169,6 @@
         }
       })();
     </script>
+    <script src="https://cdn.pulse.is/livechat/loader.js" data-live-chat-id="68fa76a75fc77f1bca09a31a" async></script>
   </body>
 </html>

--- a/public/g/index.html
+++ b/public/g/index.html
@@ -8,5 +8,6 @@
 </head>
 <body>
   <p><a href="https://northsidegta.ca/georgeina/">Redirecting to the Georgeina press release…</a></p>
+  <script src="https://cdn.pulse.is/livechat/loader.js" data-live-chat-id="68fa76a75fc77f1bca09a31a" async></script>
 </body>
 </html>

--- a/public/georgeina/index.html
+++ b/public/georgeina/index.html
@@ -137,5 +137,6 @@
       } catch(e) { alert('Link copy failed'); }
     });
   </script>
+  <script src="https://cdn.pulse.is/livechat/loader.js" data-live-chat-id="68fa76a75fc77f1bca09a31a" async></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -67,5 +67,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdn.pulse.is/livechat/loader.js" data-live-chat-id="68fa76a75fc77f1bca09a31a" async></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the SendPulse live chat widget from the global React entrypoint so it appears across the SPA
- embed the same asynchronous loader script on static redirect and CMS pages to ensure complete coverage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa77318024832490fb80f9df7aae45