### PR TITLE
Pre-render marketing route meta tags during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pretest": "node scripts/sync-site-seo.js",
     "prebuild": "node scripts/sync-site-seo.js && node scripts/generate-insights-data.js && node scripts/generate-insights-index.js",
     "build": "react-scripts build",
-    "postbuild": "node scripts/generate-curated-html.js && node scripts/generate-insight-html.js && node scripts/generate-event-html.js && node scripts/generate-sitemap.js && node scripts/check-insight-images.js && cp build/index.html build/404.html",
+    "postbuild": "node scripts/generate-curated-html.js && node scripts/generate-insight-html.js && node scripts/generate-event-html.js && node scripts/generate-static-route-html.js && node scripts/generate-sitemap.js && node scripts/check-insight-images.js && cp build/index.html build/404.html",
     "generate:curated": "node scripts/generate-curated-html.js",
     "ingest:events": "node scripts/ingest-events.js",
     "events:backfill-daily": "node scripts/backfill-daily-schedule.mjs",

--- a/scripts/generate-static-route-html.js
+++ b/scripts/generate-static-route-html.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("node-html-parser");
+
+const {
+  loadTemplate,
+  stripSeoTags,
+  appendHeadTag,
+  finalizeHtml,
+} = require("./utils/staticMeta");
+const { getMetaTagsFromData } = require("../src/components/seo/metaTagUtils.js");
+const {
+  DEFAULT_GLOBAL_META_CONFIG,
+  STATIC_ROUTE_META_CONFIGS,
+} = require("../src/components/seo/staticRouteMetaConfigs.js");
+
+function main() {
+  const template = loadTemplate();
+  if (!template) {
+    console.warn("[generate-static-route-html] Skipping — unable to locate HTML template");
+    process.exit(0);
+  }
+
+  const routes = Array.isArray(STATIC_ROUTE_META_CONFIGS)
+    ? STATIC_ROUTE_META_CONFIGS.filter((entry) => entry && entry.route && entry.meta)
+    : [];
+
+  if (routes.length === 0) {
+    console.warn("[generate-static-route-html] No static routes configured. Skipping.");
+    return;
+  }
+
+  const baseDoc = template.baseHtml;
+  const outputRoot = template.hasBuildTemplate ? template.buildDir : template.publicDir;
+
+  const baseMeta = getMetaTagsFromData(DEFAULT_GLOBAL_META_CONFIG);
+  const baseTags = baseMeta && Array.isArray(baseMeta.tags) ? baseMeta.tags : [];
+
+  let created = 0;
+  const failures = [];
+
+  routes.forEach((entry) => {
+    const { route, meta } = entry;
+    try {
+      const headFragments = buildHeadFragments(baseDoc, template.doctype, baseTags, meta);
+      const targetPath = getOutputPath(outputRoot, route);
+      const targetDir = path.dirname(targetPath);
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(targetPath, headFragments, "utf8");
+      created += 1;
+    } catch (error) {
+      failures.push({ route, reason: error.message });
+    }
+  });
+
+  if (created > 0) {
+    console.log(
+      `[generate-static-route-html] Created ${created} static route page${created === 1 ? "" : "s"}`
+    );
+  }
+
+  if (failures.length > 0) {
+    failures.forEach((failure) => {
+      console.warn(
+        `[generate-static-route-html] Failed to generate ${failure.route || "<unknown>"}: ${failure.reason}`
+      );
+    });
+    process.exitCode = 1;
+  }
+}
+
+function buildHeadFragments(baseHtml, doctype, baseTags, routeMeta) {
+  if (!routeMeta || typeof routeMeta !== "object") {
+    throw new Error("Missing route meta configuration");
+  }
+
+  const doc = parse(baseHtml, { comment: true });
+  const head = doc.querySelector("head");
+  if (!head) {
+    throw new Error("Template is missing <head> element");
+  }
+
+  stripSeoTags(head);
+
+  const combinedTags = mergeMetaTags(baseTags, routeMeta);
+  const fragments = combinedTags.map(stringifyTag).filter(Boolean);
+  fragments.forEach((fragment) => appendHeadTag(head, fragment));
+
+  return finalizeHtml(doc, doctype);
+}
+
+function mergeMetaTags(baseTags, routeMetaConfig) {
+  const routeMeta = getMetaTagsFromData(routeMetaConfig);
+  const routeTags = routeMeta && Array.isArray(routeMeta.tags) ? routeMeta.tags : [];
+
+  const result = [];
+  const keyIndex = new Map();
+
+  [baseTags, routeTags].forEach((tagList) => {
+    tagList.forEach((tag) => {
+      if (!tag) return;
+      const key = resolveTagKey(tag);
+      if (key && keyIndex.has(key)) {
+        const index = keyIndex.get(key);
+        result[index] = tag;
+      } else {
+        result.push(tag);
+        if (key) {
+          keyIndex.set(key, result.length - 1);
+        }
+      }
+    });
+  });
+
+  return result.filter(Boolean);
+}
+
+function resolveTagKey(tag) {
+  if (!tag || typeof tag !== "object") return "";
+  if (tag.key) return tag.key;
+  if (tag.type === "meta") {
+    const attrs = tag.attributes || {};
+    if (attrs.name) return `meta:name:${attrs.name}`;
+    if (attrs.property) return `meta:property:${attrs.property}`;
+  }
+  if (tag.type === "link") {
+    const attrs = tag.attributes || {};
+    if (attrs.rel) return `link:rel:${attrs.rel}`;
+  }
+  if (tag.type === "title") {
+    return "document-title";
+  }
+  return "";
+}
+
+function stringifyTag(tag) {
+  if (!tag) return "";
+  if (tag.type === "title") {
+    return `<title>${escapeHtml(tag.content || "")}</title>`;
+  }
+  if (tag.type === "meta") {
+    const attrs = tag.attributes || {};
+    const attrText = Object.entries(attrs)
+      .filter(([, value]) => value != null && value !== "")
+      .map(([key, value]) => `${key}="${escapeAttribute(value)}"`)
+      .join(" ");
+    return attrText ? `<meta ${attrText} />` : "";
+  }
+  if (tag.type === "link") {
+    const attrs = tag.attributes || {};
+    const attrText = Object.entries(attrs)
+      .filter(([, value]) => value != null && value !== "")
+      .map(([key, value]) => `${key}="${escapeAttribute(value)}"`)
+      .join(" ");
+    return attrText ? `<link ${attrText} />` : "";
+  }
+  return "";
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value).replace(/"/g, "&quot;");
+}
+
+function getOutputPath(root, route) {
+  if (!route || route === "/") {
+    return path.join(root, "index.html");
+  }
+  const normalized = route.replace(/^\//, "");
+  return path.join(root, normalized, "index.html");
+}
+
+main();

--- a/src/AboutPage.js
+++ b/src/AboutPage.js
@@ -5,6 +5,7 @@ import Navigation from "./Navigation";
 import { Award, Heart, Lightbulb, Mail, MapPin, ShieldCheck } from "lucide-react";
 import teamMembers from "./data/teamMembers";
 import DynamicMetaTags from "./components/seo/DynamicMetaTags";
+import { getStaticRouteMeta } from "./components/seo/staticRouteMetaExports";
 
 const metrics = [
   {
@@ -104,28 +105,13 @@ const testimonials = [
   },
 ];
 
+const ABOUT_ROUTE_META = getStaticRouteMeta("/about") || {};
+
 export default function AboutPage() {
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
       <Navigation />
-      <DynamicMetaTags
-        route="/about"
-        documentTitle="About Finally Home Agents | Local NorthSide GTA Realtors®"
-        title="About Finally Home Agents | Local NorthSide GTA Realtors®"
-        description="We’re a local, relationship-first real estate team serving the NorthSide GTA—Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
-        canonicalUrl="https://www.northsidegta.ca/about"
-        ogType="profile"
-        ogImage="/Images/northsidegta-map-bg.jpg"
-        twitterCard="summary_large_image"
-        twitterImage="/Images/northsidegta-map-bg.jpg"
-        additionalMeta={[
-          {
-            name: "keywords",
-            content:
-              "about Finally Home Agents, NorthSide GTA realtors, local real estate team, Newmarket, Aurora, Uxbridge",
-          },
-        ]}
-      />
+      <DynamicMetaTags {...ABOUT_ROUTE_META} />
 
       <main className="pb-16">
         {/* ───────── Hero Banner ───────── */}

--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -4,6 +4,7 @@ import Navigation from "./Navigation";
 import Footer from "./Footer";
 import GoogleGradientReviews from "./components/reviews/GoogleGradientReviews";
 import DynamicMetaTags from "./components/seo/DynamicMetaTags";
+import { getStaticRouteMeta } from "./components/seo/staticRouteMetaExports";
 
 /* ───────── helpers ───────── */
 const emailOk = (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
@@ -654,36 +655,22 @@ function BuyerSignupForm() {
   );
 }
 
+const BUYERS_ROUTE_META = getStaticRouteMeta("/buyers") || {};
+
 /* ───────── Page ───────── */
 export default function BuyersPage() {
   return (
     <div className="min-h-screen overflow-hidden bg-[#04110c] text-white">
       <Navigation />
-      <DynamicMetaTags
-        route="/buyers"
-        documentTitle="Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents"
-        title="Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents"
-        description="Ready to buy in the NorthSide GTA? Get a personalized town match, VIP listing alerts, and expert guidance from Finally Home Agents in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog."
-        canonicalUrl="https://www.northsidegta.ca/buyers"
-        ogType="website"
-        ogImage="https://www.northsidegta.ca/Images/northsidegta-map-bg.jpg"
-        twitterCard="summary_large_image"
-        twitterImage="https://www.northsidegta.ca/Images/northsidegta-map-bg.jpg"
-        additionalMeta={[
-          { name: "robots", content: "index,follow" },
-          {
-            name: "keywords",
-            content:
-              "NorthSide GTA homes for sale, buy a home Georgina, buy a home East Gwillimbury, buy a home Newmarket, buy a home Aurora, buy a home Stouffville, buy a home Uxbridge, buy a home Scugog, town match, VIP listing alerts, Finally Home Agents",
-          },
-        ]}
-      >
+      <DynamicMetaTags {...BUYERS_ROUTE_META}>
         <script type="application/ld+json">
           {JSON.stringify({
             "@context": "https://schema.org",
             "@type": "WebPage",
-            name: "Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents",
-            url: "https://www.northsidegta.ca/buyers",
+            name:
+              BUYERS_ROUTE_META.title ||
+              "Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents",
+            url: BUYERS_ROUTE_META.canonicalUrl || "https://northsidegta.ca/buyers",
             description:
               "Personalized town match, VIP listing alerts, and expert guidance for buyers in the NorthSide GTA.",
             about: {
@@ -698,7 +685,7 @@ export default function BuyersPage() {
                 "Uxbridge",
                 "Scugog",
               ],
-              url: "https://www.northsidegta.ca",
+              url: "https://northsidegta.ca",
               brand: "Finally Home Agents",
             },
           })}

--- a/src/CommunityPage.js
+++ b/src/CommunityPage.js
@@ -17,6 +17,7 @@ import {
   hydrateEvents,
 } from './community/eventUtils'
 import DynamicMetaTags from './components/seo/DynamicMetaTags'
+import { getStaticRouteMeta } from './components/seo/staticRouteMetaExports'
 
 const VIEW_STORAGE_KEY = 'northside-community-view'
 const monthFormatter = new Intl.DateTimeFormat('en-CA', {
@@ -148,6 +149,7 @@ export default function CommunityPage() {
   const structuredData = React.useMemo(() => getStructuredData(filteredEvents), [filteredEvents])
 
   const pageDescription =
+    COMMUNITY_ROUTE_META.description ||
     'Always-updated guide to NorthSide GTA events across Aurora, Uxbridge, Georgina, Stouffville, East Gwillimbury, Newmarket and Scugog.'
 
   const parseHashSlug = React.useCallback(() => {
@@ -254,15 +256,7 @@ export default function CommunityPage() {
 
   return (
     <>
-      <DynamicMetaTags
-        route="/community"
-        documentTitle="NorthSide GTA Events | What's On Across Aurora, Uxbridge & Beyond"
-        title="NorthSide GTA Events | What's On Across Aurora, Uxbridge & Beyond"
-        description={pageDescription}
-        canonicalUrl="https://www.northsidegta.ca/community"
-        ogType="website"
-        ogImage="/Images/hero-desktop.jpg"
-      >
+      <DynamicMetaTags {...COMMUNITY_ROUTE_META} description={pageDescription}>
         {structuredData && (
           <script type="application/ld+json">{structuredData}</script>
         )}
@@ -456,3 +450,5 @@ export default function CommunityPage() {
     </>
   )
 }
+const COMMUNITY_ROUTE_META = getStaticRouteMeta('/community') || {}
+

--- a/src/ContactPage.js
+++ b/src/ContactPage.js
@@ -55,7 +55,7 @@ function ContactPageV2() {
         documentTitle={config.seoTitle}
         title={config.seoTitle}
         description={config.seoDescription}
-        canonicalUrl="https://www.northsidegta.ca/contact"
+        canonicalUrl="https://northsidegta.ca/contact"
         ogType="website"
         ogImage={config.seoImage || undefined}
         twitterCard="summary_large_image"

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -8,6 +8,9 @@ import DidYouKnowCard from "./components/DidYouKnowCard";
 import { didYouKnowFacts } from "./components/DidYouKnowData";
 import { CANONICAL_TESTIMONIALS } from "./data/testimonials";
 import DynamicMetaTags from "./components/seo/DynamicMetaTags";
+import { getStaticRouteMeta } from "./components/seo/staticRouteMetaExports";
+
+const HOME_ROUTE_META = getStaticRouteMeta("/") || {};
 
 const HOME_REVIEWS = CANONICAL_TESTIMONIALS.map((review) => ({
   id: review.id,
@@ -42,33 +45,13 @@ export default function HomePage() {
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
       <Navigation />
-      <DynamicMetaTags
-        route="/"
-        documentTitle="NorthSide GTA | Real Estate Agents for Buyers & Sellers"
-        title="NorthSide GTA | Real Estate Agents for Buyers & Sellers"
-        description="Find your perfect home or sell for more in the NorthSide GTA. Local experts serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
-        canonicalUrl="https://www.northsidegta.ca/"
-        ogType="website"
-        ogImage="https://www.northsidegta.ca/Images/og-home.jpg"
-        ogImageAlt="NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog"
-        twitterCard="summary_large_image"
-        twitterImage="https://www.northsidegta.ca/Images/og-home.jpg"
-        additionalMeta={[
-          {
-            name: "keywords",
-            content:
-              "NorthSide GTA real estate, homes for sale North GTA, sell my home, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog, Finally Home Agents",
-          },
-          { property: "og:image:width", content: "1200" },
-          { property: "og:image:height", content: "630" },
-        ]}
-      >
+      <DynamicMetaTags {...HOME_ROUTE_META}>
         <script type="application/ld+json">
           {JSON.stringify({
             "@context": "https://schema.org",
             "@type": "RealEstateAgent",
             name: "Finally Home Agents",
-            url: "https://www.northsidegta.ca/",
+            url: HOME_ROUTE_META.canonicalUrl || "https://northsidegta.ca/",
             areaServed: [
               "Georgina",
               "East Gwillimbury",
@@ -88,11 +71,11 @@ export default function HomePage() {
           {JSON.stringify({
             "@context": "https://schema.org",
             "@type": "WebSite",
-            name: "NorthSide GTA",
-            url: "https://www.northsidegta.ca/",
+            name: HOME_ROUTE_META.title || "NorthSide GTA",
+            url: HOME_ROUTE_META.canonicalUrl || "https://northsidegta.ca/",
             potentialAction: {
               "@type": "SearchAction",
-              target: "https://www.northsidegta.ca/search?q={query}",
+              target: `${(HOME_ROUTE_META.canonicalUrl || "https://northsidegta.ca/").replace(/\/$/, "")}/search?q={query}`,
               "query-input": "required name=query",
             },
           })}

--- a/src/InsightsPage.js
+++ b/src/InsightsPage.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import Navigation from "./Navigation";
 import Footer from "./Footer";
 import DynamicMetaTags from "./components/seo/DynamicMetaTags";
+import { getStaticRouteMeta } from "./components/seo/staticRouteMetaExports";
 
 const PAGE_SIZE = 12;
 
@@ -208,17 +209,7 @@ export default function InsightsPage() {
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
-      <DynamicMetaTags
-        route="/insights"
-        documentTitle="NorthSide GTA Insights — Stories, Market Updates & Local Highlights"
-        title="NorthSide GTA Insights — Stories, Market Updates & Local Highlights"
-        description="Discover the latest stories, market updates, and community insights from the NorthSide GTA. Learn what’s happening across Uxbridge, Stouffville, Georgina, East Gwillimbury, and beyond — powered by Finally Home Agents."
-        canonicalUrl="https://northsidegta.ca/insights"
-        ogType="website"
-        ogImage="https://northsidegta.ca/uploads/insights/northside-insights-hero.png"
-        twitterCard="summary_large_image"
-        twitterImage="https://northsidegta.ca/uploads/insights/northside-insights-hero.png"
-      />
+      <DynamicMetaTags {...INSIGHTS_ROUTE_META} />
 
       <Navigation />
 
@@ -281,3 +272,5 @@ export default function InsightsPage() {
     </div>
   );
 }
+const INSIGHTS_ROUTE_META = getStaticRouteMeta("/insights") || {};
+

--- a/src/MediaPage.js
+++ b/src/MediaPage.js
@@ -4,6 +4,7 @@ import Footer from "./Footer";
 import HeroPromo from "./components/socials/HeroPromo";
 import IgEmbedCard from "./components/socials/IgEmbedCard";
 import DynamicMetaTags from "./components/seo/DynamicMetaTags";
+import { getStaticRouteMeta } from "./components/seo/staticRouteMetaExports";
 
 function normalize(items = []) {
   const filtered = items.filter((item) => item && item.published !== false && item.url);
@@ -16,6 +17,8 @@ function normalize(items = []) {
     return bDate - aDate;
   });
 }
+
+const MEDIA_ROUTE_META = getStaticRouteMeta("/media") || {};
 
 export default function MediaPage() {
   const [settings, setSettings] = useState(null);
@@ -59,17 +62,7 @@ export default function MediaPage() {
 
   return (
     <>
-      <DynamicMetaTags
-        route="/media"
-        documentTitle="Videos + Reels — NorthSide GTA & Finally Home Agents"
-        title="Videos + Reels — NorthSide GTA & Finally Home Agents"
-        description="Watch our latest NorthSide GTA and Finally Home Agents videos and Instagram Reels — listings, community, and brand stories."
-        canonicalUrl="https://www.northsidegta.ca/media"
-        ogType="website"
-        ogImage="/uploads/hero-poster.jpg"
-        twitterCard="summary_large_image"
-        twitterImage="/uploads/hero-poster.jpg"
-      />
+      <DynamicMetaTags {...MEDIA_ROUTE_META} />
       <Navigation />
       <main className="relative min-h-screen bg-neutral-950 text-white">
         <div className="relative mx-auto max-w-6xl px-6 pt-12 pb-10">

--- a/src/SellersPage.js
+++ b/src/SellersPage.js
@@ -3,6 +3,7 @@ import Navigation from "./Navigation";
 import Footer from "./Footer";
 import Card from "./components/ui/Card";
 import DynamicMetaTags from "./components/seo/DynamicMetaTags";
+import { getStaticRouteMeta } from "./components/seo/staticRouteMetaExports";
 
 // ===== Helpers (reused) =====
 const emailOk = (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
@@ -888,36 +889,22 @@ function SellerMediaSection() {
   );
 }
 
+const SELLERS_ROUTE_META = getStaticRouteMeta("/sellers") || {};
+
 // ===== Page shell =====
 export default function SellersPage() {
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
       <Navigation />
-      <DynamicMetaTags
-        route="/sellers"
-        documentTitle="Sell Your Home for More in the NorthSide GTA | Strategy, Staging & Marketing"
-        title="Sell Your Home for More in the NorthSide GTA | Strategy, Staging & Marketing"
-        description="Thinking of selling in the NorthSide GTA? Get AI-backed pricing, pro staging, premium media, and negotiation that wins—serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog."
-        canonicalUrl="https://www.northsidegta.ca/sellers"
-        ogType="website"
-        ogImage="https://www.northsidegta.ca/Images/northsidegta-map-bg.jpg"
-        twitterCard="summary_large_image"
-        twitterImage="https://www.northsidegta.ca/Images/northsidegta-map-bg.jpg"
-        additionalMeta={[
-          { name: "robots", content: "index,follow" },
-          {
-            name: "keywords",
-            content:
-              "sell my home NorthSide GTA, list my home Georgina, list my home East Gwillimbury, sell house Newmarket, sell house Aurora, sell house Stouffville, sell house Uxbridge, sell house Scugog, home marketing, real estate agent",
-          },
-        ]}
-      >
+      <DynamicMetaTags {...SELLERS_ROUTE_META}>
         <script type="application/ld+json">
           {JSON.stringify({
             "@context": "https://schema.org",
             "@type": "WebPage",
-            name: "Sell Your Home for More in the NorthSide GTA | Strategy, Staging & Marketing",
-            url: "https://www.northsidegta.ca/sellers",
+            name:
+              SELLERS_ROUTE_META.title ||
+              "Sell Your Home for More in the NorthSide GTA | Strategy, Staging & Marketing",
+            url: SELLERS_ROUTE_META.canonicalUrl || "https://northsidegta.ca/sellers",
             description:
               "Full-service selling strategy with AI pricing, pro staging, premium media, and expert negotiation.",
             about: {
@@ -932,7 +919,7 @@ export default function SellersPage() {
                 "Uxbridge",
                 "Scugog",
               ],
-              url: "https://www.northsidegta.ca",
+              url: "https://northsidegta.ca",
               brand: "Finally Home Agents",
             },
           })}

--- a/src/components/seo/GlobalDefaultMeta.js
+++ b/src/components/seo/GlobalDefaultMeta.js
@@ -1,36 +1,12 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
 
-import {
-  DEFAULT_META_IMAGE_PATH,
-  SITE_BASE_URL,
-  getMetaTagsFromData,
-} from "./metaTagUtils";
+import { getMetaTagsFromData } from "./metaTagUtils";
 import renderHelmetTag from "./renderHelmetTag";
-
-const DEFAULT_TITLE = "NorthSide GTA | Real Estate Agents for Buyers & Sellers";
-const DEFAULT_DESCRIPTION =
-  "Find your perfect home or sell for more in the NorthSide GTA. Local experts serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.";
-const DEFAULT_IMAGE_ALT =
-  "NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog";
-
-const DEFAULT_META_CONFIG = {
-  route: "/",
-  documentTitle: DEFAULT_TITLE,
-  title: DEFAULT_TITLE,
-  description: DEFAULT_DESCRIPTION,
-  canonicalUrl: `${SITE_BASE_URL}/`,
-  ogType: "website",
-  ogImage: DEFAULT_META_IMAGE_PATH,
-  ogImageAlt: DEFAULT_IMAGE_ALT,
-  twitterCard: "summary_large_image",
-  twitterImage: DEFAULT_META_IMAGE_PATH,
-  twitterImageAlt: DEFAULT_IMAGE_ALT,
-  siteName: "NorthSide GTA",
-};
+import { DEFAULT_GLOBAL_META_CONFIG } from "./staticRouteMetaExports";
 
 export default function GlobalDefaultMeta() {
-  const meta = getMetaTagsFromData(DEFAULT_META_CONFIG);
+  const meta = getMetaTagsFromData(DEFAULT_GLOBAL_META_CONFIG);
   const tags = meta && Array.isArray(meta.tags) ? meta.tags : [];
 
   if (tags.length === 0) {

--- a/src/components/seo/staticRouteMetaConfigs.js
+++ b/src/components/seo/staticRouteMetaConfigs.js
@@ -1,0 +1,210 @@
+const DEFAULT_GLOBAL_META_CONFIG = {
+  route: "/",
+  documentTitle: "NorthSide GTA | Real Estate Agents for Buyers & Sellers",
+  title: "NorthSide GTA | Real Estate Agents for Buyers & Sellers",
+  description:
+    "Find your perfect home or sell for more in the NorthSide GTA. Local experts serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.",
+  canonicalUrl: "https://northsidegta.ca/",
+  ogType: "website",
+  ogImage: "/Images/og-home.jpg",
+  ogImageAlt:
+    "NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog",
+  twitterCard: "summary_large_image",
+  twitterImage: "/Images/og-home.jpg",
+  twitterImageAlt:
+    "NorthSide GTA Map showing towns: Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog",
+  siteName: "NorthSide GTA",
+  additionalMeta: [
+    {
+      name: "keywords",
+      content:
+        "NorthSide GTA, real estate, homes for sale North GTA, sell my home, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog",
+    },
+  ],
+};
+
+const STATIC_ROUTE_META_CONFIGS = [
+  {
+    route: "/",
+    meta: {
+      ...DEFAULT_GLOBAL_META_CONFIG,
+      additionalMeta: [
+        ...DEFAULT_GLOBAL_META_CONFIG.additionalMeta,
+        { property: "og:image:width", content: "1200" },
+        { property: "og:image:height", content: "630" },
+      ],
+    },
+  },
+  {
+    route: "/buyers",
+    meta: {
+      route: "/buyers",
+      documentTitle: "Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents",
+      title: "Buy a Home in the NorthSide GTA | Town Match, VIP Alerts & Expert Agents",
+      description:
+        "Ready to buy in the NorthSide GTA? Get a personalized town match, VIP listing alerts, and expert guidance from Finally Home Agents in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.",
+      canonicalUrl: "https://northsidegta.ca/buyers",
+      ogType: "website",
+      ogImage: "https://northsidegta.ca/uploads/buyers-page-seo.jpg",
+      twitterCard: "summary_large_image",
+      twitterImage: "https://northsidegta.ca/uploads/buyers-page-seo.jpg",
+      siteName: "NorthSide GTA",
+      additionalMeta: [
+        { name: "robots", content: "index,follow" },
+        {
+          name: "keywords",
+          content:
+            "NorthSide GTA homes for sale, buy a home Georgina, buy a home East Gwillimbury, buy a home Newmarket, buy a home Aurora, buy a home Stouffville, buy a home Uxbridge, buy a home Scugog, town match, VIP listing alerts, Finally Home Agents",
+        },
+      ],
+    },
+  },
+  {
+    route: "/sellers",
+    meta: {
+      route: "/sellers",
+      documentTitle: "Sell Your Home for More in the NorthSide GTA | Strategy, Staging & Marketing",
+      title: "Sell Your Home for More in the NorthSide GTA | Strategy, Staging & Marketing",
+      description:
+        "Thinking of selling in the NorthSide GTA? Get AI-backed pricing, pro staging, premium media, and negotiation that wins—serving Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.",
+      canonicalUrl: "https://northsidegta.ca/sellers",
+      ogType: "website",
+      ogImage: "https://northsidegta.ca/Images/northsidegta-map-bg.jpg",
+      twitterCard: "summary_large_image",
+      twitterImage: "https://northsidegta.ca/Images/northsidegta-map-bg.jpg",
+      siteName: "NorthSide GTA",
+      additionalMeta: [
+        { name: "robots", content: "index,follow" },
+        {
+          name: "keywords",
+          content:
+            "sell my home NorthSide GTA, list my home Georgina, list my home East Gwillimbury, sell house Newmarket, sell house Aurora, sell house Stouffville, sell house Uxbridge, sell house Scugog, home marketing, real estate agent",
+        },
+      ],
+    },
+  },
+  {
+    route: "/community",
+    meta: {
+      route: "/community",
+      documentTitle: "NorthSide GTA Events | What's On Across Aurora, Uxbridge & Beyond",
+      title: "NorthSide GTA Events | What's On Across Aurora, Uxbridge & Beyond",
+      description:
+        "Always-updated guide to NorthSide GTA events across Aurora, Uxbridge, Georgina, Stouffville, East Gwillimbury, Newmarket and Scugog.",
+      canonicalUrl: "https://northsidegta.ca/community",
+      ogType: "website",
+      ogImage: "/Images/hero-desktop.jpg",
+      twitterCard: "summary_large_image",
+      twitterImage: "/Images/hero-desktop.jpg",
+      siteName: "NorthSide GTA",
+    },
+  },
+  {
+    route: "/community/events",
+    meta: {
+      route: "/community/events",
+      documentTitle: "NorthSide GTA Events | What's On Across Aurora, Uxbridge & Beyond",
+      title: "NorthSide GTA Events | What's On Across Aurora, Uxbridge & Beyond",
+      description:
+        "Always-updated guide to NorthSide GTA events across Aurora, Uxbridge, Georgina, Stouffville, East Gwillimbury, Newmarket and Scugog.",
+      canonicalUrl: "https://northsidegta.ca/community/events",
+      ogType: "website",
+      ogImage: "/Images/hero-desktop.jpg",
+      twitterCard: "summary_large_image",
+      twitterImage: "/Images/hero-desktop.jpg",
+      siteName: "NorthSide GTA",
+    },
+  },
+  {
+    route: "/media",
+    meta: {
+      route: "/media",
+      documentTitle: "Videos + Reels — NorthSide GTA & Finally Home Agents",
+      title: "Videos + Reels — NorthSide GTA & Finally Home Agents",
+      description:
+        "Watch our latest NorthSide GTA and Finally Home Agents videos and Instagram Reels — listings, community, and brand stories.",
+      canonicalUrl: "https://northsidegta.ca/media",
+      ogType: "website",
+      ogImage: "/uploads/hero-poster.jpg",
+      twitterCard: "summary_large_image",
+      twitterImage: "/uploads/hero-poster.jpg",
+      siteName: "NorthSide GTA",
+    },
+  },
+  {
+    route: "/about",
+    meta: {
+      route: "/about",
+      documentTitle: "About Finally Home Agents | Local NorthSide GTA Realtors®",
+      title: "About Finally Home Agents | Local NorthSide GTA Realtors®",
+      description:
+        "We’re a local, relationship-first real estate team serving the NorthSide GTA—Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog.",
+      canonicalUrl: "https://northsidegta.ca/about",
+      ogType: "profile",
+      ogImage: "/Images/northsidegta-map-bg.jpg",
+      twitterCard: "summary_large_image",
+      twitterImage: "/Images/northsidegta-map-bg.jpg",
+      siteName: "NorthSide GTA",
+      additionalMeta: [
+        {
+          name: "keywords",
+          content:
+            "about Finally Home Agents, NorthSide GTA realtors, local real estate team, Newmarket, Aurora, Uxbridge",
+        },
+      ],
+    },
+  },
+  {
+    route: "/contact",
+    meta: {
+      route: "/contact",
+      documentTitle: "Contact Finally Home Agents | NorthSide GTA Real Estate Experts",
+      title: "Contact Finally Home Agents | NorthSide GTA Real Estate Experts",
+      description:
+        "Talk to NorthSide GTA real estate experts for buying and selling guidance across Uxbridge, Georgina, Scugog, Stouffville, East Gwillimbury, and Newmarket.",
+      canonicalUrl: "https://northsidegta.ca/contact",
+      ogType: "website",
+      ogImage: "/Images/northsidegta-map-bg.jpg",
+      twitterCard: "summary_large_image",
+      twitterImage: "/Images/northsidegta-map-bg.jpg",
+      siteName: "NorthSide GTA",
+    },
+  },
+  {
+    route: "/insights",
+    meta: {
+      route: "/insights",
+      documentTitle: "NorthSide GTA Insights — Stories, Market Updates & Local Highlights",
+      title: "NorthSide GTA Insights — Stories, Market Updates & Local Highlights",
+      description:
+        "Discover the latest stories, market updates, and community insights from the NorthSide GTA. Learn what’s happening across Uxbridge, Stouffville, Georgina, East Gwillimbury, and beyond — powered by Finally Home Agents.",
+      canonicalUrl: "https://northsidegta.ca/insights",
+      ogType: "website",
+      ogImage: "https://northsidegta.ca/uploads/insights/northside-insights-hero.png",
+      twitterCard: "summary_large_image",
+      twitterImage: "https://northsidegta.ca/uploads/insights/northside-insights-hero.png",
+      siteName: "NorthSide GTA",
+    },
+  },
+];
+
+function cloneMeta(meta = {}) {
+  return JSON.parse(JSON.stringify(meta));
+}
+
+function getStaticRouteMeta(route) {
+  if (!route) return null;
+  const normalized = route === "/" ? "/" : `/${route.replace(/^\//, "")}`;
+  const entry = STATIC_ROUTE_META_CONFIGS.find((item) => item.route === normalized);
+  if (!entry) return null;
+  return cloneMeta(entry.meta);
+}
+
+module.exports = {
+  DEFAULT_GLOBAL_META_CONFIG: cloneMeta(DEFAULT_GLOBAL_META_CONFIG),
+  STATIC_ROUTE_META_CONFIGS: STATIC_ROUTE_META_CONFIGS.map((item) => ({
+    route: item.route,
+    meta: cloneMeta(item.meta),
+  })),
+  getStaticRouteMeta,
+};

--- a/src/components/seo/staticRouteMetaExports.js
+++ b/src/components/seo/staticRouteMetaExports.js
@@ -1,0 +1,9 @@
+const metaConfigs = require("./staticRouteMetaConfigs");
+
+const {
+  DEFAULT_GLOBAL_META_CONFIG,
+  STATIC_ROUTE_META_CONFIGS,
+  getStaticRouteMeta,
+} = metaConfigs || {};
+
+export { DEFAULT_GLOBAL_META_CONFIG, STATIC_ROUTE_META_CONFIGS, getStaticRouteMeta };


### PR DESCRIPTION
## Summary
- add a build-time generator that injects prerendered head tags for top-level marketing routes
- centralize reusable meta configurations for global defaults and static routes and wire pages to use them
- update contact canonical URL to the non-www domain used elsewhere

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6151215c8324a14af8540bbdee88)