### PR TITLE
Normalize Insight image handling and add checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "react-scripts start",
     "prebuild": "node scripts/generate-insights-data.js",
     "build": "react-scripts build",
-    "postbuild": "node scripts/generate-curated-html.js && node scripts/generate-sitemap.js && cp build/index.html build/404.html",
+    "postbuild": "node scripts/generate-curated-html.js && node scripts/generate-sitemap.js && node scripts/check-insight-images.js && cp build/index.html build/404.html",
     "generate:curated": "node scripts/generate-curated-html.js",
     "ingest:events": "node scripts/ingest-events.js",
     "events:backfill-daily": "node scripts/backfill-daily-schedule.mjs",
@@ -16,7 +16,9 @@
     "events:recover": "node scripts/events-recover.mjs",
     "events:normalize": "node scripts/events-normalize.mjs",
     "test": "node --test",
-    "generate:insights": "node scripts/generate-insights-data.js"
+    "generate:insights": "node scripts/generate-insights-data.js",
+    "insights:migrate-images": "node scripts/migrate-insight-image-paths.js",
+    "insights:check-images": "node scripts/check-insight-images.js"
   },
   "dependencies": {
     "@vercel/blob": "^2.0.0",

--- a/public/config.yml
+++ b/public/config.yml
@@ -550,6 +550,7 @@ collections:
     format: 'frontmatter'
     media_folder: 'public/uploads/insights'
     public_folder: '/uploads/insights'
+    media_folder_relative: false
     preview_path: 'insights/{{slug}}'
     summary: '{{title}} — {{publishDate}}'
     identifier_field: 'slug'

--- a/public/content/insights/why-we-built-northside-gta/index.md
+++ b/public/content/insights/why-we-built-northside-gta/index.md
@@ -1,12 +1,9 @@
 ---
 title: Why We Built NorthSide GTA — and What It Means for Home Buyers
 slug: why-we-built-northside-gta
-publishDate: 2025-10-28T15:52:00-04:00
+publishDate: 2025-10-28T19:52:00.000Z
 author: Landon Mulhall & Matthew Mulhall
-excerpt: We created NorthSide GTA to help home buyers see what life north of
-  Toronto is really like. Discover how towns like Uxbridge, Stouffville, Aurora,
-  and Georgina offer more space, more value, and stronger community while
-  staying closer to the city than most people think.
+excerpt: 'We created NorthSide GTA to help home buyers see what life north of Toronto is really like. Discover how towns like Uxbridge, Stouffville, Aurora, and Georgina offer more space, more value, and stronger community while staying closer to the city than most people think.'
 tags:
   - northside gta
   - homes north of toronto
@@ -21,14 +18,10 @@ tags:
 featureImage: /uploads/insights/whynorthsidegtablog.jpg
 featureImageAlt: View of the NorthSide GTA with morning sunlight
 gallery:
-  - image: uploads/insights/whynorthsidegtablog.jpg
+  - image: /uploads/insights/whynorthsidegtablog.jpg
 seo:
-  title: Why We Built NorthSide GTA — and What It Means for Home Buyers |
-    NorthSide GTA
-  description: We created NorthSide GTA to help home buyers see what life north of
-    Toronto is really like. Discover how towns like Uxbridge, Stouffville,
-    Aurora, and Georgina offer more space, more value, and stronger community
-    while staying closer to the city than most people think.
+  title: Why We Built NorthSide GTA — and What It Means for Home Buyers | NorthSide GTA
+  description: 'We created NorthSide GTA to help home buyers see what life north of Toronto is really like. Discover how towns like Uxbridge, Stouffville, Aurora, and Georgina offer more space, more value, and stronger community while staying closer to the city than most people think.'
   ogImage: /uploads/insights/whynorthsidegtablog.jpg
 ---
 **Why We Built NorthSide GTA and What It Means for Home Buyers**

--- a/public/data/insights/testing-123.json
+++ b/public/data/insights/testing-123.json
@@ -1,22 +1,22 @@
 {
   "slug": "testing-123",
   "title": "Testing 123",
-  "publishDate": "2025-10-28T20:41:00.000Z",
+  "publishDate": "2025-10-30T14:04:00.000Z",
   "author": "Landon Mulhall & Matthew Mulhall",
   "excerpt": "Test",
   "tags": [
     "northside gta"
   ],
-  "featureImage": "/uploads/insights/og-home.jpg",
+  "featureImage": "/uploads/insights/hero-about.jpg",
   "featureImageAlt": "Aerial view of the NorthSide GTA with morning sunlight",
   "seo": {
     "title": "Testing 123 | NorthSide GTA",
     "description": "Test",
-    "ogImage": "/uploads/insights/og-home.jpg"
+    "ogImage": "/uploads/insights/eastgwillimbury-banner.jpg"
   },
   "gallery": [
     {
-      "image": "/uploads/insights/og-home.jpg",
+      "image": "/uploads/insights/scugog-banner.jpg",
       "alt": "",
       "caption": ""
     }

--- a/scripts/check-insight-images.js
+++ b/scripts/check-insight-images.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const matter = require("gray-matter");
+
+const rootDir = path.resolve(__dirname, "..");
+const insightsDir = path.join(rootDir, "public", "content", "insights");
+const uploadsDir = path.join(rootDir, "public", "uploads", "insights");
+const INSIGHTS_UPLOAD_WEB_PATH = "/uploads/insights/";
+
+function parseImageDestination(destination) {
+  if (!destination) return null;
+  const trimmed = destination.trim();
+  if (!trimmed) return null;
+
+  let body = trimmed;
+  if (body.startsWith("<") && body.endsWith(">")) {
+    body = body.slice(1, -1).trim();
+  }
+
+  const match = body.match(/^([^\s]+)(?:\s+(['"])(.*)\2)?$/);
+  if (!match) return null;
+  return match[1];
+}
+
+function isExternal(url) {
+  return /^https?:\/\//i.test(url) || url.startsWith("data:");
+}
+
+function extractMarkdownImagePaths(markdown) {
+  if (!markdown) return [];
+  const results = [];
+  const pattern = /!\[[^\]]*]\(([^)]+)\)/g;
+  let match;
+  while ((match = pattern.exec(markdown)) !== null) {
+    const destination = match[1];
+    const url = parseImageDestination(destination);
+    if (url) {
+      results.push(url);
+    }
+  }
+  return results;
+}
+
+function findInsightMarkdownFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(dir, entry.name, "index.md"))
+    .filter((filePath) => fs.existsSync(filePath));
+}
+
+function main() {
+  if (!fs.existsSync(uploadsDir)) {
+    console.warn(
+      `[check-insight-images] Skipping verification — uploads directory not found at ${path.relative(rootDir, uploadsDir)}`,
+    );
+    return;
+  }
+
+  const files = findInsightMarkdownFiles(insightsDir);
+  if (!files.length) {
+    console.log("[check-insight-images] No insight markdown files found.");
+    return;
+  }
+
+  const missing = [];
+  const unprefixed = [];
+
+  files.forEach((filePath) => {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = matter(raw);
+    const imagePaths = extractMarkdownImagePaths(parsed.content);
+    const relativeMarkdownPath = path.relative(rootDir, filePath);
+
+    imagePaths.forEach((url) => {
+      if (isExternal(url)) {
+        return;
+      }
+
+      if (url.startsWith(INSIGHTS_UPLOAD_WEB_PATH)) {
+        const diskPath = path.join(rootDir, "public", url);
+        if (!fs.existsSync(diskPath)) {
+          missing.push(`${relativeMarkdownPath} -> ${url}`);
+        }
+        return;
+      }
+
+      unprefixed.push(`${relativeMarkdownPath} -> ${url}`);
+    });
+  });
+
+  if (missing.length) {
+    console.warn("[check-insight-images] Missing insight image files:");
+    missing.forEach((entry) => console.warn(`  - ${entry}`));
+  }
+
+  if (unprefixed.length) {
+    console.warn("[check-insight-images] Insight markdown images missing /uploads/insights/ prefix:");
+    unprefixed.forEach((entry) => console.warn(`  - ${entry}`));
+  }
+
+  if (!missing.length && !unprefixed.length) {
+    console.log("[check-insight-images] All insight markdown images resolved successfully.");
+  }
+}
+
+main();

--- a/scripts/generate-insights-data.js
+++ b/scripts/generate-insights-data.js
@@ -8,6 +8,9 @@ const rootDir = path.resolve(__dirname, "..");
 const contentDir = path.join(rootDir, "public", "content", "insights");
 const outputDir = path.join(rootDir, "public", "data", "insights");
 
+const INSIGHTS_UPLOAD_WEB_PATH = "/uploads/insights/";
+const INSIGHTS_UPLOAD_INTERNAL_PREFIX = "uploads/insights/";
+
 function safeString(value, fallback = "") {
   if (value == null) return fallback;
   if (typeof value === "string") return value.trim();
@@ -21,11 +24,20 @@ function safeString(value, fallback = "") {
 function normalizeAssetPath(value) {
   const raw = safeString(value);
   if (!raw) return "";
-  if (/^https?:\/\//i.test(raw)) return raw;
+  if (/^https?:\/\//i.test(raw) || raw.startsWith("data:")) return raw;
+  if (raw.startsWith(INSIGHTS_UPLOAD_WEB_PATH)) return raw;
+
   const normalized = raw
     .replace(/^(\.\/|\.\.\/)+/, "")
     .replace(/^\/+/, "");
-  return `/${normalized}`;
+
+  if (!normalized) return "";
+
+  if (normalized.startsWith(INSIGHTS_UPLOAD_INTERNAL_PREFIX)) {
+    return `/${normalized}`;
+  }
+
+  return `${INSIGHTS_UPLOAD_WEB_PATH}${normalized}`;
 }
 
 function normalizeGallery(raw) {

--- a/scripts/migrate-insight-image-paths.js
+++ b/scripts/migrate-insight-image-paths.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const matter = require("gray-matter");
+
+const rootDir = path.resolve(__dirname, "..");
+const insightsDir = path.join(rootDir, "public", "content", "insights");
+const INSIGHTS_UPLOAD_WEB_PATH = "/uploads/insights/";
+const INSIGHTS_UPLOAD_INTERNAL_PREFIX = "uploads/insights/";
+
+function ensureUploadPath(value) {
+  if (value == null) return "";
+  const raw = typeof value === "string" ? value.trim() : String(value).trim();
+  if (!raw) return "";
+  if (/^https?:\/\//i.test(raw) || raw.startsWith("data:")) return raw;
+  if (raw.startsWith(INSIGHTS_UPLOAD_WEB_PATH)) return raw;
+
+  const normalized = raw
+    .replace(/^(\.\/|\.\.\/)+/, "")
+    .replace(/^\/+/, "");
+
+  if (!normalized) return "";
+
+  if (normalized.startsWith(INSIGHTS_UPLOAD_INTERNAL_PREFIX)) {
+    return `/${normalized}`;
+  }
+
+  return `${INSIGHTS_UPLOAD_WEB_PATH}${normalized}`;
+}
+
+function updateAssetField(target, key) {
+  if (!target || typeof target !== "object") return false;
+  if (!Object.prototype.hasOwnProperty.call(target, key)) return false;
+  const current = target[key];
+  const normalized = ensureUploadPath(current);
+  if (!normalized || normalized === current) return false;
+  target[key] = normalized;
+  return true;
+}
+
+function normalizeGalleryEntries(gallery) {
+  if (!Array.isArray(gallery)) return false;
+  let changed = false;
+  gallery.forEach((entry, index) => {
+    if (!entry) return;
+    if (typeof entry === "string") {
+      const normalized = ensureUploadPath(entry);
+      if (normalized && normalized !== entry) {
+        gallery[index] = normalized;
+        changed = true;
+      }
+      return;
+    }
+
+    if (typeof entry === "object") {
+      const normalized = ensureUploadPath(entry.image);
+      if (normalized && normalized !== entry.image) {
+        entry.image = normalized;
+        changed = true;
+      }
+    }
+  });
+  return changed;
+}
+
+function parseImageDestination(destination) {
+  if (!destination) return null;
+  const trimmed = destination.trim();
+  if (!trimmed) return null;
+
+  let body = trimmed;
+  let hasAngles = false;
+  if (body.startsWith("<") && body.endsWith(">")) {
+    body = body.slice(1, -1).trim();
+    hasAngles = true;
+  }
+
+  const match = body.match(/^([^\s]+?)(?:\s+(['"])(.*)\2)?$/);
+  if (!match) {
+    return {
+      url: body,
+      title: "",
+      quote: "\"",
+      hasAngles,
+    };
+  }
+
+  return {
+    url: match[1],
+    title: match[3] || "",
+    quote: match[2] || "\"",
+    hasAngles,
+  };
+}
+
+function rewriteMarkdownImages(markdown) {
+  if (!markdown) return { content: markdown, changed: false };
+
+  const imagePattern = /!\[([^\]]*)]\(([^)]+)\)/g;
+  let changed = false;
+
+  const updated = markdown.replace(imagePattern, (match, altText, destination) => {
+    const parsed = parseImageDestination(destination);
+    if (!parsed) return match;
+
+    const normalized = ensureUploadPath(parsed.url);
+    if (!normalized || normalized === parsed.url) {
+      return match;
+    }
+
+    changed = true;
+    const urlPart = parsed.hasAngles ? `<${normalized}>` : normalized;
+    const quote = parsed.quote || '"';
+    const titleSegment = parsed.title ? ` ${quote}${parsed.title}${quote}` : "";
+    return `![${altText}](${urlPart}${titleSegment})`;
+  });
+
+  return { content: updated, changed };
+}
+
+function findInsightEntries(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(dir, entry.name, "index.md"))
+    .filter((filePath) => fs.existsSync(filePath));
+}
+
+function processFile(filePath) {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const parsed = matter(raw);
+  const data = parsed.data || {};
+
+  let changed = false;
+
+  if (updateAssetField(data, "featureImage")) changed = true;
+  if (updateAssetField(data, "feature_image")) changed = true;
+
+  if (data.seo && typeof data.seo !== "object") {
+    data.seo = {};
+    changed = true;
+  }
+
+  if (data.seo && typeof data.seo === "object") {
+    if (updateAssetField(data.seo, "ogImage")) changed = true;
+    if (updateAssetField(data.seo, "og_image")) changed = true;
+  }
+
+  if (normalizeGalleryEntries(data.gallery)) changed = true;
+
+  const { content: updatedContent, changed: bodyChanged } = rewriteMarkdownImages(parsed.content);
+  if (bodyChanged) {
+    parsed.content = updatedContent;
+    changed = true;
+  }
+
+  if (!changed) return false;
+
+  const output = matter.stringify(parsed.content, data, { lineWidth: 1000 });
+  fs.writeFileSync(filePath, output, "utf8");
+  console.log(`[migrate-insight-image-paths] Updated ${path.relative(rootDir, filePath)}`);
+  return true;
+}
+
+function main() {
+  if (!fs.existsSync(insightsDir)) {
+    console.warn(
+      `[migrate-insight-image-paths] Skipping — insights directory not found at ${path.relative(rootDir, insightsDir)}`,
+    );
+    return;
+  }
+
+  const files = findInsightEntries(insightsDir);
+  if (!files.length) {
+    console.log("[migrate-insight-image-paths] No insight markdown files found.");
+    return;
+  }
+
+  let updatedCount = 0;
+  files.forEach((filePath) => {
+    if (processFile(filePath)) {
+      updatedCount += 1;
+    }
+  });
+
+  if (updatedCount === 0) {
+    console.log("[migrate-insight-image-paths] All insight image paths are already normalized.");
+  } else {
+    console.log(`[migrate-insight-image-paths] Normalized image paths in ${updatedCount} file${updatedCount === 1 ? "" : "s"}.`);
+  }
+}
+
+main();

--- a/src/insights/InsightPage.js
+++ b/src/insights/InsightPage.js
@@ -22,11 +22,33 @@ import {
 } from "lucide-react";
 
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
+const INSIGHT_UPLOAD_WEB_PATH = "/uploads/insights/";
+const INSIGHT_UPLOAD_INTERNAL_PREFIX = "uploads/insights/";
+
+function ensureInsightUploadPath(value) {
+  if (value == null) return "";
+  const raw = typeof value === "string" ? value.trim() : String(value).trim();
+  if (!raw) return "";
+  if (/^https?:\/\//i.test(raw) || raw.startsWith("data:")) return raw;
+  if (raw.startsWith(INSIGHT_UPLOAD_WEB_PATH)) return raw;
+
+  const normalized = raw
+    .replace(/^(\.\/|\.\.\/)+/, "")
+    .replace(/^\/+/, "");
+
+  if (!normalized) return "";
+
+  if (normalized.startsWith(INSIGHT_UPLOAD_INTERNAL_PREFIX)) {
+    return `/${normalized}`;
+  }
+
+  return `${INSIGHT_UPLOAD_WEB_PATH}${normalized}`;
+}
 
 const markdownRenderer = new marked.Renderer();
 markdownRenderer.image = (href, title, text) => {
   const caption = title ? `<figcaption class="insight-figure__caption">${title}</figcaption>` : "";
-  const safeSrc = href || "";
+  const safeSrc = ensureInsightUploadPath(href || "");
   const safeAlt = text || "";
   return `
     <figure class="insight-figure">
@@ -48,7 +70,8 @@ function normalizeGallery(raw) {
   return raw
     .map((item) => {
       if (!item) return null;
-      const image = typeof item === "string" ? item : item.image;
+      const imageValue = typeof item === "string" ? item : item.image;
+      const image = ensureInsightUploadPath(imageValue);
       if (!image) return null;
       return {
         image,
@@ -87,14 +110,14 @@ function normalizeInsight(data, sourcePath = "") {
     excerpt: safeString(data.excerpt),
     publishDate: safeString(data.publishDate),
     tags,
-    featureImage: safeString(data.featureImage),
+    featureImage: ensureInsightUploadPath(data.featureImage),
     featureImageAlt: safeString(data.featureImageAlt),
     body: typeof data.body === "string" ? data.body : "",
     sourcePath: safeString(data.sourcePath) || sourcePath,
     seo: {
       title: safeString(data?.seo?.title),
       description: safeString(data?.seo?.description),
-      ogImage: safeString(data?.seo?.ogImage),
+      ogImage: ensureInsightUploadPath(data?.seo?.ogImage),
     },
     gallery: normalizeGallery(data.gallery),
   };


### PR DESCRIPTION
## Summary
- enforce /uploads/insights paths when generating data and rendering Insight content
- add a one-time migration utility plus a post-build validator for Insight image references
- normalize existing Insight content front matter and regenerate data with absolute image URLs

## Testing
- npm run insights:migrate-images
- npm run generate:insights
- npm run insights:check-images

------
https://chatgpt.com/codex/tasks/task_e_69037230779483249170cc2926126b17