### PR TITLE
Downgrade approved event statuses to pending

### DIFF
--- a/public/data/events/2025-10-04-finally-home-agents-golf-tournament-scramble-at-mill-run.json
+++ b/public/data/events/2025-10-04-finally-home-agents-golf-tournament-scramble-at-mill-run.json
@@ -21,7 +21,7 @@
   "featured": true,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "manual",
   "updatedAt": "2025-10-02T00:55:54Z"
 }

--- a/public/data/events/20250501-kate-greenway-recent-works-toronto-adjacent.json
+++ b/public/data/events/20250501-kate-greenway-recent-works-toronto-adjacent.json
@@ -741,7 +741,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011938-1746057600-1760831999@www.experienceyorkregion.com",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20250915-acrylic-pouring-and-mediums-aurora.json
+++ b/public/data/events/20250915-acrylic-pouring-and-mediums-aurora.json
@@ -361,7 +361,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002666-1757894400-1762819199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250915-comic-drawing-for-children-aurora.json
+++ b/public/data/events/20250915-comic-drawing-for-children-aurora.json
@@ -361,7 +361,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002643-1757894400-1762819199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250915-wood-carving-aurora.json
+++ b/public/data/events/20250915-wood-carving-aurora.json
@@ -361,7 +361,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002667-1757894400-1762819199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250916-expand-your-horizons-in-acrylics-level-2-aurora.json
+++ b/public/data/events/20250916-expand-your-horizons-in-acrylics-level-2-aurora.json
@@ -361,7 +361,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002670-1757980800-1762905599@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250916-watercolour-level-1-55-aurora.json
+++ b/public/data/events/20250916-watercolour-level-1-55-aurora.json
@@ -445,7 +445,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002668-1757980800-1764115199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250916-watercolour-level-2-55-aurora.json
+++ b/public/data/events/20250916-watercolour-level-2-55-aurora.json
@@ -445,7 +445,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002669-1757980800-1764115199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250917-drawing-club-intermediate-aurora.json
+++ b/public/data/events/20250917-drawing-club-intermediate-aurora.json
@@ -235,7 +235,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002677-1758067200-1761177599@auroraculturalcentre.ca",
   "updatedAt": "2025-10-22T08:36:57Z"

--- a/public/data/events/20250917-drawing-fundamentals-session-a-55-aurora.json
+++ b/public/data/events/20250917-drawing-fundamentals-session-a-55-aurora.json
@@ -403,7 +403,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002671-1758067200-1763596799@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250917-guitar-beginner-aurora.json
+++ b/public/data/events/20250917-guitar-beginner-aurora.json
@@ -319,7 +319,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002675-1758067200-1762387199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250917-guitar-intermediate-aurora.json
+++ b/public/data/events/20250917-guitar-intermediate-aurora.json
@@ -319,7 +319,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002676-1758067200-1762387199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250917-watercolours-intermediate-advanced-aurora.json
+++ b/public/data/events/20250917-watercolours-intermediate-advanced-aurora.json
@@ -319,7 +319,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002673-1758067200-1762387199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250917-you-can-uke-it-beginner-and-intermediate-aurora.json
+++ b/public/data/events/20250917-you-can-uke-it-beginner-and-intermediate-aurora.json
@@ -319,7 +319,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002645-1758067200-1762387199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250918-acrylic-paint-beginner-55-aurora.json
+++ b/public/data/events/20250918-acrylic-paint-beginner-55-aurora.json
@@ -403,7 +403,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002678-1758153600-1763683199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250918-acrylic-paint-intermediate-55-aurora.json
+++ b/public/data/events/20250918-acrylic-paint-intermediate-55-aurora.json
@@ -403,7 +403,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002679-1758153600-1763683199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250918-drawing-fundamentals-session-b-55-aurora.json
+++ b/public/data/events/20250918-drawing-fundamentals-session-b-55-aurora.json
@@ -403,7 +403,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002672-1758153600-1763683199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250918-watercolours-basics-beyond-aurora.json
+++ b/public/data/events/20250918-watercolours-basics-beyond-aurora.json
@@ -319,7 +319,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002674-1758153600-1762473599@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250920-children-s-visual-art-2-aurora.json
+++ b/public/data/events/20250920-children-s-visual-art-2-aurora.json
@@ -361,7 +361,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002657-1758326400-1763251199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250927-children-s-visual-art-1-aurora.json
+++ b/public/data/events/20250927-children-s-visual-art-1-aurora.json
@@ -361,7 +361,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002656-1758931200-1763855999@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250927-lil-jammers-caregiver-child-aurora.json
+++ b/public/data/events/20250927-lil-jammers-caregiver-child-aurora.json
@@ -361,7 +361,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002652-1758931200-1763855999@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20250927-rhythm-kids-aurora.json
+++ b/public/data/events/20250927-rhythm-kids-aurora.json
@@ -361,7 +361,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002653-1758931200-1763855999@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251009-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251009-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009007-1760002200-1760720400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-17T15:44:24Z"

