### PR TITLE
Fix static route meta module to restore runtime rendering

### DIFF
--- a/scripts/generate-static-route-html.js
+++ b/scripts/generate-static-route-html.js
@@ -11,12 +11,12 @@ const {
   finalizeHtml,
 } = require("./utils/staticMeta");
 const { getMetaTagsFromData } = require("../src/components/seo/metaTagUtils.js");
-const {
-  DEFAULT_GLOBAL_META_CONFIG,
-  STATIC_ROUTE_META_CONFIGS,
-} = require("../src/components/seo/staticRouteMetaConfigs.js");
+async function main() {
+  const {
+    DEFAULT_GLOBAL_META_CONFIG,
+    STATIC_ROUTE_META_CONFIGS,
+  } = await import("../src/components/seo/staticRouteMetaConfigs.mjs");
 
-function main() {
   const template = loadTemplate();
   if (!template) {
     console.warn("[generate-static-route-html] Skipping — unable to locate HTML template");
@@ -178,4 +178,7 @@ function getOutputPath(root, route) {
   return path.join(root, normalized, "index.html");
 }
 
-main();
+main().catch((error) => {
+  console.error("[generate-static-route-html] Failed:", error);
+  process.exitCode = 1;
+});

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -192,7 +192,7 @@ function cloneMeta(meta = {}) {
   return JSON.parse(JSON.stringify(meta));
 }
 
-function getStaticRouteMeta(route) {
+export function getStaticRouteMeta(route) {
   if (!route) return null;
   const normalized = route === "/" ? "/" : `/${route.replace(/^\//, "")}`;
   const entry = STATIC_ROUTE_META_CONFIGS.find((item) => item.route === normalized);
@@ -200,11 +200,16 @@ function getStaticRouteMeta(route) {
   return cloneMeta(entry.meta);
 }
 
-module.exports = {
-  DEFAULT_GLOBAL_META_CONFIG: cloneMeta(DEFAULT_GLOBAL_META_CONFIG),
-  STATIC_ROUTE_META_CONFIGS: STATIC_ROUTE_META_CONFIGS.map((item) => ({
-    route: item.route,
-    meta: cloneMeta(item.meta),
-  })),
+const CLONED_DEFAULT_GLOBAL_META_CONFIG = cloneMeta(DEFAULT_GLOBAL_META_CONFIG);
+const CLONED_STATIC_ROUTE_META_CONFIGS = STATIC_ROUTE_META_CONFIGS.map((item) => ({
+  route: item.route,
+  meta: cloneMeta(item.meta),
+}));
+
+export { CLONED_DEFAULT_GLOBAL_META_CONFIG as DEFAULT_GLOBAL_META_CONFIG, CLONED_STATIC_ROUTE_META_CONFIGS as STATIC_ROUTE_META_CONFIGS };
+
+export default {
+  DEFAULT_GLOBAL_META_CONFIG: CLONED_DEFAULT_GLOBAL_META_CONFIG,
+  STATIC_ROUTE_META_CONFIGS: CLONED_STATIC_ROUTE_META_CONFIGS,
   getStaticRouteMeta,
 };

--- a/src/components/seo/staticRouteMetaExports.js
+++ b/src/components/seo/staticRouteMetaExports.js
@@ -1,9 +1,5 @@
-const metaConfigs = require("./staticRouteMetaConfigs");
-
-const {
+export {
   DEFAULT_GLOBAL_META_CONFIG,
   STATIC_ROUTE_META_CONFIGS,
   getStaticRouteMeta,
-} = metaConfigs || {};
-
-export { DEFAULT_GLOBAL_META_CONFIG, STATIC_ROUTE_META_CONFIGS, getStaticRouteMeta };
+} from "./staticRouteMetaConfigs.mjs";


### PR DESCRIPTION
## Summary
- convert the static route SEO configuration module to an ES module so it can be safely loaded in the browser build
- update the static route export helper and static HTML generator to consume the new module without triggering CommonJS assignment errors

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e73c9763c83248559f82ae3673c45)