### PR TITLE
Improve front matter error context

### DIFF
--- a/src/insights/InsightPage.js
+++ b/src/insights/InsightPage.js
@@ -26,11 +26,15 @@ const IS_PRODUCTION = process.env.NODE_ENV === "production";
 
 class FrontMatterParseError extends Error {
   constructor(message, path = "", originalError = null) {
-    super(message);
+    const normalizedMessage = path
+      ? `Unable to parse front matter in ${path}: ${message}`
+      : `Unable to parse front matter: ${message}`;
+    super(normalizedMessage);
     this.name = "FrontMatterParseError";
     this.type = "frontmatter";
     this.path = path;
     this.originalError = originalError;
+    this.attemptedPaths = [];
   }
 }
 


### PR DESCRIPTION
## Summary
- extend the front matter parse error to include the source path in its message
- provide a default attempted path list on the custom error for clearer diagnostics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69024df5d96483248913d1ea32d79907