--- a/public/data/events/20251010-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251010-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009008-1760088600-1760806800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251011-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251011-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009009-1760175000-1760893200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-19T08:29:49Z"

--- a/public/data/events/20251011-the-stouffville-market-oktoberfest-stouffville-on.json
+++ b/public/data/events/20251011-the-stouffville-market-oktoberfest-stouffville-on.json
@@ -21,7 +21,7 @@
   "featured": true,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/the-stouffville-market-oktoberfest/",
   "updatedAt": "2025-10-10T17:07:55Z"

--- a/public/data/events/20251012-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251012-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009010-1760261400-1760979600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-20T08:41:30Z"

--- a/public/data/events/20251013-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251013-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009011-1760347800-1761066000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-21T08:36:48Z"

--- a/public/data/events/20251014-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251014-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011574-1760432400-1760716800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-17T15:44:24Z"

--- a/public/data/events/20251014-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251014-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009012-1760434200-1761152400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-22T08:36:57Z"

--- a/public/data/events/20251015-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251015-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011575-1760518800-1760803200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251015-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251015-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009013-1760520600-1761238800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-23T08:36:02Z"

--- a/public/data/events/20251016-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251016-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011576-1760605200-1760889600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-19T08:29:49Z"

--- a/public/data/events/20251016-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251016-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009014-1760607000-1761325200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251016-newmarket-culture-days-step-into-the-world-of-5-000-years-of-toronto-adjacent.json
+++ b/public/data/events/20251016-newmarket-culture-days-step-into-the-world-of-5-000-years-of-toronto-adjacent.json
@@ -109,7 +109,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014187-1760608800-1761840000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251017-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251017-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011577-1760691600-1760976000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-20T08:41:30Z"

--- a/public/data/events/20251017-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251017-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009015-1760693400-1761411600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251017-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251017-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010890-1760702400-1760716800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-17T15:44:24Z"

--- a/public/data/events/20251018-aurora-cultural-centre-presents-lori-cullen-talia-schlanger-toronto-adjacent.json
+++ b/public/data/events/20251018-aurora-cultural-centre-presents-lori-cullen-talia-schlanger-toronto-adjacent.json
@@ -27,7 +27,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014046-1760815800-1760823000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251018-boofest-toronto-adjacent.json
+++ b/public/data/events/20251018-boofest-toronto-adjacent.json
@@ -27,7 +27,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014227-1760781600-1760806800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251018-lori-cullen-talia-schlanger-aurora.json
+++ b/public/data/events/20251018-lori-cullen-talia-schlanger-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002604-1760815800-1760823000@auroraculturalcentre.ca",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251018-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251018-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009016-1760779800-1761498000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251018-stouffville-studio-tour-whitchurch-stoufville.json
+++ b/public/data/events/20251018-stouffville-studio-tour-whitchurch-stoufville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/stouffvillestudiotour/",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251018-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251018-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010891-1760788800-1760803200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251019-boofest-toronto-adjacent.json
+++ b/public/data/events/20251019-boofest-toronto-adjacent.json
@@ -27,7 +27,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014228-1760868000-1760893200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-19T08:29:49Z"

