### PR TITLE
Refactor Aurora town page layout

### DIFF
--- a/src/TownPage.js
+++ b/src/TownPage.js
@@ -6,6 +6,22 @@ import Navigation from "./Navigation";
 import Footer from "./Footer";
 import QuickContactCard from "./QuickContactCard";
 import TownStrip from "./TownStrip";
+import TownPageLayout from "./components/towns/TownPageLayout";
+import {
+  FiTrendingUp,
+  FiClock,
+  FiMapPin,
+  FiFlag,
+  FiAnchor,
+  FiFeather,
+  FiCoffee,
+  FiCalendar,
+  FiUsers,
+  FiBriefcase,
+  FiActivity,
+  FiHome,
+  FiMap,
+} from "react-icons/fi";
 
 const CATEGORY_LABELS = {
   housePrices: "House Prices",
@@ -28,6 +44,27 @@ const CATEGORY_ORDER = [
   "restaurants",
   "localEvents",
 ];
+
+const RATING_ICONS = {
+  housePrices: FiTrendingUp,
+  commuterAccess: FiClock,
+  localTraffic: FiMapPin,
+  golf: FiFlag,
+  fishing: FiAnchor,
+  trailsNature: FiFeather,
+  restaurants: FiCoffee,
+  localEvents: FiCalendar,
+};
+
+const GENERIC_ICON_MAP = {
+  leaf: FiFeather,
+  users: FiUsers,
+  map: FiMap,
+  family: FiUsers,
+  briefcase: FiBriefcase,
+  activity: FiActivity,
+  home: FiHome,
+};
 
 function DotRow({ value = 0 }) {
   const v = Math.round(value);
@@ -78,6 +115,62 @@ export default function TownPage() {
     );
   }
 
+  if ((town.slug || "").toLowerCase() === "aurora") {
+    const ratingDescriptions = town.ratingDescriptions || {};
+    const ratings = CATEGORY_ORDER.filter((k) => town.ratings?.[k] != null).map((key) => ({
+      label: CATEGORY_LABELS[key] || key,
+      score: town.ratings[key],
+      description: ratingDescriptions[key],
+      icon: RATING_ICONS[key],
+    }));
+
+    const mapIcon = (iconKey) => GENERIC_ICON_MAP[iconKey] || null;
+
+    const lifestyleHighlights = Array.isArray(town.lifestyleHighlights)
+      ? town.lifestyleHighlights.map((item) => ({
+          ...item,
+          icon: mapIcon(item?.icon),
+        }))
+      : [];
+
+    const audiences = Array.isArray(town.audiences)
+      ? town.audiences.map((item) => ({
+          ...item,
+          icon: mapIcon(item?.icon),
+        }))
+      : [];
+
+    return (
+      <div className="bg-white text-gray-900 min-h-screen overflow-x-hidden">
+        <Navigation />
+        <TownPageLayout
+          townName={town.name}
+          hero={town.hero}
+          snapshot={town.snapshot}
+          ratings={ratings}
+          ratingScaleMax={5}
+          lifestyleHighlights={lifestyleHighlights}
+          audiences={audiences}
+          neighbourhoods={town.neighbourhoods || []}
+          faqs={town.faqs || []}
+          cta={town.cta}
+          guide={
+            town.pdf
+              ? {
+                  href: town.pdf,
+                  label: `Download ${town.name} Guide (PDF)`,
+                }
+              : null
+          }
+        />
+        <section className="mx-auto max-w-6xl px-4 pb-12">
+          <TownStrip />
+        </section>
+        <Footer />
+      </div>
+    );
+  }
+
   return (
     // Keep horizontal overflow hidden at the page level to prevent accidental widening.
     <div className="bg-white text-gray-900 min-h-screen overflow-x-hidden">
@@ -111,11 +204,11 @@ export default function TownPage() {
 
             {/* Summary + download + MATCH card */}
             <div className="p-5 md:p-6 space-y-4">
-              {town.summary && (
-                <p className="text-gray-700 text-base md:text-lg">
-                  {town.summary}
-                </p>
-              )}
+            {town.summary && (
+              <p className="text-gray-700 text-base md:text-lg">
+                {town.summary}
+              </p>
+            )}
 
               <div className="flex flex-wrap items-center gap-3">
                 {town.pdf && (

--- a/src/components/towns/TownPageLayout.js
+++ b/src/components/towns/TownPageLayout.js
@@ -1,0 +1,373 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+
+function ButtonLink({ href, label, variant = "primary" }) {
+  if (!href || !label) return null;
+
+  const baseClasses =
+    "inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2";
+
+  const variantClasses =
+    variant === "secondary"
+      ? "bg-white text-emerald-700 border border-emerald-200 hover:bg-emerald-50 focus:ring-emerald-300 focus:ring-offset-emerald-900"
+      : "bg-emerald-600 text-white shadow hover:bg-emerald-500 focus:ring-emerald-200 focus:ring-offset-emerald-900";
+
+  const className = `${baseClasses} ${variantClasses}`;
+
+  const isInternal = href.startsWith("/");
+
+  if (isInternal) {
+    return (
+      <Link to={href} className={className}>
+        {label}
+      </Link>
+    );
+  }
+
+  return (
+    <a href={href} className={className}>
+      {label}
+    </a>
+  );
+}
+
+function IconBubble({ icon: Icon, label }) {
+  if (!Icon) {
+    return (
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 font-semibold">
+        {label ? label.charAt(0) : ""}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100">
+      <Icon className="h-6 w-6 text-emerald-700" aria-hidden />
+    </div>
+  );
+}
+
+function SnapshotRow({ label, value }) {
+  if (!value) return null;
+  return (
+    <div className="flex flex-col gap-1 rounded-xl border border-emerald-50 bg-white/80 p-4 shadow-sm">
+      <span className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
+        {label}
+      </span>
+      <span className="text-sm text-gray-800">{value}</span>
+    </div>
+  );
+}
+
+function RatingRow({ item, scaleMax = 10 }) {
+  if (!item) return null;
+  const { icon, label, score = 0, description } = item;
+  const normalized = scaleMax > 0 ? (score / scaleMax) * 10 : 0;
+  const displayScore = Number.isFinite(normalized)
+    ? normalized % 1 === 0
+      ? `${normalized.toFixed(0)} / 10`
+      : `${normalized.toFixed(1)} / 10`
+    : "–";
+  const barPercent = scaleMax > 0 ? Math.max(0, Math.min(100, (score / scaleMax) * 100)) : 0;
+
+  return (
+    <div className="rounded-2xl border border-emerald-50 bg-white/75 p-4 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <IconBubble icon={icon} label={label} />
+          <div>
+            <p className="text-base font-semibold text-gray-900">{label}</p>
+            {description && <p className="text-sm text-gray-600">{description}</p>}
+          </div>
+        </div>
+        <span className="text-sm font-semibold text-emerald-700">{displayScore}</span>
+      </div>
+      <div className="mt-3 h-2.5 w-full overflow-hidden rounded-full bg-emerald-100">
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-emerald-600 to-emerald-400"
+          style={{ width: `${barPercent}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function LifestyleCard({ item }) {
+  if (!item) return null;
+  const { icon, title, description } = item;
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-emerald-50 bg-white/80 p-6 shadow-sm">
+      <IconBubble icon={icon} label={title} />
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+        {description && <p className="mt-1 text-sm text-gray-700">{description}</p>}
+      </div>
+    </div>
+  );
+}
+
+function AudienceTile({ item }) {
+  if (!item) return null;
+  const { icon, title, description } = item;
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-emerald-50 bg-white/80 p-5 shadow-sm">
+      <IconBubble icon={icon} label={title} />
+      <div>
+        <h3 className="text-base font-semibold text-gray-900">{title}</h3>
+        {description && <p className="mt-1 text-sm text-gray-600">{description}</p>}
+      </div>
+    </div>
+  );
+}
+
+function NeighbourhoodCard({ item }) {
+  if (!item) return null;
+  const { name, description } = item;
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-emerald-50 bg-white/85 p-5 shadow-sm">
+      <h3 className="text-base font-semibold text-gray-900">{name}</h3>
+      {description && <p className="text-sm text-gray-600">{description}</p>}
+    </div>
+  );
+}
+
+function FaqItem({ item, isOpen, onToggle, index }) {
+  if (!item) return null;
+  const { question, answer } = item;
+  const regionId = `faq-panel-${index}`;
+  return (
+    <div className="rounded-2xl border border-emerald-50 bg-white/80 shadow-sm">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left"
+        aria-expanded={isOpen}
+        aria-controls={regionId}
+      >
+        <span className="text-base font-semibold text-gray-900">{question}</span>
+        <span className="text-emerald-600">{isOpen ? "−" : "+"}</span>
+      </button>
+      <div
+        id={regionId}
+        hidden={!isOpen}
+        className="px-5 pb-4 text-sm text-gray-700"
+      >
+        {answer}
+      </div>
+    </div>
+  );
+}
+
+export default function TownPageLayout({
+  townName,
+  hero,
+  snapshot = {},
+  ratings = [],
+  ratingScaleMax = 10,
+  lifestyleHighlights = [],
+  audiences = [],
+  neighbourhoods = [],
+  faqs = [],
+  cta,
+  guide,
+}) {
+  const [openFaq, setOpenFaq] = useState(null);
+
+  const snapshotFields = [
+    { key: "population", label: "Population" },
+    { key: "driveToToronto", label: "Drive to Toronto" },
+    { key: "goTrainTime", label: "GO Train" },
+    { key: "homePriceRange", label: "Typical Home Price" },
+    { key: "highways", label: "Highways" },
+    { key: "transitSummary", label: "Transit" },
+  ];
+
+  return (
+    <main className="flex-1">
+      {/* Hero */}
+      <section className="relative isolate overflow-hidden">
+        <div className="absolute inset-0">
+          {hero?.backgroundImage ? (
+            <img
+              src={hero.backgroundImage}
+              alt={hero?.backgroundAlt || `${townName} skyline`}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="h-full w-full bg-gradient-to-br from-emerald-900 via-emerald-800 to-emerald-600" />
+          )}
+          <div className="absolute inset-0 bg-emerald-950/70" />
+        </div>
+        <div className="relative mx-auto flex max-w-6xl flex-col gap-8 px-4 py-20 sm:py-24 lg:py-28">
+          <div className="max-w-3xl text-white">
+            {hero?.tagline && (
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-100">
+                {hero.tagline}
+              </p>
+            )}
+            <h1 className="mt-4 text-3xl font-black tracking-tight sm:text-4xl lg:text-5xl">
+              {hero?.title || `Living in ${townName}`}
+            </h1>
+            {hero?.subtitle && (
+              <p className="mt-4 text-base text-emerald-50 sm:text-lg">
+                {hero.subtitle}
+              </p>
+            )}
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+              <ButtonLink
+                href={hero?.primaryButton?.href || "#"}
+                label={hero?.primaryButton?.label}
+                variant="primary"
+              />
+              <ButtonLink
+                href={hero?.secondaryButton?.href || "#"}
+                label={hero?.secondaryButton?.label}
+                variant="secondary"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Snapshot + Ratings */}
+      <section className="mx-auto max-w-6xl px-4 py-16">
+        <div className="grid gap-8 lg:grid-cols-2">
+          <div className="rounded-[28px] border border-emerald-100 bg-white/90 p-6 shadow-lg backdrop-blur">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <h2 className="text-xl font-semibold text-gray-900">Town Snapshot</h2>
+              {guide?.href && guide?.label && (
+                <a
+                  href={guide.href}
+                  target={guide.target || "_blank"}
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sm font-semibold text-emerald-700 hover:text-emerald-800"
+                >
+                  {guide.label}
+                  <span aria-hidden>→</span>
+                </a>
+              )}
+            </div>
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              {snapshotFields.map((field) => (
+                <SnapshotRow key={field.key} label={field.label} value={snapshot?.[field.key]} />
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-[28px] border border-emerald-100 bg-white/90 p-6 shadow-lg backdrop-blur">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-gray-900">NorthSide Town Ratings</h2>
+            </div>
+            <div className="mt-6 space-y-4">
+              {ratings.map((item, index) => (
+                <RatingRow key={item?.label || index} item={item} scaleMax={ratingScaleMax} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Lifestyle */}
+      {lifestyleHighlights.length > 0 && (
+        <section className="bg-emerald-950/02">
+          <div className="mx-auto max-w-6xl px-4 py-16">
+            <div className="max-w-3xl">
+              <h2 className="text-2xl font-bold text-gray-900">Lifestyle at a Glance</h2>
+              <p className="mt-2 text-sm text-gray-600">
+                What day-to-day life feels like in {townName}.
+              </p>
+            </div>
+            <div className="mt-8 grid gap-6 lg:grid-cols-3">
+              {lifestyleHighlights.map((item, index) => (
+                <LifestyleCard key={item?.title || index} item={item} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Audiences */}
+      {audiences.length > 0 && (
+        <section>
+          <div className="mx-auto max-w-6xl px-4 py-16">
+            <div className="max-w-3xl">
+              <h2 className="text-2xl font-bold text-gray-900">Who {townName} is Great For</h2>
+            </div>
+            <div className="mt-8 grid gap-6 md:grid-cols-2">
+              {audiences.map((item, index) => (
+                <AudienceTile key={item?.title || index} item={item} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Neighbourhoods */}
+      {neighbourhoods.length > 0 && (
+        <section className="bg-gradient-to-b from-emerald-50 to-white/60">
+          <div className="mx-auto max-w-6xl px-4 py-16">
+            <div className="max-w-3xl">
+              <h2 className="text-2xl font-bold text-gray-900">Neighbourhoods in {townName}</h2>
+              <p className="mt-2 text-sm text-gray-600">
+                A few of the areas home buyers ask us about.
+              </p>
+            </div>
+            <div className="mt-8 grid gap-6 md:grid-cols-2">
+              {neighbourhoods.map((item, index) => (
+                <NeighbourhoodCard key={item?.name || index} item={item} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* FAQs */}
+      {faqs.length > 0 && (
+        <section>
+          <div className="mx-auto max-w-5xl px-4 py-16">
+            <div className="max-w-3xl">
+              <h2 className="text-2xl font-bold text-gray-900">Key Questions About Living in {townName}</h2>
+            </div>
+            <div className="mt-8 space-y-4">
+              {faqs.map((item, index) => (
+                <FaqItem
+                  key={item?.question || index}
+                  item={item}
+                  index={index}
+                  isOpen={openFaq === index}
+                  onToggle={() => setOpenFaq(openFaq === index ? null : index)}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* CTA */}
+      {cta && (
+        <section className="relative isolate overflow-hidden py-20">
+          <div className="absolute inset-0 bg-gradient-to-br from-emerald-900 via-emerald-800 to-emerald-600" />
+          <div className="absolute inset-0 opacity-70" style={{ backgroundImage: "radial-gradient(circle at top, rgba(255,255,255,0.2), transparent 55%)" }} />
+          <div className="relative mx-auto max-w-4xl px-4 text-center text-white">
+            <h2 className="text-3xl font-extrabold tracking-tight sm:text-4xl">{cta.title}</h2>
+            {cta.description && (
+              <p className="mt-4 text-base text-emerald-50 sm:text-lg">{cta.description}</p>
+            )}
+            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <ButtonLink
+                href={cta?.primaryButton?.href || "#"}
+                label={cta?.primaryButton?.label}
+                variant="primary"
+              />
+              <ButtonLink
+                href={cta?.secondaryButton?.href || "#"}
+                label={cta?.secondaryButton?.label}
+                variant="secondary"
+              />
+            </div>
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/towns.json
+++ b/src/towns.json
@@ -4,7 +4,11 @@
     "name": "Georgina",
     "heroImage": "/Images/georgina-banner.jpg",
     "summary": "Lake life, beaches, and room to roam with easy escapes to the water.",
-    "highlights": ["Lake Simcoe access", "Beaches & marinas", "Growing family neighbourhoods"],
+    "highlights": [
+      "Lake Simcoe access",
+      "Beaches & marinas",
+      "Growing family neighbourhoods"
+    ],
     "ratings": {
       "housePrices": 5,
       "commuterAccess": 4,
@@ -15,7 +19,9 @@
       "restaurants": 3,
       "localEvents": 4
     },
-    "commute": { "to404SteelesMinutes": 33 },
+    "commute": {
+      "to404SteelesMinutes": 33
+    },
     "pdf": "/PDF/Georgina-Guide.pdf"
   },
   {
@@ -23,7 +29,11 @@
     "name": "East Gwillimbury",
     "heroImage": "/Images/eastgwillimbury-banner.jpg",
     "summary": "New builds, schools and quick 404 access from Sharon, Queensville & Holland Landing.",
-    "highlights": ["Newer homes", "Schools & parks", "Fast 404 access"],
+    "highlights": [
+      "Newer homes",
+      "Schools & parks",
+      "Fast 404 access"
+    ],
     "ratings": {
       "housePrices": 4,
       "commuterAccess": 4,
@@ -34,7 +44,9 @@
       "restaurants": 4,
       "localEvents": 4
     },
-    "commute": { "to404SteelesMinutes": 27 },
+    "commute": {
+      "to404SteelesMinutes": 27
+    },
     "pdf": "/PDF/East-Gwillimbury-Guide.pdf"
   },
   {
@@ -42,7 +54,11 @@
     "name": "Newmarket",
     "heroImage": "/Images/newmarket-banner.jpg",
     "summary": "Shops, dining and GO convenience with a vibrant Main Street.",
-    "highlights": ["Historic Main Street", "GO Train access", "Shops & dining"],
+    "highlights": [
+      "Historic Main Street",
+      "GO Train access",
+      "Shops & dining"
+    ],
     "ratings": {
       "housePrices": 3,
       "commuterAccess": 5,
@@ -53,7 +69,9 @@
       "restaurants": 5,
       "localEvents": 4
     },
-    "commute": { "to404SteelesMinutes": 25 },
+    "commute": {
+      "to404SteelesMinutes": 25
+    },
     "pdf": "/PDF/Newmarket-Guide.pdf"
   },
   {
@@ -61,7 +79,11 @@
     "name": "Aurora",
     "heroImage": "/Images/aurora-banner.jpg",
     "summary": "Mature neighbourhoods, schools and quiet streets with fast commuter access.",
-    "highlights": ["Top schools", "Established streets", "GO & 404 access"],
+    "highlights": [
+      "Top schools",
+      "Established streets",
+      "GO & 404 access"
+    ],
     "ratings": {
       "housePrices": 3,
       "commuterAccess": 5,
@@ -72,15 +94,137 @@
       "restaurants": 4,
       "localEvents": 4
     },
-    "commute": { "to404SteelesMinutes": 23 },
-    "pdf": "/PDF/Aurora-Guide.pdf"
+    "commute": {
+      "to404SteelesMinutes": 23
+    },
+    "pdf": "/PDF/Aurora-Guide.pdf",
+    "hero": {
+      "tagline": "Town \u2022 NorthSide GTA",
+      "title": "Living in Aurora",
+      "subtitle": "A NorthSide GTA community with strong schools, established neighbourhoods, and convenient access to Toronto.",
+      "backgroundImage": "/Images/aurora-banner.jpg",
+      "backgroundAlt": "Aurora streetscape at dusk",
+      "primaryButton": {
+        "label": "Explore Homes in Aurora",
+        "href": "/buyers"
+      },
+      "secondaryButton": {
+        "label": "Match With a Local Agent",
+        "href": "/contact"
+      }
+    },
+    "snapshot": {
+      "population": "~62,000 (2021 Census)",
+      "driveToToronto": "Approx 40\u201350 minutes via Highway 404",
+      "goTrainTime": "Approx 50\u201355 minutes to Union Station from Aurora GO",
+      "homePriceRange": "Detached homes often trade in the mid-to-high $1M range, with townhomes providing more entry options.",
+      "highways": "Easy access to Highway 404 with connections toward Highway 400 via nearby routes.",
+      "transitSummary": "Aurora GO and local YRT/Viva routes connect to Toronto and neighbouring towns."
+    },
+    "ratingDescriptions": {
+      "housePrices": "Aurora\u2019s established detached homes keep pricing on the higher side for the NorthSide GTA.",
+      "commuterAccess": "Direct Highway 404 access and frequent GO trains make downtown commutes manageable.",
+      "localTraffic": "Local roads move steadily, though Yonge Street and Bayview can back up during rush hour.",
+      "golf": "Magna Golf Club, St. Andrew\u2019s Valley, and nearby courses provide plenty of fairways.",
+      "fishing": "In-town fishing spots are limited, but Lake Simcoe and the Holland River are a quick drive away.",
+      "trailsNature": "The Aurora Arboretum, Sheppard\u2019s Bush, and Moraine trails weave green space throughout town.",
+      "restaurants": "Independent restaurants downtown mix with convenient chains along Bayview and Wellington.",
+      "localEvents": "Seasonal farmers\u2019 markets, concerts in the park, and community festivals keep the calendar full."
+    },
+    "lifestyleHighlights": [
+      {
+        "icon": "leaf",
+        "title": "Nature & Green Space",
+        "description": "Aurora sits along the Oak Ridges Moraine with trails, parks, and conservation areas linking neighbourhoods to the outdoors."
+      },
+      {
+        "icon": "users",
+        "title": "Community & Family Life",
+        "description": "Established schools, recreation centres, and active minor sports make it easy for families to plug into the community."
+      },
+      {
+        "icon": "map",
+        "title": "Local Spots & Convenience",
+        "description": "Downtown boutiques, big-box conveniences, and growing dining options keep errands and evenings close to home."
+      }
+    ],
+    "audiences": [
+      {
+        "icon": "family",
+        "title": "Families with Kids",
+        "description": "Top-ranked public schools plus St. Andrew\u2019s College and St. Anne\u2019s School anchor education options."
+      },
+      {
+        "icon": "briefcase",
+        "title": "Commuters & Professionals",
+        "description": "Highway 404 and regular GO service keep downtown Toronto commutes practical on weekdays."
+      },
+      {
+        "icon": "activity",
+        "title": "Active Lifestyles",
+        "description": "Community centres, club sports, and nearby golf courses keep weekends busy."
+      },
+      {
+        "icon": "home",
+        "title": "Upsizers & Move-Up Buyers",
+        "description": "Larger lots and mature trees provide space for upsizing without leaving the GTA."
+      }
+    ],
+    "neighbourhoods": [
+      {
+        "name": "Aurora Village",
+        "description": "Historic downtown streets with century homes, caf\u00e9s, and quick GO Station access."
+      },
+      {
+        "name": "Bayview Wellington",
+        "description": "Family-friendly master-planned area with parks, schools, and everyday amenities."
+      },
+      {
+        "name": "Aurora Highlands",
+        "description": "Tree-lined streets of detached homes close to top schools and the town\u2019s recreation complex."
+      }
+    ],
+    "faqs": [
+      {
+        "question": "How long is the commute to Toronto?",
+        "answer": "Highway 404 typically delivers a 40\u201350 minute drive to downtown Toronto, and GO trains run about 50\u201355 minutes to Union Station."
+      },
+      {
+        "question": "What types of homes are common here?",
+        "answer": "Aurora is dominated by detached homes and townhomes from the 1980s onward, with some newer infill and estate properties."
+      },
+      {
+        "question": "Is Aurora good for families?",
+        "answer": "Yes\u2014Aurora is known for its school network, community programs, and recreation facilities that cater to families year-round."
+      },
+      {
+        "question": "What\u2019s the general price point for homes?",
+        "answer": "Detached homes often sell in the mid-to-high $1M range, with townhomes and semis offering slightly more attainable options."
+      }
+    ],
+    "cta": {
+      "title": "Ready to explore homes in Aurora?",
+      "description": "We live and work across the NorthSide GTA and can help you decide if Aurora fits your commute, your budget, and your lifestyle.",
+      "primaryButton": {
+        "label": "Book a Discovery Call",
+        "href": "/contact"
+      },
+      "secondaryButton": {
+        "label": "Tell Us What You\u2019re Looking For",
+        "href": "/vip"
+      }
+    }
   },
   {
     "slug": "stouffville",
     "name": "Stouffville",
     "heroImage": "/Images/stouffville-banner.jpg",
     "summary": "Family streets, parks and a lively Main Street close to nature.",
-    "highlights": ["Main Street vibe", "Parks & rec", "Family-friendly"],
+    "highlights": [
+      "Main Street vibe",
+      "Parks & rec",
+      "Family-friendly"
+    ],
     "ratings": {
       "housePrices": 4,
       "commuterAccess": 4,
@@ -91,7 +235,9 @@
       "restaurants": 4,
       "localEvents": 4
     },
-    "commute": { "to404SteelesMinutes": 26 },
+    "commute": {
+      "to404SteelesMinutes": 26
+    },
     "pdf": "/PDF/Stouffville-Guide.pdf"
   },
   {
@@ -99,7 +245,11 @@
     "name": "Uxbridge",
     "heroImage": "/Images/uxbridge-banner.jpg",
     "summary": "Trail capital charm, rolling hills and small-town feel with outdoor living.",
-    "highlights": ["Trails & nature", "Small-town charm", "Active community"],
+    "highlights": [
+      "Trails & nature",
+      "Small-town charm",
+      "Active community"
+    ],
     "ratings": {
       "housePrices": 3,
       "commuterAccess": 3,
@@ -110,7 +260,9 @@
       "restaurants": 4,
       "localEvents": 4
     },
-    "commute": { "to404SteelesMinutes": 37 },
+    "commute": {
+      "to404SteelesMinutes": 37
+    },
     "pdf": "/PDF/Uxbridge-Guide.pdf"
   },
   {
@@ -118,7 +270,11 @@
     "name": "Scugog",
     "heroImage": "/Images/scugog-banner.jpg",
     "summary": "Port Perry heritage, lakefront sunsets and a relaxed pace by the water.",
-    "highlights": ["Lakefront living", "Main Street heritage", "Community events"],
+    "highlights": [
+      "Lakefront living",
+      "Main Street heritage",
+      "Community events"
+    ],
     "ratings": {
       "housePrices": 4,
       "commuterAccess": 3,
@@ -129,7 +285,9 @@
       "restaurants": 4,
       "localEvents": 5
     },
-    "commute": { "to404SteelesMinutes": 40 },
+    "commute": {
+      "to404SteelesMinutes": 40
+    },
     "pdf": "/PDF/Scugog-Guide.pdf"
   }
 ]


### PR DESCRIPTION
## Summary
- add a reusable TownPageLayout component with hero, snapshot, ratings, lifestyle, audience, neighbourhood, FAQ, and CTA sections
- update the Aurora town configuration with structured snapshot, lifestyle, audience, FAQ, and CTA content and button links
- switch the Aurora route to TownPageLayout while keeping existing ratings data and providing icons, guide link, and navigation strip

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690cea0e37a083248fc43b624a209c6d