### PR TITLE
Use calendar filters for list view

### DIFF
--- a/src/CommunityPage.js
+++ b/src/CommunityPage.js
@@ -281,7 +281,7 @@ export default function CommunityPage() {
           </div>
         </section>
 
-        {view === 'calendar' ? (
+        {view === 'calendar' && (
           <>
             <div className="mx-auto mb-6 max-w-6xl px-4 pt-8 text-center sm:px-6">
               <p className="text-base font-medium text-slate-600 sm:text-lg">
@@ -296,7 +296,17 @@ export default function CommunityPage() {
               onClear={handleResetFilters}
             />
           </>
-        ) : (
+        )}
+        {view === 'list' && (
+          <CalendarFilterBar
+            selectedCategories={filters.categories}
+            onSelectCategories={(categories) =>
+              setFilters((prev) => ({ ...prev, categories }))
+            }
+            onClear={handleResetFilters}
+          />
+        )}
+        {view === 'map' && (
           <EventFilters filters={filters} onChange={setFilters} onReset={handleResetFilters} />
         )}
 


### PR DESCRIPTION
## Summary
- render the calendar filter bar for the events list view so the filter controls match the calendar experience
- retain the existing advanced filters for the map view only

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6900d7d5fd8c83249c28acaeb2d9b61b