--- a/public/data/events/20251019-family-team-challenge-day-stouffville.json
+++ b/public/data/events/20251019-family-team-challenge-day-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/family-team-challenge-day/",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251019-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251019-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009017-1760866200-1761584400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251019-markham-concert-band-music-of-the-40s-and-cba-spectacular-toronto-adjacent.json
+++ b/public/data/events/20251019-markham-concert-band-music-of-the-40s-and-cba-spectacular-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014294-1760882400-1760893200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-19T08:29:49Z"

--- a/public/data/events/20251019-sabzeh-closing-panel-aurora.json
+++ b/public/data/events/20251019-sabzeh-closing-panel-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002691-1760871600-1760878800@auroraculturalcentre.ca",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251019-sabzeh-closing-panel-toronto-adjacent.json
+++ b/public/data/events/20251019-sabzeh-closing-panel-toronto-adjacent.json
@@ -27,7 +27,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014245-1760871600-1760878800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-19T08:29:49Z"

--- a/public/data/events/20251019-sculpt-your-own-light-aurora.json
+++ b/public/data/events/20251019-sculpt-your-own-light-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002684-1760832000-1760918399@auroraculturalcentre.ca",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251019-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251019-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010892-1760875200-1760889600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-19T08:29:49Z"

--- a/public/data/events/20251019-walk-and-learn-historical-tours-toronto-adjacent.json
+++ b/public/data/events/20251019-walk-and-learn-historical-tours-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014154-1760878800-1760884200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-19T08:29:49Z"

--- a/public/data/events/20251020-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251020-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011578-1760950800-1761235200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-23T08:36:02Z"

--- a/public/data/events/20251020-building-your-brand-online-with-adam-rodricks-stouffville-on.json
+++ b/public/data/events/20251020-building-your-brand-online-with-adam-rodricks-stouffville-on.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/building-your-brand-online-with-adam-rodricks/",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251020-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251020-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009018-1760952600-1761670800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251020-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251020-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010893-1760961600-1760976000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-20T08:41:30Z"

--- a/public/data/events/20251021-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251021-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011579-1761037200-1761321600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251021-future-ready-leadership-for-an-uncertain-world-stouffville-on.json
+++ b/public/data/events/20251021-future-ready-leadership-for-an-uncertain-world-stouffville-on.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/future-ready-leadership-for-an-uncertain-world/",
   "updatedAt": "2025-10-18T08:30:46Z"

--- a/public/data/events/20251021-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251021-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009019-1761039000-1761757200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251021-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251021-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010894-1761048000-1761062400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-21T08:36:48Z"

--- a/public/data/events/20251022-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251022-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011580-1761123600-1761408000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251022-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251022-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009020-1761125400-1761843600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251022-open-studio-ages-18-aurora.json
+++ b/public/data/events/20251022-open-studio-ages-18-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002589-1761091200-1761177599@auroraculturalcentre.ca",
   "updatedAt": "2025-10-22T08:36:57Z"

--- a/public/data/events/20251022-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251022-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010895-1761134400-1761148800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-22T08:36:57Z"

--- a/public/data/events/20251022-when-construction-comes-calling-stouffville-on.json
+++ b/public/data/events/20251022-when-construction-comes-calling-stouffville-on.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/when-construction-comes-calling/",
   "updatedAt": "2025-10-22T08:36:57Z"

--- a/public/data/events/20251023-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251023-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011581-1761210000-1761494400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251023-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251023-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009021-1761211800-1761930000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251023-member-hosted-networking-night-8211-sold-out-stouffville.json
+++ b/public/data/events/20251023-member-hosted-networking-night-8211-sold-out-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/member-hosted-networking-night/",
   "updatedAt": "2025-10-23T08:36:02Z"

--- a/public/data/events/20251023-member-hosted-networking-night-stouffville.json
+++ b/public/data/events/20251023-member-hosted-networking-night-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/member-hosted-networking-night/",
   "updatedAt": "2025-10-22T08:36:57Z"

--- a/public/data/events/20251023-pizza-paint-and-pints-stouffville.json
+++ b/public/data/events/20251023-pizza-paint-and-pints-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/pizza-paint-and-pints/",
   "updatedAt": "2025-10-22T08:36:57Z"

--- a/public/data/events/20251023-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251023-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010896-1761220800-1761235200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-23T08:36:02Z"

