### PR TITLE
Refactor dynamic SEO meta handling for collections, events, and insights

### DIFF
--- a/scripts/generate-curated-html.js
+++ b/scripts/generate-curated-html.js
@@ -161,7 +161,7 @@ function computeMeta(data, slug, origin) {
   const ogImage = ogImageSecure || ogImageRaw;
   const pageTitle = `${headline} • NorthSide GTA`;
   const heroAltText = `${heroAltBase} hero image`;
-  const twitterCard = ogImage ? "summary_large_image" : "summary";
+  const twitterCard = "summary_large_image";
 
   return {
     slug,

--- a/src/CuratedPage.js
+++ b/src/CuratedPage.js
@@ -1,8 +1,8 @@
 // src/CuratedPage.js
 import React from "react";
 import { useParams } from "react-router-dom";
-import { Helmet } from "react-helmet-async";
 import LeadForm from "./components/LeadForm";
+import DynamicMetaTags from "./components/seo/DynamicMetaTags";
 
 function useCurated(slug) {
   const [page, setPage] = React.useState(null);
@@ -107,40 +107,36 @@ export default function CuratedPage() {
   const whatsappHref = typeof page.whatsappUrl === "string" ? page.whatsappUrl.trim() : "";
 
   const slugValue = typeof slug === "string" ? slug.trim() : "";
+  const canonicalSlug =
+    (typeof page.slug === "string" && page.slug.trim()) || slugValue || "";
   const slugText = slugValue ? slugValue.replace(/[-_]+/g, " ").trim() : "";
   const heroAltText = `${headline || slugText || "NorthSide GTA"} hero image`;
-  const canonicalUrl =
-    typeof window !== "undefined" && window.location
-      ? window.location.href
-      : absoluteUrl(`/collections/${encodeURIComponent(slugValue)}`);
+  const canonicalUrl = absoluteUrl(`/collections/${encodeURIComponent(canonicalSlug)}`);
   const pageTitle = `${headline} • NorthSide GTA`;
-  const twitterCardType = ogImage ? "summary_large_image" : "summary";
+
+  const metaConfig = {
+    documentTitle: pageTitle,
+    title: pageTitle,
+    description: seoDescription,
+    canonicalUrl,
+    ogType: "website",
+    ogImage,
+    ogImageAlt: heroAltText,
+    siteName: "NorthSide GTA",
+    twitterCard: "summary_large_image",
+    twitterImage: ogImage,
+    additionalMeta: [
+      { name: "robots", content: "noindex,nofollow" },
+      ogImageSecure && { property: "og:image:secure_url", content: ogImageSecure || ogImage },
+      ogImageType && { property: "og:image:type", content: ogImageType },
+      canonicalUrl && { name: "twitter:url", content: canonicalUrl },
+      ogImageType && { name: "twitter:image:type", content: ogImageType },
+    ].filter(Boolean),
+  };
 
   return (
     <>
-      <Helmet>
-        <title>{pageTitle}</title>
-        <meta name="description" content={seoDescription} />
-        <meta name="robots" content="noindex,nofollow" />
-        <link rel="canonical" href={canonicalUrl} />
-        <meta property="og:title" content={pageTitle} />
-        <meta property="og:description" content={seoDescription} />
-        <meta property="og:url" content={canonicalUrl} />
-        <meta property="og:type" content="website" />
-        {ogImage && <meta property="og:image" content={ogImage} />}
-        {(ogImageSecure || ogImage) && (
-          <meta property="og:image:secure_url" content={ogImageSecure || ogImage} />
-        )}
-        {ogImageType && <meta property="og:image:type" content={ogImageType} />}
-        {ogImage && <meta property="og:image:alt" content={heroAltText} />}
-        <meta name="twitter:card" content={twitterCardType} />
-        <meta name="twitter:title" content={pageTitle} />
-        <meta name="twitter:description" content={seoDescription} />
-        <meta name="twitter:url" content={canonicalUrl} />
-        {ogImage && <meta name="twitter:image" content={ogImage} />}
-        {ogImageType && <meta name="twitter:image:type" content={ogImageType} />}
-        {ogImage && <meta name="twitter:image:alt" content={heroAltText} />}
-      </Helmet>
+      <DynamicMetaTags {...metaConfig} />
 
       <div style={layout.page}>
         <main style={layout.main}>

--- a/src/community/EventDetailPage.js
+++ b/src/community/EventDetailPage.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useParams, Link, useLocation } from 'react-router-dom'
-import { Helmet } from 'react-helmet-async'
 import {
   ArrowLeft,
   CalendarPlus,
@@ -23,6 +22,7 @@ import {
   shareEvent,
   toAbsoluteUrl,
 } from './shareUtils'
+import DynamicMetaTags from '../components/seo/DynamicMetaTags'
 
 const SITE_ORIGIN = 'https://northsidegta.ca'
 const FALLBACK_IMAGE = '/Images/hero-desktop.jpg'
@@ -66,6 +66,13 @@ function splitParagraphs(text) {
     .split(/\n{2,}/)
     .map((segment) => segment.trim())
     .filter(Boolean)
+}
+
+function toIsoString(value) {
+  if (!value) return ''
+  const date = value instanceof Date ? value : new Date(value)
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return ''
+  return date.toISOString()
 }
 
 function buildEventSchema(event, origin = SITE_ORIGIN, descriptionOverride = '', occurrenceOverride = null) {
@@ -416,6 +423,53 @@ export default function EventDetailPage() {
       ? new Date(event.startDate).toISOString()
       : ''
 
+  const eventStartIso = occurrence?.start ? toIsoString(occurrence.start) : toIsoString(event?.startDate)
+  const eventEndIso = occurrence?.end ? toIsoString(occurrence.end) : toIsoString(event?.endDate)
+  const eventLocation = React.useMemo(() => {
+    if (!event) return ''
+    const parts = [event.locationName, event.address, event.subArea, event.town]
+      .map((value) => (typeof value === 'string' ? normalizeWhitespace(value) : ''))
+      .filter(Boolean)
+    if (!parts.length) return ''
+    return [...new Set(parts)].join(', ')
+  }, [event])
+
+  const metaConfig = React.useMemo(
+    () => ({
+      documentTitle: pageTitle,
+      title: shareTitle || pageTitle,
+      ogTitle: shareTitle || pageTitle,
+      twitterTitle: shareTitle || pageTitle,
+      description: pageDescription,
+      canonicalUrl,
+      ogType: 'event',
+      ogImage,
+      ogImageAlt: shareTitle,
+      siteName: 'NorthSide GTA',
+      twitterCard: 'summary_large_image',
+      twitterImage: ogImage,
+      articlePublishedTime: publishedTime,
+      additionalMeta: [
+        eventStartIso && { property: 'event:start_time', content: eventStartIso },
+        eventEndIso && { property: 'event:end_time', content: eventEndIso },
+        eventLocation && { property: 'event:location', content: eventLocation },
+        event?.hidden && { name: 'robots', content: 'noindex' },
+      ].filter(Boolean),
+    }),
+    [
+      canonicalUrl,
+      event?.hidden,
+      eventEndIso,
+      eventLocation,
+      eventStartIso,
+      ogImage,
+      pageDescription,
+      pageTitle,
+      publishedTime,
+      shareTitle,
+    ],
+  )
+
   const handleAddToCalendar = React.useCallback(() => {
     if (!event) return
     if (event.icsUrl) {
@@ -481,26 +535,9 @@ export default function EventDetailPage() {
 
   return (
     <>
-      <Helmet>
-        <title>{pageTitle}</title>
-        <meta name="description" content={pageDescription} />
-        <link rel="canonical" href={canonicalUrl} />
-        <meta property="og:title" content={shareTitle} />
-        <meta property="og:description" content={pageDescription} />
-        <meta property="og:type" content="event" />
-        <meta property="og:url" content={shareUrl} />
-        {ogImage && <meta property="og:image" content={ogImage} />}
-        {ogImage && <meta property="og:image:alt" content={shareTitle} />}
-        <meta property="og:site_name" content="NorthSide GTA" />
-        {publishedTime && <meta property="article:published_time" content={publishedTime} />}
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={shareTitle} />
-        <meta name="twitter:description" content={pageDescription} />
-        {ogImage && <meta name="twitter:image" content={ogImage} />}
-        {ogImage && <meta name="twitter:image:alt" content={shareTitle} />}
-        {event?.hidden && <meta name="robots" content="noindex" />}
+      <DynamicMetaTags {...metaConfig}>
         {schema && <script type="application/ld+json">{schema}</script>}
-      </Helmet>
+      </DynamicMetaTags>
 
       <Navigation />
 

--- a/src/components/seo/DynamicMetaTags.js
+++ b/src/components/seo/DynamicMetaTags.js
@@ -1,0 +1,129 @@
+import React from "react";
+import { Helmet } from "react-helmet-async";
+
+const DEFAULT_TWITTER_CARD = "summary_large_image";
+
+function safeString(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value.trim();
+  return String(value).trim();
+}
+
+export default function DynamicMetaTags({
+  documentTitle,
+  title,
+  ogTitle,
+  twitterTitle,
+  description,
+  ogDescription,
+  twitterDescription,
+  canonicalUrl,
+  ogType,
+  ogImage,
+  ogImageAlt,
+  twitterCard,
+  twitterImage,
+  twitterImageAlt,
+  siteName,
+  articleAuthor,
+  articlePublishedTime,
+  additionalMeta = [],
+  children,
+}) {
+  const titleValue = safeString(title);
+  const documentTitleValue = safeString(documentTitle || titleValue);
+  const ogTitleValue = safeString(ogTitle || titleValue);
+  const twitterTitleValue = safeString(twitterTitle || ogTitleValue || documentTitleValue);
+
+  const descriptionValue = safeString(description);
+  const ogDescriptionValue = safeString(ogDescription || descriptionValue);
+  const twitterDescriptionValue = safeString(twitterDescription || ogDescriptionValue || descriptionValue);
+
+  const canonicalValue = safeString(canonicalUrl);
+  const ogTypeValue = safeString(ogType);
+  const ogImageValue = safeString(ogImage);
+  const twitterCardValue = safeString(twitterCard) || DEFAULT_TWITTER_CARD;
+  const ogImageAltValue = safeString(ogImageAlt);
+  const twitterImageValue = safeString(twitterImage || ogImageValue);
+  const twitterImageAltValue = safeString(twitterImageAlt || ogImageAltValue);
+  const siteNameValue = safeString(siteName);
+  const articleAuthorValue = safeString(articleAuthor);
+  const articlePublishedTimeValue = safeString(articlePublishedTime);
+
+  const normalizedAdditionalMeta = Array.isArray(additionalMeta)
+    ? additionalMeta
+        .map((meta) => {
+          if (!meta) return null;
+          const name = safeString(meta.name);
+          const property = safeString(meta.property);
+          const content = safeString(meta.content);
+          if (!content || (!name && !property)) return null;
+          return {
+            key: meta.key,
+            name: name || undefined,
+            property: property || undefined,
+            content,
+          };
+        })
+        .filter(Boolean)
+    : [];
+
+  if (
+    !documentTitleValue &&
+    !titleValue &&
+    !descriptionValue &&
+    !canonicalValue &&
+    !ogTypeValue &&
+    !ogImageValue &&
+    !twitterImageValue &&
+    !siteNameValue &&
+    !articleAuthorValue &&
+    !articlePublishedTimeValue &&
+    normalizedAdditionalMeta.length === 0 &&
+    !children
+  ) {
+    return null;
+  }
+
+  return (
+    <Helmet>
+      {documentTitleValue && <title>{documentTitleValue}</title>}
+      {descriptionValue && <meta name="description" content={descriptionValue} />}
+      {canonicalValue && <link rel="canonical" href={canonicalValue} />}
+
+      {ogTypeValue && <meta property="og:type" content={ogTypeValue} />}
+      {ogTitleValue && <meta property="og:title" content={ogTitleValue} />}
+      {ogDescriptionValue && <meta property="og:description" content={ogDescriptionValue} />}
+      {canonicalValue && <meta property="og:url" content={canonicalValue} />}
+      {ogImageValue && <meta property="og:image" content={ogImageValue} />}
+      {ogImageAltValue && <meta property="og:image:alt" content={ogImageAltValue} />}
+      {siteNameValue && <meta property="og:site_name" content={siteNameValue} />}
+
+      <meta name="twitter:card" content={twitterCardValue || DEFAULT_TWITTER_CARD} />
+      {(twitterTitleValue || ogTitleValue) && (
+        <meta name="twitter:title" content={twitterTitleValue || ogTitleValue} />
+      )}
+      {(twitterDescriptionValue || ogDescriptionValue) && (
+        <meta name="twitter:description" content={twitterDescriptionValue || ogDescriptionValue} />
+      )}
+      {twitterImageValue && <meta name="twitter:image" content={twitterImageValue} />}
+      {twitterImageAltValue && <meta name="twitter:image:alt" content={twitterImageAltValue} />}
+
+      {articlePublishedTimeValue && (
+        <meta property="article:published_time" content={articlePublishedTimeValue} />
+      )}
+      {articleAuthorValue && <meta property="article:author" content={articleAuthorValue} />}
+
+      {normalizedAdditionalMeta.map((meta, index) => (
+        <meta
+          key={meta.key || `${meta.name || meta.property}-${index}`}
+          {...(meta.name ? { name: meta.name } : { property: meta.property })}
+          content={meta.content}
+        />
+      ))}
+
+      {children}
+    </Helmet>
+  );
+}
+

--- a/src/insights/InsightPage.js
+++ b/src/insights/InsightPage.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useParams } from "react-router-dom";
-import { Helmet } from "react-helmet-async";
 import { marked } from "marked";
 import { DateTime } from "luxon";
 import Navigation from "../Navigation";
@@ -13,6 +12,7 @@ import {
 import { trackEvent } from "../utils/analytics";
 import { getSiteOrigin, toAbsoluteUrl } from "../community/shareUtils";
 import { getSocialLinks } from "../utils/socialLinks";
+import DynamicMetaTags from "../components/seo/DynamicMetaTags";
 import {
   Facebook,
   Instagram,
@@ -788,30 +788,47 @@ export default function InsightPage() {
     errorMessage = "Something went wrong while loading this insight. Please try again.";
   }
 
+  const articleTagsMeta = useMemo(() => {
+    if (!Array.isArray(insight?.tags)) return [];
+    return insight.tags
+      .map((tag) => {
+        if (!tag) return null;
+        const trimmed = typeof tag === "string" ? tag.trim() : String(tag).trim();
+        if (!trimmed) return null;
+        return { property: "article:tag", content: trimmed, key: `article-tag-${trimmed}` };
+      })
+      .filter(Boolean);
+  }, [insight?.tags]);
+
+  const metaConfig = useMemo(
+    () => ({
+      documentTitle: seoTitle,
+      title: seoTitle,
+      description: metaDescription,
+      canonicalUrl,
+      ogType: "article",
+      ogImage: ogImageAbsolute,
+      ogImageAlt,
+      twitterCard: "summary_large_image",
+      articlePublishedTime: publishedIso,
+      articleAuthor: insight?.author,
+      additionalMeta: articleTagsMeta,
+    }),
+    [
+      seoTitle,
+      metaDescription,
+      canonicalUrl,
+      ogImageAbsolute,
+      ogImageAlt,
+      publishedIso,
+      insight?.author,
+      articleTagsMeta,
+    ],
+  );
+
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
-      <Helmet>
-        <title>{seoTitle}</title>
-        {metaDescription && <meta name="description" content={metaDescription} />}
-        {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
-        <meta property="og:type" content="article" />
-        {seoTitle && <meta property="og:title" content={seoTitle} />}
-        {metaDescription && <meta property="og:description" content={metaDescription} />}
-        {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
-        {ogImageAbsolute && <meta property="og:image" content={ogImageAbsolute} />}
-        {ogImageAlt && <meta property="og:image:alt" content={ogImageAlt} />}
-        <meta name="twitter:card" content="summary_large_image" />
-        {seoTitle && <meta name="twitter:title" content={seoTitle} />}
-        {metaDescription && <meta name="twitter:description" content={metaDescription} />}
-        {ogImageAbsolute && <meta name="twitter:image" content={ogImageAbsolute} />}
-        {ogImageAlt && <meta name="twitter:image:alt" content={ogImageAlt} />}
-        {publishedIso && <meta property="article:published_time" content={publishedIso} />}
-        {insight?.author && <meta property="article:author" content={insight.author} />}
-        {Array.isArray(insight?.tags) &&
-          insight.tags.map((tag) => (
-            <meta key={tag} property="article:tag" content={tag} />
-          ))}
-      </Helmet>
+      <DynamicMetaTags {...metaConfig} />
 
       <Navigation />
 


### PR DESCRIPTION
## Summary
- add a reusable DynamicMetaTags helper for building Open Graph, Twitter, and canonical tags
- update insight, event, and collection routes to supply CMS-driven SEO data and required type-specific metadata
- align the curated page static generator with the shared configuration for Twitter cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6904ccc2f94c8324afb24677ef5205c6