### PR TITLE
Update footer link to upcoming events

### DIFF
--- a/src/Footer.js
+++ b/src/Footer.js
@@ -9,10 +9,10 @@ export default function Footer() {
       <span aria-hidden="true">•</span>
       {' '}
       <a
-        href="/events/archive"
-        className="font-medium text-emerald-600 hover:text-emerald-700"
+        href="/community"
+        className="font-medium text-gray-500 hover:text-[#32610E] focus:text-[#32610E]"
       >
-        Past Events Archive
+        Upcoming Events Across the NorthSide GTA
       </a>
     </footer>
   );


### PR DESCRIPTION
## Summary
- replace the footer "Past Events Archive" link with "Upcoming Events Across the NorthSide GTA" linking to /community
- apply the NorthSide Green (#32610E) accent on hover and focus for the updated footer link

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e18be83388324a96a6e65887ee207)