### PR TITLE
Prevent duplicate social meta tags when Site SEO overrides

### DIFF
--- a/src/components/seo/DynamicMetaTags.js
+++ b/src/components/seo/DynamicMetaTags.js
@@ -1,25 +1,36 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
 
-import { getMetaTagsFromData } from "./metaTagUtils";
+import { getMetaTagsFromData, SOCIAL_META_KEYS } from "./metaTagUtils";
 
 export { getMetaTagsFromData } from "./metaTagUtils";
+
+const SOCIAL_META_KEY_SET = new Set(SOCIAL_META_KEYS);
 
 export default function DynamicMetaTags(props) {
   const { children, ...metaProps } = props || {};
   const meta = getMetaTagsFromData(metaProps);
 
   if (!meta) {
-    if (!children) {
+    const childArray = React.Children.toArray(children);
+    if (childArray.length === 0) {
       return null;
     }
-    return <Helmet>{children}</Helmet>;
+    return <Helmet>{childArray}</Helmet>;
+  }
+
+  const tags = Array.isArray(meta.tags) ? meta.tags : [];
+  const hasSiteSeoOverrides = Boolean(meta.flags && meta.flags.hasSiteSeoOverrides);
+  const filteredChildren = filterMetaChildren(children, hasSiteSeoOverrides);
+
+  if (tags.length === 0 && filteredChildren.length === 0) {
+    return null;
   }
 
   return (
     <Helmet>
-      {meta.tags.map(renderHelmetTag)}
-      {children}
+      {tags.map(renderHelmetTag)}
+      {filteredChildren}
     </Helmet>
   );
 }
@@ -41,5 +52,37 @@ function renderHelmetTag(tag, index) {
   }
 
   return null;
+}
+
+function filterMetaChildren(children, hasSiteSeoOverrides) {
+  const array = React.Children.toArray(children);
+  if (!hasSiteSeoOverrides || array.length === 0) {
+    return array;
+  }
+
+  return array.filter((child) => {
+    if (!React.isValidElement(child)) return true;
+    if (child.type !== "meta") return true;
+    const key = getChildMetaKey(child.props);
+    if (!key) return true;
+    return !SOCIAL_META_KEY_SET.has(key);
+  });
+}
+
+function getChildMetaKey(props = {}) {
+  if (!props || typeof props !== "object") return "";
+  const property = safeMetaKey(props.property);
+  if (property) {
+    return `property:${property}`;
+  }
+  const name = safeMetaKey(props.name);
+  if (name) {
+    return `name:${name}`;
+  }
+  return "";
+}
+
+function safeMetaKey(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 

--- a/src/components/seo/metaTagUtils.js
+++ b/src/components/seo/metaTagUtils.js
@@ -2,6 +2,62 @@ const { getSiteSeoForRoute } = require("./siteSeoConfig");
 
 const DEFAULT_TWITTER_CARD = "summary_large_image";
 
+const SOCIAL_META_KEYS = [
+  "property:og:type",
+  "property:og:title",
+  "property:og:description",
+  "property:og:url",
+  "property:og:image",
+  "property:og:image:alt",
+  "property:og:site_name",
+  "name:twitter:card",
+  "name:twitter:title",
+  "name:twitter:description",
+  "name:twitter:image",
+  "name:twitter:image:alt",
+];
+
+const SOCIAL_META_KEY_SET = new Set(SOCIAL_META_KEYS);
+
+function getMetaAttributeKey(attributes = {}) {
+  if (!attributes || typeof attributes !== "object") return "";
+  const property = safeString(attributes.property);
+  if (property) {
+    return `property:${property}`;
+  }
+  const name = safeString(attributes.name);
+  if (name) {
+    return `name:${name}`;
+  }
+  return "";
+}
+
+function dedupeSocialMetaTags(tags = []) {
+  if (!Array.isArray(tags) || tags.length <= 1) {
+    return tags;
+  }
+
+  const result = tags.slice();
+  const latestIndexByKey = new Map();
+
+  for (let index = 0; index < result.length; index += 1) {
+    const tag = result[index];
+    if (!tag || tag.type !== "meta") continue;
+
+    const key = getMetaAttributeKey(tag.attributes);
+    if (!key || !SOCIAL_META_KEY_SET.has(key)) continue;
+
+    if (latestIndexByKey.has(key)) {
+      const previousIndex = latestIndexByKey.get(key);
+      result[previousIndex] = null;
+    }
+
+    latestIndexByKey.set(key, index);
+  }
+
+  return result.filter(Boolean);
+}
+
 function safeString(value) {
   if (value == null) return "";
   if (typeof value === "string") return value.trim();
@@ -34,6 +90,7 @@ function getMetaTagsFromData(raw = {}) {
   const siteSeoTitle = safeString(siteSeo && siteSeo.seo_title);
   const siteSeoDescription = safeString(siteSeo && siteSeo.seo_description);
   const siteSeoImage = safeString(siteSeo && siteSeo.seo_image);
+  const hasSiteSeoOverrides = Boolean(siteSeo);
 
   const fallbackTitleValue = safeString(raw.title);
   const titleValue = siteSeoTitle || fallbackTitleValue;
@@ -254,8 +311,10 @@ function getMetaTagsFromData(raw = {}) {
     return null;
   }
 
+  const dedupedTags = dedupeSocialMetaTags(tags);
+
   return {
-    tags,
+    tags: dedupedTags,
     values: {
       documentTitle: documentTitleValue,
       title: titleValue,
@@ -270,6 +329,9 @@ function getMetaTagsFromData(raw = {}) {
       siteName: siteNameValue,
       articleAuthor: articleAuthorValue,
       articlePublishedTime: articlePublishedTimeValue,
+    },
+    flags: {
+      hasSiteSeoOverrides,
     },
   };
 }
@@ -324,6 +386,7 @@ function renderMetaTagsToString(raw = {}) {
 
 module.exports = {
   DEFAULT_TWITTER_CARD,
+  SOCIAL_META_KEYS,
   getMetaTagsFromData,
   getMetaTagHtmlList,
   renderMetaTagsToString,


### PR DESCRIPTION
## Summary
- dedupe Open Graph and Twitter meta descriptors in metaTagUtils so overrides replace global defaults
- flag Site SEO overrides and filter default social meta children in DynamicMetaTags to avoid duplicate tags when route-specific SEO exists

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4870b4a0832483a4409b35f77206)