### PR TITLE
Normalize social SEO metadata pipeline

### DIFF
--- a/src/components/seo/DynamicMetaTags.js
+++ b/src/components/seo/DynamicMetaTags.js
@@ -3,6 +3,8 @@ import { Helmet } from "react-helmet-async";
 
 import {
   SITE_BASE_URL,
+  SOCIAL_IMAGE_HEIGHT,
+  SOCIAL_IMAGE_WIDTH,
   getMetaTagsFromData,
   SOCIAL_META_KEYS,
 } from "./metaTagUtils";
@@ -26,8 +28,8 @@ export default function DynamicMetaTags(props) {
 
   const tags = Array.isArray(meta.tags) ? meta.tags : [];
   const metaValues = meta.values || {};
-  const socialImageContent = resolveSocialImageContent(metaValues);
-  const tagsWithSocialImages = ensureSocialImageTags(tags, socialImageContent);
+  const socialImage = resolveSocialImageContent(metaValues);
+  const tagsWithSocialImages = ensureSocialImageTags(tags, socialImage);
   const hasSiteSeoOverrides = Boolean(meta.flags && meta.flags.hasSiteSeoOverrides);
   const filteredChildren = filterMetaChildren(children, hasSiteSeoOverrides);
 
@@ -75,14 +77,20 @@ function safeMetaKey(value) {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
-function ensureSocialImageTags(tags, socialImageContent) {
-  if (!socialImageContent) {
+function ensureSocialImageTags(tags, socialImage) {
+  if (!socialImage || !socialImage.url) {
     return tags.slice();
   }
 
   const next = [];
   let hasOgImage = false;
   let hasTwitterImage = false;
+  let hasOgImageWidth = false;
+  let hasOgImageHeight = false;
+
+  const imageUrl = socialImage.url;
+  const imageWidth = safeString(socialImage.width) || SOCIAL_IMAGE_WIDTH;
+  const imageHeight = safeString(socialImage.height) || SOCIAL_IMAGE_HEIGHT;
 
   for (const tag of tags) {
     if (!tag || tag.type !== "meta") {
@@ -95,7 +103,25 @@ function ensureSocialImageTags(tags, socialImageContent) {
       hasOgImage = true;
       next.push({
         ...tag,
-        attributes: { ...attributes, content: socialImageContent },
+        attributes: { ...attributes, content: imageUrl },
+      });
+      continue;
+    }
+
+    if (attributes.property === "og:image:width") {
+      hasOgImageWidth = true;
+      next.push({
+        ...tag,
+        attributes: { ...attributes, content: imageWidth },
+      });
+      continue;
+    }
+
+    if (attributes.property === "og:image:height") {
+      hasOgImageHeight = true;
+      next.push({
+        ...tag,
+        attributes: { ...attributes, content: imageHeight },
       });
       continue;
     }
@@ -104,7 +130,7 @@ function ensureSocialImageTags(tags, socialImageContent) {
       hasTwitterImage = true;
       next.push({
         ...tag,
-        attributes: { ...attributes, content: socialImageContent },
+        attributes: { ...attributes, content: imageUrl },
       });
       continue;
     }
@@ -118,7 +144,29 @@ function ensureSocialImageTags(tags, socialImageContent) {
       key: "meta:og:image",
       attributes: {
         property: "og:image",
-        content: socialImageContent,
+        content: imageUrl,
+      },
+    });
+  }
+
+  if (!hasOgImageWidth) {
+    next.push({
+      type: "meta",
+      key: "meta:og:image:width",
+      attributes: {
+        property: "og:image:width",
+        content: imageWidth,
+      },
+    });
+  }
+
+  if (!hasOgImageHeight) {
+    next.push({
+      type: "meta",
+      key: "meta:og:image:height",
+      attributes: {
+        property: "og:image:height",
+        content: imageHeight,
       },
     });
   }
@@ -129,7 +177,7 @@ function ensureSocialImageTags(tags, socialImageContent) {
       key: "meta:twitter:image",
       attributes: {
         name: "twitter:image",
-        content: socialImageContent,
+        content: imageUrl,
       },
     });
   }
@@ -138,11 +186,28 @@ function ensureSocialImageTags(tags, socialImageContent) {
 }
 
 function resolveSocialImageContent(values = {}) {
-  const path = safeString(values.metaImagePath);
-  if (path) {
-    return `${SITE_BASE_URL}${path}`;
+  const absoluteUrl = safeString(values.metaImage);
+  let resolvedUrl = absoluteUrl;
+
+  if (!resolvedUrl) {
+    const path = safeString(values.metaImagePath);
+    if (path) {
+      resolvedUrl = `${SITE_BASE_URL}${path}`;
+    }
   }
-  return safeString(values.metaImage);
+
+  if (!resolvedUrl) {
+    return null;
+  }
+
+  const width = safeString(values.metaImageWidth) || SOCIAL_IMAGE_WIDTH;
+  const height = safeString(values.metaImageHeight) || SOCIAL_IMAGE_HEIGHT;
+
+  return {
+    url: resolvedUrl,
+    width,
+    height,
+  };
 }
 
 function safeString(value) {

--- a/src/components/seo/metaTagUtils.js
+++ b/src/components/seo/metaTagUtils.js
@@ -3,6 +3,8 @@ const { getSiteSeoForRoute } = require("./siteSeoConfig");
 const SITE_BASE_URL = "https://northsidegta.ca";
 const DEFAULT_META_IMAGE_PATH = "/Images/og-home.jpg";
 const DEFAULT_TWITTER_CARD = "summary_large_image";
+const SOCIAL_IMAGE_WIDTH = "1200";
+const SOCIAL_IMAGE_HEIGHT = "630";
 
 const SOCIAL_META_KEYS = [
   "property:og:type",
@@ -10,6 +12,8 @@ const SOCIAL_META_KEYS = [
   "property:og:description",
   "property:og:url",
   "property:og:image",
+  "property:og:image:width",
+  "property:og:image:height",
   "property:og:image:alt",
   "property:og:site_name",
   "name:twitter:card",
@@ -101,59 +105,57 @@ function buildAbsoluteUrl(value) {
 
 function normalizeMetaImage(siteSeoImage, raw = {}) {
   const candidates = [
-    safeString(siteSeoImage),
-    safeString(raw.ogImage),
-    safeString(raw.image),
-    safeString(raw.twitterImage),
+    siteSeoImage,
+    raw.ogImage,
+    raw.image,
+    raw.twitterImage,
+    raw.metaImage,
+    raw.metaImagePath,
     DEFAULT_META_IMAGE_PATH,
   ];
 
-  let chosen = "";
+  let resolvedPath = "";
+
   for (const candidate of candidates) {
-    if (candidate) {
-      chosen = candidate;
+    const normalized = normalizeImageCandidate(candidate);
+    if (normalized) {
+      resolvedPath = normalized;
       break;
     }
   }
 
-  let absoluteUrl = "";
-  let path = "";
-
-  if (chosen) {
-    if (isAbsoluteUrl(chosen)) {
-      absoluteUrl = chosen;
-      if (absoluteUrl.startsWith(`${SITE_BASE_URL}`)) {
-        try {
-          const url = new URL(absoluteUrl);
-          path = `${url.pathname}${url.search}${url.hash}`.replace(/[#?]$/, "");
-        } catch (error) {
-          path = "";
-        }
-      }
-    } else if (chosen.startsWith("//")) {
-      absoluteUrl = `https:${chosen}`;
-    } else {
-      path = ensureLeadingSlash(chosen);
-      absoluteUrl = `${SITE_BASE_URL}${path}`;
-    }
+  if (!resolvedPath) {
+    resolvedPath = ensureLeadingSlash(DEFAULT_META_IMAGE_PATH);
   }
 
-  if (!absoluteUrl) {
-    path = ensureLeadingSlash(DEFAULT_META_IMAGE_PATH);
-    absoluteUrl = `${SITE_BASE_URL}${path}`;
-  } else if (!path && absoluteUrl.startsWith(`${SITE_BASE_URL}`)) {
-    try {
-      const url = new URL(absoluteUrl);
-      path = `${url.pathname}${url.search}${url.hash}`.replace(/[#?]$/, "");
-    } catch (error) {
-      path = ensureLeadingSlash(DEFAULT_META_IMAGE_PATH);
-    }
-  }
+  const absoluteUrl = buildAbsoluteUrl(resolvedPath);
 
   return {
-    path,
+    path: resolvedPath,
     absoluteUrl,
   };
+}
+
+function normalizeImageCandidate(candidate) {
+  const value = safeString(candidate);
+  if (!value) return "";
+
+  if (value.startsWith("//")) {
+    return normalizeImageCandidate(`https:${value}`);
+  }
+
+  if (isAbsoluteUrl(value)) {
+    try {
+      const url = new URL(value);
+      const combined = `${url.pathname}${url.search}${url.hash}`.replace(/[#?]$/, "");
+      const path = combined || url.pathname || "";
+      return ensureLeadingSlash(path);
+    } catch (error) {
+      return "";
+    }
+  }
+
+  return ensureLeadingSlash(value);
 }
 
 function normalizeAdditionalMeta(additionalMeta) {
@@ -284,6 +286,18 @@ function getMetaTagsFromData(raw = {}) {
       type: "meta",
       key: "meta:og:image",
       attributes: { property: "og:image", content: ogImageValue },
+    });
+
+    tags.push({
+      type: "meta",
+      key: "meta:og:image:width",
+      attributes: { property: "og:image:width", content: SOCIAL_IMAGE_WIDTH },
+    });
+
+    tags.push({
+      type: "meta",
+      key: "meta:og:image:height",
+      attributes: { property: "og:image:height", content: SOCIAL_IMAGE_HEIGHT },
     });
   }
 
@@ -418,6 +432,8 @@ function getMetaTagsFromData(raw = {}) {
       ogImage: ogImageValue,
       metaImagePath,
       metaImage: resolvedMetaImageUrl,
+      metaImageWidth: ogImageValue ? SOCIAL_IMAGE_WIDTH : "",
+      metaImageHeight: ogImageValue ? SOCIAL_IMAGE_HEIGHT : "",
       ogImageAlt: ogImageAltValue,
       twitterCard: twitterCardValue,
       twitterImage: twitterImageValue,
@@ -484,6 +500,8 @@ module.exports = {
   DEFAULT_META_IMAGE_PATH,
   DEFAULT_TWITTER_CARD,
   SITE_BASE_URL,
+  SOCIAL_IMAGE_WIDTH,
+  SOCIAL_IMAGE_HEIGHT,
   SOCIAL_META_KEYS,
   buildAbsoluteUrl,
   getMetaTagsFromData,


### PR DESCRIPTION
## Summary
- normalize the social image resolver to always choose the correct asset and emit absolute URLs with default dimensions
- ensure DynamicMetaTags injects a single og/twitter image block with matching width and height metadata

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e7c91ee448324a1675af5c3793209)