### PR TITLE
Generate server-rendered SEO tags for insights and events

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "react-scripts start",
     "prebuild": "node scripts/generate-insights-data.js",
     "build": "react-scripts build",
-    "postbuild": "node scripts/generate-curated-html.js && node scripts/generate-sitemap.js && node scripts/check-insight-images.js && cp build/index.html build/404.html",
+    "postbuild": "node scripts/generate-curated-html.js && node scripts/generate-insight-html.js && node scripts/generate-event-html.js && node scripts/generate-sitemap.js && node scripts/check-insight-images.js && cp build/index.html build/404.html",
     "generate:curated": "node scripts/generate-curated-html.js",
     "ingest:events": "node scripts/ingest-events.js",
     "events:backfill-daily": "node scripts/backfill-daily-schedule.mjs",

--- a/scripts/generate-event-html.js
+++ b/scripts/generate-event-html.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("node-html-parser");
+
+const {
+  DEFAULT_ORIGIN,
+  loadTemplate,
+  sanitizeSlug,
+  cleanString,
+  collapseWhitespace,
+  truncate,
+  buildUrl,
+  absoluteUrl,
+  ensureSecureUrl,
+  stripSeoTags,
+  appendHeadTag,
+  finalizeHtml,
+} = require("./utils/staticMeta");
+const { getMetaTagHtmlList } = require("../src/components/seo/metaTagUtils.js");
+
+const FALLBACK_IMAGE = "/Images/hero-desktop.jpg";
+const DESCRIPTION_LENGTH = 160;
+const DEFAULT_DESCRIPTION = "Explore community events across the NorthSide GTA.";
+
+function main() {
+  const template = loadTemplate();
+  if (!template) {
+    console.warn("[generate-event-html] Skipping — unable to locate HTML template");
+    process.exit(0);
+  }
+
+  const dataDir = path.join(template.publicDir, "data", "events");
+  if (!fs.existsSync(dataDir)) {
+    console.warn(
+      `[generate-event-html] Skipping — events directory not found at ${path.relative(
+        template.rootDir,
+        dataDir,
+      )}`,
+    );
+    process.exit(0);
+  }
+
+  const outputRoot = template.hasBuildTemplate
+    ? path.join(template.buildDir, "events")
+    : path.join(template.publicDir, "events");
+
+  if (fs.existsSync(outputRoot)) {
+    fs.rmSync(outputRoot, { recursive: true, force: true });
+  }
+  fs.mkdirSync(outputRoot, { recursive: true });
+
+  const files = fs
+    .readdirSync(dataDir)
+    .filter((name) => name.toLowerCase().endsWith(".json"))
+    .sort();
+
+  if (files.length === 0) {
+    console.log("[generate-event-html] No events to process.");
+    return;
+  }
+
+  const failures = [];
+  let created = 0;
+
+  files.forEach((fileName) => {
+    const filePath = path.join(dataDir, fileName);
+    let payload;
+    try {
+      payload = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch (error) {
+      failures.push({ file: fileName, reason: `Invalid JSON (${error.message})` });
+      return;
+    }
+
+    const fallbackSlug = fileName.replace(/\.json$/i, "");
+    const slug = sanitizeSlug(payload.slug, fallbackSlug);
+    if (!slug) {
+      failures.push({ file: fileName, reason: "Missing slug" });
+      return;
+    }
+
+    try {
+      const metaConfig = computeEventMeta(payload, slug, template.siteOrigin || DEFAULT_ORIGIN);
+      const headFragments = getMetaTagHtmlList(metaConfig);
+
+      const doc = parse(template.baseHtml, { comment: true });
+      const head = doc.querySelector("head");
+      if (!head) {
+        throw new Error("Template is missing <head> element");
+      }
+
+      stripSeoTags(head);
+      headFragments.forEach((fragment) => appendHeadTag(head, fragment));
+
+      const html = finalizeHtml(doc, template.doctype);
+      const targetDir = path.join(outputRoot, slug);
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(path.join(targetDir, "index.html"), html, "utf8");
+      created += 1;
+    } catch (error) {
+      failures.push({ file: fileName, reason: error.message });
+    }
+  });
+
+  if (created > 0) {
+    console.log(
+      `[generate-event-html] Created ${created} event page${created === 1 ? "" : "s"} → ${path.relative(
+        template.rootDir,
+        outputRoot,
+      )}`,
+    );
+  }
+
+  if (failures.length > 0) {
+    failures.forEach((failure) => {
+      console.warn(`[generate-event-html] Skipped ${failure.file}: ${failure.reason}`);
+    });
+    process.exitCode = 1;
+  }
+}
+
+function computeEventMeta(data, slug, origin) {
+  const safeOrigin = typeof origin === "string" && origin ? origin : DEFAULT_ORIGIN;
+  const title = cleanString(data.title) || "NorthSide GTA Event";
+  const pageTitle = `${title} | NorthSide GTA`;
+  const descriptionSource = cleanString(data.summary) || cleanString(data.description) || DEFAULT_DESCRIPTION;
+  const description = truncate(descriptionSource || DEFAULT_DESCRIPTION, DESCRIPTION_LENGTH) || DEFAULT_DESCRIPTION;
+
+  const canonicalSlug = encodeSlug(slug);
+  const canonicalUrl = buildUrl(safeOrigin, `/events/${canonicalSlug}`);
+
+  const imageSource = cleanString(data.image) || FALLBACK_IMAGE;
+  const ogImageAbsolute = absoluteUrl(safeOrigin, imageSource);
+  const secureImage = ensureSecureUrl(ogImageAbsolute);
+  const ogImage = secureImage || ogImageAbsolute;
+
+  const locationParts = [data.locationName, data.address, data.subArea, data.town]
+    .map((value) => cleanString(value))
+    .filter(Boolean);
+  const locationText = collapseWhitespace([...new Set(locationParts)].join(", "));
+
+  const startIso = parseIsoDate(data.startDate);
+  const endIso = parseIsoDate(data.endDate);
+
+  const additionalMeta = [];
+  if (secureImage) {
+    additionalMeta.push({ property: "og:image:secure_url", content: secureImage });
+  }
+  if (canonicalUrl) {
+    additionalMeta.push({ name: "twitter:url", content: canonicalUrl });
+  }
+  if (startIso) {
+    additionalMeta.push({ property: "event:start_time", content: startIso });
+  }
+  if (endIso) {
+    additionalMeta.push({ property: "event:end_time", content: endIso });
+  }
+  if (locationText) {
+    additionalMeta.push({ property: "event:location", content: locationText });
+  }
+  if (data.hidden) {
+    additionalMeta.push({ name: "robots", content: "noindex" });
+  }
+
+  return {
+    documentTitle: pageTitle,
+    title,
+    ogTitle: title,
+    twitterTitle: title,
+    description,
+    canonicalUrl,
+    ogType: "event",
+    ogImage,
+    ogImageAlt: title,
+    siteName: "NorthSide GTA",
+    twitterCard: "summary_large_image",
+    twitterImage: ogImage,
+    articlePublishedTime: startIso,
+    additionalMeta,
+  };
+}
+
+function encodeSlug(slug) {
+  return slug
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function parseIsoDate(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toISOString();
+}
+
+main();

--- a/scripts/generate-insight-html.js
+++ b/scripts/generate-insight-html.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("node-html-parser");
+
+const {
+  DEFAULT_ORIGIN,
+  loadTemplate,
+  sanitizeSlug,
+  cleanString,
+  collapseWhitespace,
+  truncate,
+  buildUrl,
+  absoluteUrl,
+  ensureSecureUrl,
+  stripSeoTags,
+  appendHeadTag,
+  finalizeHtml,
+} = require("./utils/staticMeta");
+const { getMetaTagHtmlList } = require("../src/components/seo/metaTagUtils.js");
+
+const OG_FALLBACK_IMAGE = "/Images/og-home.jpg";
+const DESCRIPTION_LENGTH = 160;
+
+function main() {
+  const template = loadTemplate();
+  if (!template) {
+    console.warn("[generate-insight-html] Skipping — unable to locate HTML template");
+    process.exit(0);
+  }
+
+  const dataDir = path.join(template.publicDir, "data", "insights");
+  if (!fs.existsSync(dataDir)) {
+    console.warn(
+      `[generate-insight-html] Skipping — insights directory not found at ${path.relative(
+        template.rootDir,
+        dataDir,
+      )}`,
+    );
+    process.exit(0);
+  }
+
+  const outputRoot = template.hasBuildTemplate
+    ? path.join(template.buildDir, "insights")
+    : path.join(template.publicDir, "insights");
+
+  if (fs.existsSync(outputRoot)) {
+    fs.rmSync(outputRoot, { recursive: true, force: true });
+  }
+  fs.mkdirSync(outputRoot, { recursive: true });
+
+  const files = fs
+    .readdirSync(dataDir)
+    .filter((name) => name.toLowerCase().endsWith(".json"))
+    .sort();
+
+  if (files.length === 0) {
+    console.log("[generate-insight-html] No insights to process.");
+    return;
+  }
+
+  const failures = [];
+  let created = 0;
+
+  files.forEach((fileName) => {
+    const filePath = path.join(dataDir, fileName);
+    let payload;
+    try {
+      payload = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch (error) {
+      failures.push({ file: fileName, reason: `Invalid JSON (${error.message})` });
+      return;
+    }
+
+    const fallbackSlug = fileName.replace(/\.json$/i, "");
+    const slug = sanitizeSlug(payload.slug, fallbackSlug);
+    if (!slug) {
+      failures.push({ file: fileName, reason: "Missing slug" });
+      return;
+    }
+
+    try {
+      const metaConfig = computeInsightMeta(payload, slug, template.siteOrigin || DEFAULT_ORIGIN);
+      const headFragments = getMetaTagHtmlList(metaConfig);
+
+      const doc = parse(template.baseHtml, { comment: true });
+      const head = doc.querySelector("head");
+      if (!head) {
+        throw new Error("Template is missing <head> element");
+      }
+
+      stripSeoTags(head);
+      headFragments.forEach((fragment) => appendHeadTag(head, fragment));
+
+      const html = finalizeHtml(doc, template.doctype);
+      const targetDir = path.join(outputRoot, slug);
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(path.join(targetDir, "index.html"), html, "utf8");
+      created += 1;
+    } catch (error) {
+      failures.push({ file: fileName, reason: error.message });
+    }
+  });
+
+  if (created > 0) {
+    console.log(
+      `[generate-insight-html] Created ${created} insight page${created === 1 ? "" : "s"} → ${path.relative(
+        template.rootDir,
+        outputRoot,
+      )}`,
+    );
+  }
+
+  if (failures.length > 0) {
+    failures.forEach((failure) => {
+      console.warn(`[generate-insight-html] Skipped ${failure.file}: ${failure.reason}`);
+    });
+    process.exitCode = 1;
+  }
+}
+
+function computeInsightMeta(data, slug, origin) {
+  const safeOrigin = typeof origin === "string" && origin ? origin : DEFAULT_ORIGIN;
+  const title = cleanString(data.title);
+  const seoTitle = cleanString(data.seo?.title) || (title ? `NorthSide GTA Insights: ${title}` : "NorthSide GTA Insights");
+  const excerpt = cleanString(data.excerpt);
+  const bodyText = stripMarkdown(data.body || "");
+  const descriptionSource =
+    cleanString(data.seo?.description) || excerpt || bodyText || "NorthSide GTA insights.";
+  const description = truncate(descriptionSource, DESCRIPTION_LENGTH);
+
+  const featureImage = cleanString(data.seo?.ogImage) || cleanString(data.featureImage) || OG_FALLBACK_IMAGE;
+  const ogImageAbsolute = absoluteUrl(safeOrigin, featureImage);
+  const secureImage = ensureSecureUrl(ogImageAbsolute);
+  const ogImage = secureImage || ogImageAbsolute;
+  const canonicalSlug = encodeSlug(slug);
+  const canonicalUrl = buildUrl(safeOrigin, `/insights/${canonicalSlug}`);
+  const ogImageAlt = cleanString(data.featureImageAlt) || title || "NorthSide GTA";
+  const publishedTime = parseIsoDate(data.publishDate);
+  const articleAuthor = cleanString(data.author);
+
+  const tagsMeta = Array.isArray(data.tags)
+    ? data.tags
+        .map((tag, index) => {
+          const content = cleanString(tag);
+          if (!content) return null;
+          return { property: "article:tag", content, key: `article-tag-${index}` };
+        })
+        .filter(Boolean)
+    : [];
+
+  const additionalMeta = [...tagsMeta];
+
+  if (secureImage) {
+    additionalMeta.push({ property: "og:image:secure_url", content: secureImage });
+  }
+  if (canonicalUrl) {
+    additionalMeta.push({ name: "twitter:url", content: canonicalUrl });
+  }
+
+  return {
+    documentTitle: seoTitle,
+    title: seoTitle,
+    description,
+    canonicalUrl,
+    ogType: "article",
+    ogImage,
+    ogImageAlt,
+    siteName: "NorthSide GTA",
+    twitterCard: "summary_large_image",
+    twitterImage: ogImage,
+    articleAuthor,
+    articlePublishedTime: publishedTime,
+    additionalMeta,
+  };
+}
+
+function encodeSlug(slug) {
+  return slug
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function stripMarkdown(value) {
+  if (!value) return "";
+  return collapseWhitespace(
+    value
+      .replace(/```[\s\S]*?```/g, " ")
+      .replace(/`[^`]*`/g, " ")
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+      .replace(/[#>*_~`-]+/g, " ")
+      .replace(/<[^>]*>/g, " "),
+  );
+}
+
+function parseIsoDate(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toISOString();
+}
+
+main();

--- a/scripts/utils/staticMeta.js
+++ b/scripts/utils/staticMeta.js
@@ -1,0 +1,174 @@
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("node-html-parser");
+
+const DEFAULT_ORIGIN = process.env.SITE_ORIGIN || "https://northsidegta.ca";
+
+function loadTemplate() {
+  const rootDir = path.resolve(__dirname, "../..");
+  const publicDir = path.join(rootDir, "public");
+  const buildDir = path.join(rootDir, "build");
+  const buildIndexPath = path.join(buildDir, "index.html");
+  const hasBuildTemplate = fs.existsSync(buildIndexPath);
+  const templatePath = hasBuildTemplate ? buildIndexPath : path.join(publicDir, "index.html");
+
+  if (!fs.existsSync(templatePath)) {
+    return null;
+  }
+
+  const baseHtml = fs.readFileSync(templatePath, "utf8");
+  const doctypeMatch = baseHtml.match(/<!DOCTYPE html[^>]*>/i);
+  const doctype = doctypeMatch ? doctypeMatch[0] : "<!DOCTYPE html>";
+  const siteOrigin = deriveOrigin(baseHtml) || DEFAULT_ORIGIN;
+
+  return {
+    rootDir,
+    publicDir,
+    buildDir,
+    hasBuildTemplate,
+    templatePath,
+    baseHtml,
+    doctype,
+    siteOrigin,
+  };
+}
+
+function deriveOrigin(html) {
+  try {
+    const doc = parse(html);
+    const canonical = doc.querySelector('link[rel="canonical"]');
+    if (canonical) {
+      const href = canonical.getAttribute("href");
+      if (href) {
+        return new URL(href).origin;
+      }
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
+function sanitizeSlug(value, fallback) {
+  const raw = cleanString(value) || cleanString(fallback);
+  if (!raw) return "";
+  return raw.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9/_-]/g, "-");
+}
+
+function cleanString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function collapseWhitespace(value) {
+  if (!value) return "";
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncate(value, maxLength) {
+  const text = collapseWhitespace(value);
+  if (!text) return "";
+  if (!Number.isFinite(maxLength) || maxLength <= 0 || text.length <= maxLength) {
+    return text;
+  }
+  const slice = text.slice(0, maxLength);
+  const lastSpace = slice.lastIndexOf(" ");
+  if (lastSpace > 40) {
+    return `${slice.slice(0, lastSpace)}…`;
+  }
+  return `${slice.slice(0, maxLength - 1)}…`;
+}
+
+function buildUrl(origin, targetPath) {
+  if (!origin) {
+    return targetPath;
+  }
+  const normalizedOrigin = origin.endsWith("/") ? origin : `${origin}/`;
+  const normalizedPath = targetPath.startsWith("/") ? targetPath.slice(1) : targetPath;
+  try {
+    return new URL(normalizedPath, normalizedOrigin).toString();
+  } catch (error) {
+    return `${normalizedOrigin}${normalizedPath}`;
+  }
+}
+
+function absoluteUrl(origin, value) {
+  if (!value) return "";
+  if (/^https?:\/\//i.test(value)) {
+    return value;
+  }
+  const normalized = value.startsWith("/") ? value : `/${value}`;
+  return buildUrl(origin, normalized);
+}
+
+function ensureSecureUrl(url) {
+  if (!url) return "";
+  if (!/^https?:/i.test(url) && url.startsWith("//")) {
+    return `https:${url}`;
+  }
+  if (/^http:\/\//i.test(url)) {
+    try {
+      const parsed = new URL(url);
+      parsed.protocol = "https:";
+      return parsed.toString();
+    } catch (error) {
+      return url.replace(/^http:/i, "https:");
+    }
+  }
+  return url.startsWith("https://") ? url : "";
+}
+
+function stripSeoTags(head) {
+  head.querySelectorAll("title").forEach((node) => node.remove());
+  head.querySelectorAll("meta").forEach((node) => {
+    const name = (node.getAttribute("name") || "").toLowerCase();
+    const property = (node.getAttribute("property") || "").toLowerCase();
+    if (
+      name === "description" ||
+      name === "keywords" ||
+      name === "robots" ||
+      name.startsWith("twitter:")
+    ) {
+      node.remove();
+      return;
+    }
+    if (
+      property.startsWith("og:") ||
+      property.startsWith("twitter:") ||
+      property.startsWith("article:") ||
+      property.startsWith("event:")
+    ) {
+      node.remove();
+    }
+  });
+  head
+    .querySelectorAll('link[rel="canonical"]')
+    .forEach((node) => node.remove());
+}
+
+function appendHeadTag(head, html) {
+  if (!html) return;
+  head.insertAdjacentHTML("beforeend", `\n    ${html}`);
+}
+
+function finalizeHtml(doc, doctype) {
+  let html = doc.toString();
+  if (!/^<!DOCTYPE html/i.test(html)) {
+    html = `${doctype}\n${html}`;
+  }
+  return html;
+}
+
+module.exports = {
+  DEFAULT_ORIGIN,
+  loadTemplate,
+  sanitizeSlug,
+  cleanString,
+  collapseWhitespace,
+  truncate,
+  buildUrl,
+  absoluteUrl,
+  ensureSecureUrl,
+  stripSeoTags,
+  appendHeadTag,
+  finalizeHtml,
+};

--- a/src/components/seo/DynamicMetaTags.js
+++ b/src/components/seo/DynamicMetaTags.js
@@ -1,129 +1,45 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
 
-const DEFAULT_TWITTER_CARD = "summary_large_image";
+import { getMetaTagsFromData } from "./metaTagUtils";
 
-function safeString(value) {
-  if (value == null) return "";
-  if (typeof value === "string") return value.trim();
-  return String(value).trim();
-}
+export { getMetaTagsFromData } from "./metaTagUtils";
 
-export default function DynamicMetaTags({
-  documentTitle,
-  title,
-  ogTitle,
-  twitterTitle,
-  description,
-  ogDescription,
-  twitterDescription,
-  canonicalUrl,
-  ogType,
-  ogImage,
-  ogImageAlt,
-  twitterCard,
-  twitterImage,
-  twitterImageAlt,
-  siteName,
-  articleAuthor,
-  articlePublishedTime,
-  additionalMeta = [],
-  children,
-}) {
-  const titleValue = safeString(title);
-  const documentTitleValue = safeString(documentTitle || titleValue);
-  const ogTitleValue = safeString(ogTitle || titleValue);
-  const twitterTitleValue = safeString(twitterTitle || ogTitleValue || documentTitleValue);
+export default function DynamicMetaTags(props) {
+  const { children, ...metaProps } = props || {};
+  const meta = getMetaTagsFromData(metaProps);
 
-  const descriptionValue = safeString(description);
-  const ogDescriptionValue = safeString(ogDescription || descriptionValue);
-  const twitterDescriptionValue = safeString(twitterDescription || ogDescriptionValue || descriptionValue);
-
-  const canonicalValue = safeString(canonicalUrl);
-  const ogTypeValue = safeString(ogType);
-  const ogImageValue = safeString(ogImage);
-  const twitterCardValue = safeString(twitterCard) || DEFAULT_TWITTER_CARD;
-  const ogImageAltValue = safeString(ogImageAlt);
-  const twitterImageValue = safeString(twitterImage || ogImageValue);
-  const twitterImageAltValue = safeString(twitterImageAlt || ogImageAltValue);
-  const siteNameValue = safeString(siteName);
-  const articleAuthorValue = safeString(articleAuthor);
-  const articlePublishedTimeValue = safeString(articlePublishedTime);
-
-  const normalizedAdditionalMeta = Array.isArray(additionalMeta)
-    ? additionalMeta
-        .map((meta) => {
-          if (!meta) return null;
-          const name = safeString(meta.name);
-          const property = safeString(meta.property);
-          const content = safeString(meta.content);
-          if (!content || (!name && !property)) return null;
-          return {
-            key: meta.key,
-            name: name || undefined,
-            property: property || undefined,
-            content,
-          };
-        })
-        .filter(Boolean)
-    : [];
-
-  if (
-    !documentTitleValue &&
-    !titleValue &&
-    !descriptionValue &&
-    !canonicalValue &&
-    !ogTypeValue &&
-    !ogImageValue &&
-    !twitterImageValue &&
-    !siteNameValue &&
-    !articleAuthorValue &&
-    !articlePublishedTimeValue &&
-    normalizedAdditionalMeta.length === 0 &&
-    !children
-  ) {
-    return null;
+  if (!meta) {
+    if (!children) {
+      return null;
+    }
+    return <Helmet>{children}</Helmet>;
   }
 
   return (
     <Helmet>
-      {documentTitleValue && <title>{documentTitleValue}</title>}
-      {descriptionValue && <meta name="description" content={descriptionValue} />}
-      {canonicalValue && <link rel="canonical" href={canonicalValue} />}
-
-      {ogTypeValue && <meta property="og:type" content={ogTypeValue} />}
-      {ogTitleValue && <meta property="og:title" content={ogTitleValue} />}
-      {ogDescriptionValue && <meta property="og:description" content={ogDescriptionValue} />}
-      {canonicalValue && <meta property="og:url" content={canonicalValue} />}
-      {ogImageValue && <meta property="og:image" content={ogImageValue} />}
-      {ogImageAltValue && <meta property="og:image:alt" content={ogImageAltValue} />}
-      {siteNameValue && <meta property="og:site_name" content={siteNameValue} />}
-
-      <meta name="twitter:card" content={twitterCardValue || DEFAULT_TWITTER_CARD} />
-      {(twitterTitleValue || ogTitleValue) && (
-        <meta name="twitter:title" content={twitterTitleValue || ogTitleValue} />
-      )}
-      {(twitterDescriptionValue || ogDescriptionValue) && (
-        <meta name="twitter:description" content={twitterDescriptionValue || ogDescriptionValue} />
-      )}
-      {twitterImageValue && <meta name="twitter:image" content={twitterImageValue} />}
-      {twitterImageAltValue && <meta name="twitter:image:alt" content={twitterImageAltValue} />}
-
-      {articlePublishedTimeValue && (
-        <meta property="article:published_time" content={articlePublishedTimeValue} />
-      )}
-      {articleAuthorValue && <meta property="article:author" content={articleAuthorValue} />}
-
-      {normalizedAdditionalMeta.map((meta, index) => (
-        <meta
-          key={meta.key || `${meta.name || meta.property}-${index}`}
-          {...(meta.name ? { name: meta.name } : { property: meta.property })}
-          content={meta.content}
-        />
-      ))}
-
+      {meta.tags.map(renderHelmetTag)}
       {children}
     </Helmet>
   );
+}
+
+function renderHelmetTag(tag, index) {
+  if (!tag) return null;
+  const key = tag.key || `${tag.type || "meta"}-${index}`;
+
+  if (tag.type === "title") {
+    return <title key={key}>{tag.content}</title>;
+  }
+
+  if (tag.type === "meta") {
+    return <meta key={key} {...(tag.attributes || {})} />;
+  }
+
+  if (tag.type === "link") {
+    return <link key={key} {...(tag.attributes || {})} />;
+  }
+
+  return null;
 }
 

--- a/src/components/seo/metaTagUtils.js
+++ b/src/components/seo/metaTagUtils.js
@@ -1,0 +1,313 @@
+const DEFAULT_TWITTER_CARD = "summary_large_image";
+
+function safeString(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value.trim();
+  return String(value).trim();
+}
+
+function normalizeAdditionalMeta(additionalMeta) {
+  if (!Array.isArray(additionalMeta)) return [];
+  return additionalMeta
+    .map((meta) => {
+      if (!meta) return null;
+      const name = safeString(meta.name);
+      const property = safeString(meta.property);
+      const content = safeString(meta.content);
+      if (!content || (!name && !property)) return null;
+      const key = safeString(meta.key);
+      return {
+        key: key || (name ? `name:${name}` : `property:${property}`),
+        name: name || undefined,
+        property: property || undefined,
+        content,
+      };
+    })
+    .filter(Boolean);
+}
+
+function getMetaTagsFromData(raw = {}) {
+  const titleValue = safeString(raw.title);
+  const documentTitleValue = safeString(raw.documentTitle || titleValue);
+  const ogTitleValue = safeString(raw.ogTitle || titleValue);
+  const twitterTitleValue = safeString(
+    raw.twitterTitle || ogTitleValue || documentTitleValue,
+  );
+
+  const descriptionValue = safeString(raw.description);
+  const ogDescriptionValue = safeString(raw.ogDescription || descriptionValue);
+  const twitterDescriptionValue = safeString(
+    raw.twitterDescription || ogDescriptionValue || descriptionValue,
+  );
+
+  const canonicalValue = safeString(raw.canonicalUrl);
+  const ogTypeValue = safeString(raw.ogType);
+  const ogImageValue = safeString(raw.ogImage);
+  const ogImageAltValue = safeString(raw.ogImageAlt);
+  const twitterCardValue = safeString(raw.twitterCard) || DEFAULT_TWITTER_CARD;
+  const twitterImageValue = safeString(raw.twitterImage || ogImageValue);
+  const twitterImageAltValue = safeString(raw.twitterImageAlt || ogImageAltValue);
+  const siteNameValue = safeString(raw.siteName);
+  const articleAuthorValue = safeString(raw.articleAuthor);
+  const articlePublishedTimeValue = safeString(raw.articlePublishedTime);
+
+  const normalizedAdditionalMeta = normalizeAdditionalMeta(raw.additionalMeta);
+
+  const tags = [];
+
+  if (documentTitleValue) {
+    tags.push({
+      type: "title",
+      key: "document-title",
+      content: documentTitleValue,
+    });
+  }
+
+  if (descriptionValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:description",
+      attributes: { name: "description", content: descriptionValue },
+    });
+  }
+
+  if (canonicalValue) {
+    tags.push({
+      type: "link",
+      key: "link:canonical",
+      attributes: { rel: "canonical", href: canonicalValue },
+    });
+  }
+
+  if (ogTypeValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:og:type",
+      attributes: { property: "og:type", content: ogTypeValue },
+    });
+  }
+
+  if (ogTitleValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:og:title",
+      attributes: { property: "og:title", content: ogTitleValue },
+    });
+  }
+
+  if (ogDescriptionValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:og:description",
+      attributes: { property: "og:description", content: ogDescriptionValue },
+    });
+  }
+
+  if (canonicalValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:og:url",
+      attributes: { property: "og:url", content: canonicalValue },
+    });
+  }
+
+  if (ogImageValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:og:image",
+      attributes: { property: "og:image", content: ogImageValue },
+    });
+  }
+
+  if (ogImageAltValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:og:image:alt",
+      attributes: { property: "og:image:alt", content: ogImageAltValue },
+    });
+  }
+
+  if (siteNameValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:og:site_name",
+      attributes: { property: "og:site_name", content: siteNameValue },
+    });
+  }
+
+  tags.push({
+    type: "meta",
+    key: "meta:twitter:card",
+    attributes: { name: "twitter:card", content: twitterCardValue },
+  });
+
+  if (twitterTitleValue || ogTitleValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:twitter:title",
+      attributes: {
+        name: "twitter:title",
+        content: twitterTitleValue || ogTitleValue,
+      },
+    });
+  }
+
+  if (twitterDescriptionValue || ogDescriptionValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:twitter:description",
+      attributes: {
+        name: "twitter:description",
+        content: twitterDescriptionValue || ogDescriptionValue,
+      },
+    });
+  }
+
+  if (twitterImageValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:twitter:image",
+      attributes: { name: "twitter:image", content: twitterImageValue },
+    });
+  }
+
+  if (twitterImageAltValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:twitter:image:alt",
+      attributes: {
+        name: "twitter:image:alt",
+        content: twitterImageAltValue,
+      },
+    });
+  }
+
+  if (articlePublishedTimeValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:article:published_time",
+      attributes: {
+        property: "article:published_time",
+        content: articlePublishedTimeValue,
+      },
+    });
+  }
+
+  if (articleAuthorValue) {
+    tags.push({
+      type: "meta",
+      key: "meta:article:author",
+      attributes: {
+        property: "article:author",
+        content: articleAuthorValue,
+      },
+    });
+  }
+
+  normalizedAdditionalMeta.forEach((meta, index) => {
+    const key = meta.key || `meta:additional:${index}`;
+    if (meta.name) {
+      tags.push({
+        type: "meta",
+        key,
+        attributes: { name: meta.name, content: meta.content },
+      });
+    } else if (meta.property) {
+      tags.push({
+        type: "meta",
+        key,
+        attributes: { property: meta.property, content: meta.content },
+      });
+    }
+  });
+
+  if (
+    !documentTitleValue &&
+    !titleValue &&
+    !descriptionValue &&
+    !canonicalValue &&
+    !ogTypeValue &&
+    !ogImageValue &&
+    !twitterImageValue &&
+    !siteNameValue &&
+    !articleAuthorValue &&
+    !articlePublishedTimeValue &&
+    normalizedAdditionalMeta.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    tags,
+    values: {
+      documentTitle: documentTitleValue,
+      title: titleValue,
+      description: descriptionValue,
+      canonicalUrl: canonicalValue,
+      ogType: ogTypeValue,
+      ogImage: ogImageValue,
+      ogImageAlt: ogImageAltValue,
+      twitterCard: twitterCardValue,
+      twitterImage: twitterImageValue,
+      twitterImageAlt: twitterImageAltValue,
+      siteName: siteNameValue,
+      articleAuthor: articleAuthorValue,
+      articlePublishedTime: articlePublishedTimeValue,
+    },
+  };
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value).replace(/"/g, "&quot;");
+}
+
+function stringifyTag(descriptor) {
+  if (!descriptor) return "";
+  if (descriptor.type === "title") {
+    return `<title>${escapeHtml(descriptor.content || "")}</title>`;
+  }
+
+  if (descriptor.type === "meta") {
+    const attrs = descriptor.attributes || {};
+    const attrText = Object.entries(attrs)
+      .filter(([, value]) => value != null && value !== "")
+      .map(([key, value]) => `${key}="${escapeAttribute(value)}"`)
+      .join(" ");
+    return attrText ? `<meta ${attrText} />` : "";
+  }
+
+  if (descriptor.type === "link") {
+    const attrs = descriptor.attributes || {};
+    const attrText = Object.entries(attrs)
+      .filter(([, value]) => value != null && value !== "")
+      .map(([key, value]) => `${key}="${escapeAttribute(value)}"`)
+      .join(" ");
+    return attrText ? `<link ${attrText} />` : "";
+  }
+
+  return "";
+}
+
+function getMetaTagHtmlList(raw = {}) {
+  const meta = getMetaTagsFromData(raw);
+  if (!meta) return [];
+  return meta.tags.map(stringifyTag).filter(Boolean);
+}
+
+function renderMetaTagsToString(raw = {}) {
+  return getMetaTagHtmlList(raw).join("\n");
+}
+
+module.exports = {
+  DEFAULT_TWITTER_CARD,
+  getMetaTagsFromData,
+  getMetaTagHtmlList,
+  renderMetaTagsToString,
+};


### PR DESCRIPTION
## Summary
- extract the dynamic meta tag normalization into a reusable helper so Helmet and build tools share the same logic
- add build-time generators for insights and events that emit static HTML with page-specific SEO/OG/Twitter metadata
- update the postbuild pipeline to run the new generators alongside the curated page exporter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6904d682547c832494e05c1707756fd2