### PR TITLE
Stop rendering duplicate global social meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,28 +42,7 @@
     />
     <link rel="canonical" href="https://northsidegta.ca/" />
 
-    <!-- Open Graph / Facebook -->
-    <meta property="og:title" content="NorthSide GTA | Real Estate Agents for Buyers & Sellers" />
-    <meta
-      property="og:description"
-      content="Local team helping you buy and sell in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog."
-    />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://northsidegta.ca/" />
-    <meta property="og:image" content="https://northsidegta.ca/Images/og-home.jpg" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog" />
-    <meta property="og:image:type" content="image/jpeg" />
-
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="NorthSide GTA | Real Estate Agents for Buyers & Sellers" />
-    <meta
-      name="twitter:description"
-      content="Local team helping you buy and sell in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog."
-    />
-    <meta name="twitter:image" content="https://northsidegta.ca/og-home.jpg" />
+    <!-- Open Graph / Twitter tags are injected via React Helmet -->
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ import InsightPage      from "./insights/InsightPage";
 import MediaPage        from "./MediaPage";
 import InsightsPage     from "./InsightsPage";
 import ReferralPartnersPage from "./ReferralPartnersPage";
+import GlobalDefaultMeta from "./components/seo/GlobalDefaultMeta";
 
 // Load the town slugs right here (no helper to avoid any cyclic import)
 import towns from "./towns.json";
@@ -52,6 +53,7 @@ function App() {
 
   return (
     <Router>
+      <GlobalDefaultMeta />
       <Routes>
         {/* Core pages */}
         <Route path="/"             element={<HomePage />} />

--- a/src/components/seo/GlobalDefaultMeta.js
+++ b/src/components/seo/GlobalDefaultMeta.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { Helmet } from "react-helmet-async";
+
+const DEFAULT_TITLE = "NorthSide GTA | Real Estate Agents for Buyers & Sellers";
+const DEFAULT_DESCRIPTION =
+  "Find your perfect home or sell for more in the NorthSide GTA. Local experts serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.";
+const DEFAULT_URL = "https://www.northsidegta.ca/";
+const DEFAULT_IMAGE = "https://www.northsidegta.ca/Images/og-home.jpg";
+const DEFAULT_IMAGE_ALT =
+  "NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog";
+
+export default function GlobalDefaultMeta() {
+  return (
+    <Helmet>
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={DEFAULT_TITLE} />
+      <meta property="og:description" content={DEFAULT_DESCRIPTION} />
+      <meta property="og:url" content={DEFAULT_URL} />
+      <meta property="og:image" content={DEFAULT_IMAGE} />
+      <meta property="og:image:alt" content={DEFAULT_IMAGE_ALT} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:site_name" content="NorthSide GTA" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={DEFAULT_TITLE} />
+      <meta name="twitter:description" content={DEFAULT_DESCRIPTION} />
+      <meta name="twitter:image" content={DEFAULT_IMAGE} />
+    </Helmet>
+  );
+}


### PR DESCRIPTION
## Summary
- move the default Open Graph and Twitter meta tags into a reusable Helmet component
- remove the hard-coded social meta block from the static HTML shell to avoid duplicates
- register the global fallback meta component in the app so per-route SEO overrides replace it automatically

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e58e33ab48324b4fced012de51c4e)