--- a/public/data/events/20251023-tourism-now-presented-by-central-counties-tourism-stouffville.json
+++ b/public/data/events/20251023-tourism-now-presented-by-central-counties-tourism-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/tourism-now/",
   "updatedAt": "2025-10-22T08:36:57Z"

--- a/public/data/events/20251024-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251024-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011582-1761296400-1761580800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251024-ai-powered-marketing-reach-new-customers-and-drive-growth-stouffville.json
+++ b/public/data/events/20251024-ai-powered-marketing-reach-new-customers-and-drive-growth-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/ai-powered-marketing/",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251024-haunts-and-howls-bruce-8217-s-mill-stouffville.json
+++ b/public/data/events/20251024-haunts-and-howls-bruce-8217-s-mill-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/haunts-and-howls-bruces-mill/",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251024-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251024-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009022-1761298200-1762016400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251024-pa-day-ages-4-to-7-october-24-aurora.json
+++ b/public/data/events/20251024-pa-day-ages-4-to-7-october-24-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002647-1761264000-1761350399@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251024-pa-day-ages-7-to-12-october-24-aurora.json
+++ b/public/data/events/20251024-pa-day-ages-7-to-12-october-24-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002650-1761264000-1761350399@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251024-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251024-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010897-1761307200-1761321600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251024-y-a-r-portfolio-review-spark-sessions-spooky-miniature-chall-aurora.json
+++ b/public/data/events/20251024-y-a-r-portfolio-review-spark-sessions-spooky-miniature-chall-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002697-1761314400-1761318000@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251024-y-a-r-portfolio-review-spark-sessions-spooky-miniature-chall-toronto-adjacent.json
+++ b/public/data/events/20251024-y-a-r-portfolio-review-spark-sessions-spooky-miniature-chall-toronto-adjacent.json
@@ -27,7 +27,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014246-1761314400-1761318000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251025-aurora-s-haunted-forest-toronto-adjacent.json
+++ b/public/data/events/20251025-aurora-s-haunted-forest-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014253-1761415200-1761426000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251025-boofest-toronto-adjacent.json
+++ b/public/data/events/20251025-boofest-toronto-adjacent.json
@@ -27,7 +27,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014229-1761386400-1761411600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251025-clearwater-farm-harvest-celebration-toronto-adjacent.json
+++ b/public/data/events/20251025-clearwater-farm-harvest-celebration-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014264-1761350400-1761436799@www.experienceyorkregion.com",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251025-halloween-on-main-stouffville.json
+++ b/public/data/events/20251025-halloween-on-main-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/halloween-on-main/",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251025-halloween-on-main-toronto-adjacent.json
+++ b/public/data/events/20251025-halloween-on-main-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014247-1761390000-1761404400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251025-introduction-to-beekeeping-toronto-adjacent.json
+++ b/public/data/events/20251025-introduction-to-beekeeping-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010711-1761384600-1761395400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251025-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251025-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009023-1761384600-1762099200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251025-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251025-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010898-1761393600-1761408000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251025-york-symphony-orchestra-presents-a-symphonic-halloween-toronto-adjacent.json
+++ b/public/data/events/20251025-york-symphony-orchestra-presents-a-symphonic-halloween-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014255-1761422400-1761429600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251026-afternoon-tea-toronto-adjacent.json
+++ b/public/data/events/20251026-afternoon-tea-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014158-1761481800-1761494400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251026-boofest-toronto-adjacent.json
+++ b/public/data/events/20251026-boofest-toronto-adjacent.json
@@ -27,7 +27,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014230-1761472800-1761498000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251026-haunts-and-howls-bruce-8217-s-mill-stouffville.json
+++ b/public/data/events/20251026-haunts-and-howls-bruce-8217-s-mill-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/haunts-and-howls-bruces-mill-2/",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251026-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251026-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009024-1761471000-1762185600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251026-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251026-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010899-1761480000-1761494400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251026-walk-and-learn-historical-tours-toronto-adjacent.json
+++ b/public/data/events/20251026-walk-and-learn-historical-tours-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014155-1761483600-1761489000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251027-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251027-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011583-1761555600-1761840000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251027-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251027-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009025-1761557400-1762272000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251027-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251027-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010900-1761566400-1761580800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251028-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251028-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011584-1761642000-1761926400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251028-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251028-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009026-1761643800-1762358400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251028-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251028-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010901-1761652800-1761667200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251029-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251029-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011585-1761728400-1762012800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251029-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251029-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009027-1761730200-1762444800@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251029-open-studio-ages-18-aurora.json
+++ b/public/data/events/20251029-open-studio-ages-18-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002590-1761696000-1761782399@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251029-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251029-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010902-1761739200-1761753600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251030-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251030-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011586-1761814800-1762095600@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251030-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
+++ b/public/data/events/20251030-march-break-at-legoland-discovery-centre-toronto-toronto-adjacent.json
@@ -75,7 +75,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10009028-1761816600-1762531200@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251030-shifting-realities-evening-gala-and-artist-q-a-aurora.json
+++ b/public/data/events/20251030-shifting-realities-evening-gala-and-artist-q-a-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002705-1761847200-1761854400@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251030-shifting-realities-evening-gala-and-artist-q-a-toronto-adjacent.json
+++ b/public/data/events/20251030-shifting-realities-evening-gala-and-artist-q-a-toronto-adjacent.json
@@ -27,7 +27,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10014263-1761847200-1761854400@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251030-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
+++ b/public/data/events/20251030-the-heintzman-house-2025-art-show-and-sale-toronto-adjacent.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10010903-1761825600-1761840000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251031-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
+++ b/public/data/events/20251031-2025-summer-art-camp-at-palette-art-school-toronto-adjacent.json
@@ -45,7 +45,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10011587-1761901200-1762182000@www.experienceyorkregion.com",
   "updatedAt": "2025-10-26T08:30:15Z"

