### PR TITLE
Ensure social meta fallbacks are applied consistently

### DIFF
--- a/src/components/seo/DynamicMetaTags.js
+++ b/src/components/seo/DynamicMetaTags.js
@@ -1,7 +1,12 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
 
-import { getMetaTagsFromData, SOCIAL_META_KEYS } from "./metaTagUtils";
+import {
+  SITE_BASE_URL,
+  getMetaTagsFromData,
+  SOCIAL_META_KEYS,
+} from "./metaTagUtils";
+import renderHelmetTag from "./renderHelmetTag";
 
 export { getMetaTagsFromData } from "./metaTagUtils";
 
@@ -20,38 +25,22 @@ export default function DynamicMetaTags(props) {
   }
 
   const tags = Array.isArray(meta.tags) ? meta.tags : [];
+  const metaValues = meta.values || {};
+  const socialImageContent = resolveSocialImageContent(metaValues);
+  const tagsWithSocialImages = ensureSocialImageTags(tags, socialImageContent);
   const hasSiteSeoOverrides = Boolean(meta.flags && meta.flags.hasSiteSeoOverrides);
   const filteredChildren = filterMetaChildren(children, hasSiteSeoOverrides);
 
-  if (tags.length === 0 && filteredChildren.length === 0) {
+  if (tagsWithSocialImages.length === 0 && filteredChildren.length === 0) {
     return null;
   }
 
   return (
     <Helmet>
-      {tags.map(renderHelmetTag)}
+      {tagsWithSocialImages.map(renderHelmetTag)}
       {filteredChildren}
     </Helmet>
   );
-}
-
-function renderHelmetTag(tag, index) {
-  if (!tag) return null;
-  const key = tag.key || `${tag.type || "meta"}-${index}`;
-
-  if (tag.type === "title") {
-    return <title key={key}>{tag.content}</title>;
-  }
-
-  if (tag.type === "meta") {
-    return <meta key={key} {...(tag.attributes || {})} />;
-  }
-
-  if (tag.type === "link") {
-    return <link key={key} {...(tag.attributes || {})} />;
-  }
-
-  return null;
 }
 
 function filterMetaChildren(children, hasSiteSeoOverrides) {
@@ -84,5 +73,81 @@ function getChildMetaKey(props = {}) {
 
 function safeMetaKey(value) {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function ensureSocialImageTags(tags, socialImageContent) {
+  if (!socialImageContent) {
+    return tags.slice();
+  }
+
+  const next = [];
+  let hasOgImage = false;
+  let hasTwitterImage = false;
+
+  for (const tag of tags) {
+    if (!tag || tag.type !== "meta") {
+      next.push(tag);
+      continue;
+    }
+
+    const attributes = tag.attributes || {};
+    if (attributes.property === "og:image") {
+      hasOgImage = true;
+      next.push({
+        ...tag,
+        attributes: { ...attributes, content: socialImageContent },
+      });
+      continue;
+    }
+
+    if (attributes.name === "twitter:image") {
+      hasTwitterImage = true;
+      next.push({
+        ...tag,
+        attributes: { ...attributes, content: socialImageContent },
+      });
+      continue;
+    }
+
+    next.push(tag);
+  }
+
+  if (!hasOgImage) {
+    next.push({
+      type: "meta",
+      key: "meta:og:image",
+      attributes: {
+        property: "og:image",
+        content: socialImageContent,
+      },
+    });
+  }
+
+  if (!hasTwitterImage) {
+    next.push({
+      type: "meta",
+      key: "meta:twitter:image",
+      attributes: {
+        name: "twitter:image",
+        content: socialImageContent,
+      },
+    });
+  }
+
+  return next;
+}
+
+function resolveSocialImageContent(values = {}) {
+  const path = safeString(values.metaImagePath);
+  if (path) {
+    return `${SITE_BASE_URL}${path}`;
+  }
+  return safeString(values.metaImage);
+}
+
+function safeString(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value.trim();
+  return String(value).trim();
 }
 

--- a/src/components/seo/GlobalDefaultMeta.js
+++ b/src/components/seo/GlobalDefaultMeta.js
@@ -1,30 +1,41 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
 
+import {
+  DEFAULT_META_IMAGE_PATH,
+  SITE_BASE_URL,
+  getMetaTagsFromData,
+} from "./metaTagUtils";
+import renderHelmetTag from "./renderHelmetTag";
+
 const DEFAULT_TITLE = "NorthSide GTA | Real Estate Agents for Buyers & Sellers";
 const DEFAULT_DESCRIPTION =
   "Find your perfect home or sell for more in the NorthSide GTA. Local experts serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.";
-const DEFAULT_URL = "https://www.northsidegta.ca/";
-const DEFAULT_IMAGE = "https://www.northsidegta.ca/Images/og-home.jpg";
 const DEFAULT_IMAGE_ALT =
   "NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog";
 
+const DEFAULT_META_CONFIG = {
+  route: "/",
+  documentTitle: DEFAULT_TITLE,
+  title: DEFAULT_TITLE,
+  description: DEFAULT_DESCRIPTION,
+  canonicalUrl: `${SITE_BASE_URL}/`,
+  ogType: "website",
+  ogImage: DEFAULT_META_IMAGE_PATH,
+  ogImageAlt: DEFAULT_IMAGE_ALT,
+  twitterCard: "summary_large_image",
+  twitterImage: DEFAULT_META_IMAGE_PATH,
+  twitterImageAlt: DEFAULT_IMAGE_ALT,
+  siteName: "NorthSide GTA",
+};
+
 export default function GlobalDefaultMeta() {
-  return (
-    <Helmet>
-      <meta property="og:type" content="website" />
-      <meta property="og:title" content={DEFAULT_TITLE} />
-      <meta property="og:description" content={DEFAULT_DESCRIPTION} />
-      <meta property="og:url" content={DEFAULT_URL} />
-      <meta property="og:image" content={DEFAULT_IMAGE} />
-      <meta property="og:image:alt" content={DEFAULT_IMAGE_ALT} />
-      <meta property="og:image:width" content="1200" />
-      <meta property="og:image:height" content="630" />
-      <meta property="og:site_name" content="NorthSide GTA" />
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:title" content={DEFAULT_TITLE} />
-      <meta name="twitter:description" content={DEFAULT_DESCRIPTION} />
-      <meta name="twitter:image" content={DEFAULT_IMAGE} />
-    </Helmet>
-  );
+  const meta = getMetaTagsFromData(DEFAULT_META_CONFIG);
+  const tags = meta && Array.isArray(meta.tags) ? meta.tags : [];
+
+  if (tags.length === 0) {
+    return null;
+  }
+
+  return <Helmet>{tags.map(renderHelmetTag)}</Helmet>;
 }

--- a/src/components/seo/metaTagUtils.js
+++ b/src/components/seo/metaTagUtils.js
@@ -1,5 +1,7 @@
 const { getSiteSeoForRoute } = require("./siteSeoConfig");
 
+const SITE_BASE_URL = "https://northsidegta.ca";
+const DEFAULT_META_IMAGE_PATH = "/Images/og-home.jpg";
 const DEFAULT_TWITTER_CARD = "summary_large_image";
 
 const SOCIAL_META_KEYS = [
@@ -64,6 +66,96 @@ function safeString(value) {
   return String(value).trim();
 }
 
+function ensureLeadingSlash(value) {
+  const trimmed = safeString(value);
+  if (!trimmed) return "";
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function isAbsoluteUrl(value) {
+  return /^https?:\/\//i.test(value);
+}
+
+function normalizeCanonicalUrl(value, routeValue) {
+  const provided = safeString(value);
+  if (provided) {
+    return buildAbsoluteUrl(provided);
+  }
+  if (!routeValue) return "";
+  const normalizedRoute = routeValue === "/" ? "/" : ensureLeadingSlash(routeValue);
+  return `${SITE_BASE_URL}${normalizedRoute === "/" ? "/" : normalizedRoute}`;
+}
+
+function buildAbsoluteUrl(value) {
+  const trimmed = safeString(value);
+  if (!trimmed) return "";
+  if (isAbsoluteUrl(trimmed)) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("//")) {
+    return `https:${trimmed}`;
+  }
+  const withLeadingSlash = ensureLeadingSlash(trimmed);
+  return `${SITE_BASE_URL}${withLeadingSlash}`;
+}
+
+function normalizeMetaImage(siteSeoImage, raw = {}) {
+  const candidates = [
+    safeString(siteSeoImage),
+    safeString(raw.ogImage),
+    safeString(raw.image),
+    safeString(raw.twitterImage),
+    DEFAULT_META_IMAGE_PATH,
+  ];
+
+  let chosen = "";
+  for (const candidate of candidates) {
+    if (candidate) {
+      chosen = candidate;
+      break;
+    }
+  }
+
+  let absoluteUrl = "";
+  let path = "";
+
+  if (chosen) {
+    if (isAbsoluteUrl(chosen)) {
+      absoluteUrl = chosen;
+      if (absoluteUrl.startsWith(`${SITE_BASE_URL}`)) {
+        try {
+          const url = new URL(absoluteUrl);
+          path = `${url.pathname}${url.search}${url.hash}`.replace(/[#?]$/, "");
+        } catch (error) {
+          path = "";
+        }
+      }
+    } else if (chosen.startsWith("//")) {
+      absoluteUrl = `https:${chosen}`;
+    } else {
+      path = ensureLeadingSlash(chosen);
+      absoluteUrl = `${SITE_BASE_URL}${path}`;
+    }
+  }
+
+  if (!absoluteUrl) {
+    path = ensureLeadingSlash(DEFAULT_META_IMAGE_PATH);
+    absoluteUrl = `${SITE_BASE_URL}${path}`;
+  } else if (!path && absoluteUrl.startsWith(`${SITE_BASE_URL}`)) {
+    try {
+      const url = new URL(absoluteUrl);
+      path = `${url.pathname}${url.search}${url.hash}`.replace(/[#?]$/, "");
+    } catch (error) {
+      path = ensureLeadingSlash(DEFAULT_META_IMAGE_PATH);
+    }
+  }
+
+  return {
+    path,
+    absoluteUrl,
+  };
+}
+
 function normalizeAdditionalMeta(additionalMeta) {
   if (!Array.isArray(additionalMeta)) return [];
   return additionalMeta
@@ -114,12 +206,14 @@ function getMetaTagsFromData(raw = {}) {
       descriptionValue,
   );
 
-  const canonicalValue = safeString(raw.canonicalUrl);
+  const canonicalValue = normalizeCanonicalUrl(raw.canonicalUrl, routeValue);
   const ogTypeValue = safeString(raw.ogType);
-  const ogImageValue = safeString(siteSeoImage || raw.ogImage || raw.image);
+  const { path: metaImagePath, absoluteUrl: resolvedMetaImageUrl } =
+    normalizeMetaImage(siteSeoImage, raw);
+  const ogImageValue = resolvedMetaImageUrl;
   const ogImageAltValue = safeString(raw.ogImageAlt);
   const twitterCardValue = safeString(raw.twitterCard) || DEFAULT_TWITTER_CARD;
-  const twitterImageValue = safeString(siteSeoImage || raw.twitterImage || ogImageValue);
+  const twitterImageValue = resolvedMetaImageUrl;
   const twitterImageAltValue = safeString(raw.twitterImageAlt || ogImageAltValue);
   const siteNameValue = safeString(raw.siteName);
   const articleAuthorValue = safeString(raw.articleAuthor);
@@ -322,6 +416,8 @@ function getMetaTagsFromData(raw = {}) {
       canonicalUrl: canonicalValue,
       ogType: ogTypeValue,
       ogImage: ogImageValue,
+      metaImagePath,
+      metaImage: resolvedMetaImageUrl,
       ogImageAlt: ogImageAltValue,
       twitterCard: twitterCardValue,
       twitterImage: twitterImageValue,
@@ -385,8 +481,11 @@ function renderMetaTagsToString(raw = {}) {
 }
 
 module.exports = {
+  DEFAULT_META_IMAGE_PATH,
   DEFAULT_TWITTER_CARD,
+  SITE_BASE_URL,
   SOCIAL_META_KEYS,
+  buildAbsoluteUrl,
   getMetaTagsFromData,
   getMetaTagHtmlList,
   renderMetaTagsToString,

--- a/src/components/seo/renderHelmetTag.js
+++ b/src/components/seo/renderHelmetTag.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+export default function renderHelmetTag(tag, index) {
+  if (!tag) return null;
+  const key = tag.key || `${tag.type || "meta"}-${index}`;
+
+  if (tag.type === "title") {
+    return <title key={key}>{tag.content}</title>;
+  }
+
+  if (tag.type === "meta") {
+    return <meta key={key} {...(tag.attributes || {})} />;
+  }
+
+  if (tag.type === "link") {
+    return <link key={key} {...(tag.attributes || {})} />;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- resolve canonical URLs and social image defaults through shared SEO utilities
- enforce a single og:image/twitter:image pair in DynamicMetaTags using the resolved image
- render fallback meta tags through GlobalDefaultMeta with the shared helper

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5bcd524083249aa2493558532806)