### PR TITLE
Fix insights slug path configuration

### DIFF
--- a/public/config.yml
+++ b/public/config.yml
@@ -543,13 +543,14 @@ collections:
     label_singular: 'Insight'
     folder: 'public/content/insights'
     create: true
-    slug: '{{fields.slug}}'
-    path: '{{fields.slug}}/index'
+    slug: '{{slug}}'
+    slug_field: 'slug'
+    path: '{{slug}}/index'
     extension: 'md'
     format: 'frontmatter'
     media_folder: 'public/uploads/insights'
     public_folder: '/uploads/insights'
-    preview_path: 'insights/{{fields.slug}}'
+    preview_path: 'insights/{{slug}}'
     summary: '{{title}} — {{publishDate}}'
     identifier_field: 'slug'
     fields:


### PR DESCRIPTION
## Summary
- align the insights collection slug/path templates with Decap CMS slug handling so new entries create the correct folder structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6902508392888324a7fb7ac165abb39d