--- a/public/data/events/20251031-ales-from-the-crypt-halloween-hang-stouffville.json
+++ b/public/data/events/20251031-ales-from-the-crypt-halloween-hang-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/ales-from-the-crypt-halloween-hang/",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251101-exhibit-talk-worthy-whitchurch-stouffville.json
+++ b/public/data/events/20251101-exhibit-talk-worthy-whitchurch-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/exhibit-talk-worthy/",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251101-print-038-be-merry-workshop-stouffville.json
+++ b/public/data/events/20251101-print-038-be-merry-workshop-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/print-be-merry-workshop/",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251102-where-they-walked-stouffville-8217-s-veteran-stories-stouffville-on.json
+++ b/public/data/events/20251102-where-they-walked-stouffville-8217-s-veteran-stories-stouffville-on.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/where-they-walked-stouffvilles-veteran-stories/",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251105-open-studio-ages-18-aurora.json
+++ b/public/data/events/20251105-open-studio-ages-18-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002591-1762300800-1762387199@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251106-line-dancing-social-stouffville.json
+++ b/public/data/events/20251106-line-dancing-social-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/line-dancing-social/",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251106-mother-038-daughter-date-night-whitchurch-stouffville.json
+++ b/public/data/events/20251106-mother-038-daughter-date-night-whitchurch-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/mother-daughter-date-night/",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251108-crit-club-ages-18-aurora.json
+++ b/public/data/events/20251108-crit-club-ages-18-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002700-1762592400-1762599600@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251108-fall-artist-poet-gathering-aurora.json
+++ b/public/data/events/20251108-fall-artist-poet-gathering-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002699-1762599600-1762606800@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251108-le-vent-du-nord-aurora.json
+++ b/public/data/events/20251108-le-vent-du-nord-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002605-1762630200-1762637400@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251109-expressive-painting-for-wellness-aurora.json
+++ b/public/data/events/20251109-expressive-painting-for-wellness-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002687-1762646400-1762732799@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251112-open-studio-ages-18-aurora.json
+++ b/public/data/events/20251112-open-studio-ages-18-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002592-1762905600-1762991999@auroraculturalcentre.ca",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251115-45th-annual-victorian-tea-whitchurch-stouffville.json
+++ b/public/data/events/20251115-45th-annual-victorian-tea-whitchurch-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/45th-annual-victorian-tea/",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251115-divine-brown-sings-billie-sarah-and-ella-2-00pm-aurora.json
+++ b/public/data/events/20251115-divine-brown-sings-billie-sarah-and-ella-2-00pm-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002606-1763215200-1763220600@auroraculturalcentre.ca",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251115-divine-brown-sings-billie-sarah-and-ella-7-30pm-aurora.json
+++ b/public/data/events/20251115-divine-brown-sings-billie-sarah-and-ella-7-30pm-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002634-1763235000-1763240400@auroraculturalcentre.ca",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251115-willow-wonderland-holiday-market-3-0-stouffville.json
+++ b/public/data/events/20251115-willow-wonderland-holiday-market-3-0-stouffville.json
@@ -21,7 +21,7 @@
   "featured": true,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/willow-wonderland-holiday-market-3-0/",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251116-crepe-paper-cosmos-workshop-aurora.json
