### PR TITLE
Ensure insights slugs resolve to published articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "NorthSide GTA Real Estate Website",
   "main": "index.js",
   "scripts": {
+    "prestart": "npm run generate:insights-manifest",
     "start": "react-scripts start",
+    "prebuild": "npm run generate:insights-manifest",
     "build": "react-scripts build",
     "postbuild": "node scripts/generate-curated-html.js && node scripts/generate-sitemap.js && cp build/index.html build/404.html",
     "generate:curated": "node scripts/generate-curated-html.js",
+    "generate:insights-manifest": "node scripts/generate-insights-manifest.js",
     "ingest:events": "node scripts/ingest-events.js",
     "events:backfill-daily": "node scripts/backfill-daily-schedule.mjs",
     "events:connectivity": "node scripts/events-connectivity.mjs",

--- a/public/config.yml
+++ b/public/config.yml
@@ -543,13 +543,13 @@ collections:
     label_singular: 'Insight'
     folder: 'public/content/insights'
     create: true
-    slug: '{{slug}}'
-    path: '{{slug}}/index'
+    slug: '{{fields.slug}}'
+    path: '{{fields.slug}}/index'
     extension: 'md'
     format: 'frontmatter'
     media_folder: 'public/uploads/insights'
     public_folder: '/uploads/insights'
-    preview_path: 'insights/{{slug}}'
+    preview_path: 'insights/{{fields.slug}}'
     summary: '{{title}} — {{publishDate}}'
     identifier_field: 'slug'
     fields:

--- a/public/content/insights/_manifest.json
+++ b/public/content/insights/_manifest.json
@@ -1,0 +1,20 @@
+[
+  {
+    "slug": "sample-launch",
+    "dir": "sample-launch",
+    "path": "sample-launch/index.md",
+    "title": "Exploring Aurora's Greenway Revival"
+  },
+  {
+    "slug": "testing-123",
+    "dir": "testing-123",
+    "path": "testing-123/index.md",
+    "title": "Testing 123"
+  },
+  {
+    "slug": "why-we-built-northside-gta",
+    "dir": "why-we-built-northside-gta",
+    "path": "why-we-built-northside-gta/index.md",
+    "title": "Why We Built NorthSide GTA — and What It Means for Home Buyers"
+  }
+]

--- a/scripts/generate-insights-manifest.js
+++ b/scripts/generate-insights-manifest.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const matter = require("gray-matter");
+
+const CONTENT_DIR = path.join(__dirname, "..", "public", "content", "insights");
+const OUTPUT_PATH = path.join(CONTENT_DIR, "_manifest.json");
+
+function safeSlug(value) {
+  if (!value) return "";
+  return value.toString().trim().toLowerCase();
+}
+
+function buildManifest() {
+  if (!fs.existsSync(CONTENT_DIR)) {
+    throw new Error(`Content directory not found: ${CONTENT_DIR}`);
+  }
+
+  const entries = fs
+    .readdirSync(CONTENT_DIR, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name)
+    .sort();
+
+  const manifest = [];
+
+  for (const dirName of entries) {
+    const indexPath = path.join(CONTENT_DIR, dirName, "index.md");
+    if (!fs.existsSync(indexPath)) {
+      continue;
+    }
+
+    const raw = fs.readFileSync(indexPath, "utf8");
+    const { data } = matter(raw);
+    const explicitSlug = safeSlug(data?.slug);
+    const slug = explicitSlug || safeSlug(dirName);
+
+    if (!slug) {
+      console.warn(`Skipping insight without slug: ${indexPath}`);
+      continue;
+    }
+
+    manifest.push({
+      slug,
+      dir: dirName,
+      path: `${dirName}/index.md`,
+      title: data?.title ? data.title.toString() : "",
+    });
+  }
+
+  manifest.sort((a, b) => a.slug.localeCompare(b.slug));
+
+  fs.writeFileSync(OUTPUT_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+buildManifest();

--- a/src/insights/InsightPage.js
+++ b/src/insights/InsightPage.js
@@ -84,23 +84,83 @@ function normalizeInsight(content) {
   };
 }
 
+const INSIGHTS_MANIFEST_URL = "/content/insights/_manifest.json";
+let cachedManifest = null;
+
+function normalizeSlugValue(value) {
+  if (!value) return "";
+  return value.toString().trim().toLowerCase();
+}
+
+async function loadInsightsManifest() {
+  if (cachedManifest) return cachedManifest;
+  try {
+    const res = await fetch(INSIGHTS_MANIFEST_URL, { cache: "no-store" });
+    if (!res.ok) {
+      throw new Error(`manifest_${res.status}`);
+    }
+    const json = await res.json();
+    cachedManifest = Array.isArray(json) ? json : [];
+  } catch (error) {
+    console.warn("Failed to load insights manifest", error);
+    cachedManifest = [];
+  }
+  return cachedManifest;
+}
+
+async function fetchInsightMarkdown(slug) {
+  const normalizedSlug = normalizeSlugValue(slug);
+  if (!normalizedSlug) {
+    const err = new Error("not_found");
+    err.code = "not_found";
+    throw err;
+  }
+
+  const directUrl = `/content/insights/${normalizedSlug}/index.md`;
+  let res = await fetch(directUrl, { cache: "no-store" });
+
+  if (res.ok) {
+    return res.text();
+  }
+
+  if (res.status !== 404) {
+    throw new Error(`Request failed: ${res.status}`);
+  }
+
+  const manifest = await loadInsightsManifest();
+  const match = manifest.find((item) => normalizeSlugValue(item?.slug) === normalizedSlug);
+
+  if (!match) {
+    const err = new Error("not_found");
+    err.code = "not_found";
+    throw err;
+  }
+
+  res = await fetch(`/content/insights/${match.dir}/index.md`, { cache: "no-store" });
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      const err = new Error("not_found");
+      err.code = "not_found";
+      throw err;
+    }
+    throw new Error(`Request failed: ${res.status}`);
+  }
+
+  return res.text();
+}
+
 function useInsight(slug) {
   const [state, setState] = useState({ loading: true, insight: null, error: null });
 
   useEffect(() => {
     if (!slug) return;
     let cancelled = false;
+
     async function load() {
       setState({ loading: true, insight: null, error: null });
       try {
-        const res = await fetch(`/content/insights/${slug}/index.md`, { cache: "no-store" });
-        if (!res.ok) {
-          if (res.status === 404) {
-            throw new Error("not_found");
-          }
-          throw new Error(`Request failed: ${res.status}`);
-        }
-        const text = await res.text();
+        const text = await fetchInsightMarkdown(slug);
         if (cancelled) return;
         const parsed = normalizeInsight(text);
         setState({ loading: false, insight: parsed, error: null });
@@ -109,6 +169,7 @@ function useInsight(slug) {
         setState({ loading: false, insight: null, error });
       }
     }
+
     load();
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary
- add an insights content manifest generator and hook it into the dev/build scripts
- update the CMS collection so the slug field controls the generated folder and preview path
- teach the insight detail page to fall back to the manifest when loading markdown

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69022254e7f0832485f0346931ec6edb