### PR TITLE
Redesign community event list layout with monthly grouping

### DIFF
--- a/src/CommunityPage.js
+++ b/src/CommunityPage.js
@@ -18,6 +18,10 @@ import {
 } from './community/eventUtils'
 
 const VIEW_STORAGE_KEY = 'northside-community-view'
+const monthFormatter = new Intl.DateTimeFormat('en-CA', {
+  month: 'long',
+  year: 'numeric',
+})
 
 function usePersistedView(initialValue) {
   const [view, setView] = React.useState(() => {
@@ -88,6 +92,57 @@ export default function CommunityPage() {
     () => filterEvents(visibleEvents, filters),
     [visibleEvents, filters]
   )
+
+  const monthlyEvents = React.useMemo(() => {
+    if (!filteredEvents.length) return []
+
+    const entries = new Map()
+
+    for (const event of filteredEvents) {
+      const occurrence = event.nextOccurrence || event.occurrences?.[0]
+      const occurrenceDate = occurrence?.start instanceof Date ? occurrence.start : null
+
+      let baseDate = occurrenceDate
+      if (!baseDate && event.startDateObj instanceof Date) {
+        baseDate = event.startDateObj
+      }
+      if (!baseDate && event.startDate) {
+        const parsed = new Date(event.startDate)
+        if (!Number.isNaN(parsed.getTime())) {
+          baseDate = parsed
+        }
+      }
+
+      if (!baseDate) continue
+
+      const baseTime = baseDate.getTime()
+      if (!Number.isFinite(baseTime)) continue
+
+      const monthStart = new Date(baseDate.getFullYear(), baseDate.getMonth(), 1)
+      const monthKey = `${monthStart.getFullYear()}-${String(monthStart.getMonth() + 1).padStart(2, '0')}`
+
+      if (!entries.has(monthKey)) {
+        entries.set(monthKey, {
+          key: monthKey,
+          label: monthFormatter.format(monthStart),
+          monthStart,
+          events: [],
+        })
+      }
+
+      entries.get(monthKey).events.push({ event, sortDate: baseDate })
+    }
+
+    return Array.from(entries.values())
+      .sort((a, b) => a.monthStart.getTime() - b.monthStart.getTime())
+      .map((entry) => ({
+        key: entry.key,
+        label: entry.label,
+        events: entry.events
+          .sort((a, b) => a.sortDate.getTime() - b.sortDate.getTime())
+          .map((item) => item.event),
+      }))
+  }, [filteredEvents])
 
   const structuredData = React.useMemo(() => getStructuredData(filteredEvents), [filteredEvents])
 
@@ -290,18 +345,30 @@ export default function CommunityPage() {
               )}
 
               {view === 'list' && (
-                <section className="space-y-6">
-                  <div className="grid gap-6 lg:grid-cols-2">
-                    {filteredEvents.map((event) => (
-                      <EventCard
-                        key={event.slug}
-                        event={event}
-                        onSelect={setSelectedEvent}
-                        highlighted={highlightedSlug === event.slug}
-                      />
-                    ))}
-                  </div>
-                  {!filteredEvents.length && emptyState}
+                <section className="space-y-10">
+                  {monthlyEvents.length ? (
+                    monthlyEvents.map((month) => (
+                      <section key={month.key} className="space-y-4">
+                        <div className="flex items-center gap-4">
+                          <h4 className="text-lg font-semibold text-slate-900 sm:text-xl">{month.label}</h4>
+                          <div className="hidden flex-1 border-t border-slate-200 sm:block" aria-hidden="true" />
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+                          {month.events.map((event) => (
+                            <EventCard
+                              key={event.slug}
+                              event={event}
+                              onSelect={setSelectedEvent}
+                              highlighted={highlightedSlug === event.slug}
+                              variant="compact"
+                            />
+                          ))}
+                        </div>
+                      </section>
+                    ))
+                  ) : (
+                    emptyState
+                  )}
                 </section>
               )}
 

--- a/src/community/EventCard.js
+++ b/src/community/EventCard.js
@@ -9,15 +9,21 @@ import {
 import { BADGE_LABELS, formatDateRange, generateIcsContent } from './eventUtils'
 import { getCanonicalEventUrl, shareEvent } from './shareUtils'
 
-function PlaceholderImage() {
+function PlaceholderImage({ variant }) {
+  const isCompact = variant === 'compact'
+
   return (
-    <div className="h-36 w-full rounded-xl bg-gradient-to-br from-slate-200 via-slate-100 to-slate-200 flex items-center justify-center text-slate-500">
-      <CalendarPlus className="h-8 w-8" aria-hidden="true" />
+    <div
+      className={`flex h-full w-full items-center justify-center rounded-lg bg-gradient-to-br from-slate-100 via-white to-slate-100 ${
+        isCompact ? 'p-6' : 'p-8'
+      }`}
+    >
+      <CalendarPlus className="h-8 w-8 text-slate-400" aria-hidden="true" />
     </div>
   )
 }
 
-export default function EventCard({ event, onSelect, highlighted = false }) {
+export default function EventCard({ event, onSelect, highlighted = false, variant = 'default' }) {
   const occurrence = event.nextOccurrence || event.occurrences?.[0]
   const dateLabel = formatDateRange(occurrence, occurrence?.allDay ?? event.allDay)
   const isFree = event.priceType === 'Free'
@@ -90,6 +96,15 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
     ? { target: '_blank', rel: 'noopener noreferrer' }
     : {}
 
+  const isCompact = variant === 'compact'
+
+  const bodySpacing = isCompact ? 'gap-4 p-4' : 'gap-5 p-6'
+  const titleSize = isCompact ? 'text-xl' : 'text-2xl'
+  const summarySize = isCompact ? 'text-sm' : 'text-base'
+  const footerPadding = isCompact ? 'px-4 py-3' : 'px-6 py-4'
+  const detailButtonPadding = isCompact ? 'px-3 py-2' : 'px-4 py-3'
+  const actionButtonPadding = isCompact ? 'px-3 py-2' : 'px-4 py-2'
+
   return (
     <article
       id={event.slug ? `event-${event.slug}` : undefined}
@@ -100,17 +115,21 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
       <div className="sr-only" role="status" aria-live="polite">
         {showToast ? 'Link copied to clipboard' : ''}
       </div>
-      <div className="flex flex-col gap-5 p-6">
-        {event.image ? (
-          <img
-            src={event.image}
-            alt={`${event.title} preview`}
-            className="h-36 w-full rounded-xl object-cover"
-            loading="lazy"
-          />
-        ) : (
-          <PlaceholderImage />
-        )}
+      <div className={`flex flex-col ${bodySpacing}`}>
+        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+          <div className={`aspect-[4/3] w-full ${isCompact ? 'p-2' : 'p-3'} flex items-center justify-center bg-slate-50`}>
+            {event.image ? (
+              <img
+                src={event.image}
+                alt={`${event.title} preview`}
+                className="h-full w-full object-contain"
+                loading="lazy"
+              />
+            ) : (
+              <PlaceholderImage variant={variant} />
+            )}
+          </div>
+        </div>
 
         <div className="space-y-3">
           <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-slate-500">
@@ -118,10 +137,10 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
             <span className="h-1 w-1 rounded-full bg-slate-300" aria-hidden="true" />
             <span>{event.category}</span>
           </div>
-          <h3 className="text-2xl font-semibold tracking-tight text-slate-900">
+          <h3 className={`${titleSize} font-semibold tracking-tight text-slate-900`}>
             {event.title}
           </h3>
-          {dateLabel && <p className="text-base text-slate-700">{dateLabel}</p>}
+          {dateLabel && <p className="text-sm text-slate-700 sm:text-base">{dateLabel}</p>}
           {event.locationName && (
             <p className="flex items-center gap-2 text-sm text-slate-600">
               <MapPin className="h-4 w-4" aria-hidden="true" />
@@ -131,7 +150,7 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
               </span>
             </p>
           )}
-          {event.summary && <p className="text-sm leading-relaxed text-slate-600">{event.summary}</p>}
+          {event.summary && <p className={`${summarySize} leading-relaxed text-slate-600`}>{event.summary}</p>}
         </div>
 
         <div className="flex flex-wrap gap-2">
@@ -182,7 +201,7 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
             <a
               href={eventSiteHref}
               {...eventSiteLinkProps}
-              className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+              className={`inline-flex items-center gap-2 rounded-full border border-slate-300 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 ${actionButtonPadding}`}
             >
               Event site
               <EventSiteIcon className="h-4 w-4" aria-hidden="true" />
@@ -192,7 +211,7 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
           <button
             type="button"
             onClick={handleAddToCalendar}
-            className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+            className={`inline-flex items-center gap-2 rounded-full border border-slate-300 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 ${actionButtonPadding}`}
           >
             Add to calendar
             <CalendarPlus className="h-4 w-4" aria-hidden="true" />
@@ -203,7 +222,7 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
               href={mapHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+              className={`inline-flex items-center gap-2 rounded-full border border-slate-300 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 ${actionButtonPadding}`}
             >
               Map
               <MapPin className="h-4 w-4" aria-hidden="true" />
@@ -214,7 +233,7 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
             <button
               type="button"
               onClick={handleShare}
-              className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+              className={`inline-flex items-center gap-2 rounded-full border border-slate-300 text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 ${actionButtonPadding}`}
               aria-label={`Share ${event.title}`}
             >
               Share
@@ -230,11 +249,11 @@ export default function EventCard({ event, onSelect, highlighted = false }) {
         </div>
       )}
 
-      <div className="border-t border-slate-200 bg-slate-50 px-6 py-4">
+      <div className={`border-t border-slate-200 bg-slate-50 ${footerPadding}`}>
         <button
           type="button"
           onClick={() => onSelect?.(event)}
-          className="flex w-full items-center justify-between rounded-xl bg-white px-4 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600"
+          className={`flex w-full items-center justify-between rounded-xl bg-white text-sm font-semibold text-slate-900 shadow-sm transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600 ${detailButtonPadding}`}
           aria-label={`View details for ${event.title}`}
         >
           View details


### PR DESCRIPTION
## Summary
- group community events by month with responsive grids on the list view
- add a compact event card variant with consistent image framing and tighter spacing
- highlight month headings with dividers to improve scanning between sections

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_6900c56983f08324b7306417e8d38f70