+++ b/public/data/events/20251116-crepe-paper-cosmos-workshop-aurora.json
@@ -25,7 +25,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "10002685-1763251200-1763337599@auroraculturalcentre.ca",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251119-village-of-stouffville-ladies-night-stouffville.json
+++ b/public/data/events/20251119-village-of-stouffville-ladies-night-stouffville.json
@@ -20,7 +20,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/village-of-stouffville-ladies-night/",
   "updatedAt": "2025-10-25T08:29:42Z"

--- a/public/data/events/20251129-trail-of-treasures-at-bruce-8217-s-mill-stouffville.json
+++ b/public/data/events/20251129-trail-of-treasures-at-bruce-8217-s-mill-stouffville.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/trail-of-treasures-at-bruces-mill/",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/20251213-the-stouffville-christmas-market-stouffville-on.json
+++ b/public/data/events/20251213-the-stouffville-christmas-market-stouffville-on.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/the-stouffville-christmas-market/",
   "updatedAt": "2025-10-24T08:34:38Z"

--- a/public/data/events/discover-stouffville-https-discoverstouffville.ca-event-the-stouffville-christmas-market--20251213.json
+++ b/public/data/events/discover-stouffville-https-discoverstouffville.ca-event-the-stouffville-christmas-market--20251213.json
@@ -21,7 +21,7 @@
   "featured": false,
   "hidden": false,
   "archived": false,
-  "status": "approved",
+  "status": "pending",
   "source": "feed",
   "sourceRef": "https://discoverstouffville.ca/event/the-stouffville-christmas-market/",
   "updatedAt": "2025-10-03T10:16:54Z"

--- a/scripts/events-downgrade-status.mjs
+++ b/scripts/events-downgrade-status.mjs
@@ -1,0 +1,65 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const eventsDir = path.resolve(__dirname, '../public/data/events');
+
+async function walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+
+  const results = await Promise.all(entries.map(async (entry) => {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return walk(fullPath);
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.json')) {
+      return processFile(fullPath);
+    }
+
+    return null;
+  }));
+
+  return results.flat().filter(Boolean);
+}
+
+async function processFile(filePath) {
+  const original = await fs.readFile(filePath, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(original);
+  } catch (error) {
+    throw new Error(`Failed to parse JSON in ${filePath}: ${error.message}`);
+  }
+
+  if (parsed?.status !== 'approved') {
+    return null;
+  }
+
+  parsed.status = 'pending';
+  const updated = `${JSON.stringify(parsed, null, 2)}\n`;
+  await fs.writeFile(filePath, updated, 'utf8');
+  return filePath;
+}
+
+async function main() {
+  try {
+    const updatedFiles = await walk(eventsDir);
+    if (updatedFiles.length === 0) {
+      console.log('No files required updates.');
+    } else {
+      console.log('Updated files:');
+      for (const file of updatedFiles) {
+        console.log(` - ${path.relative(eventsDir, file)}`);
+      }
+    }
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add a maintenance script to downgrade approved event statuses to pending
- run the script to update existing event JSON files so they align with the new workflow

## Testing
- node scripts/events-downgrade-status.mjs
- rg '"status": "approved"' public/data/events


------
https://chatgpt.com/codex/tasks/task_e_68ffb2a7b9f48324b36f68cd919e5f86