### PR TITLE
Align site greens with NorthSide GTA brand palette

### DIFF
--- a/public/images/placeholder-insight-hero.svg
+++ b/public/images/placeholder-insight-hero.svg
@@ -1,5 +1,5 @@
 <svg width="1920" height="1080" viewBox="0 0 1920 1080" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="1920" height="1080" fill="#022c22"/>
+  <rect width="1920" height="1080" fill="#22440A"/>
   <g opacity="0.6">
     <circle cx="350" cy="260" r="380" fill="url(#paint0_radial)"/>
     <circle cx="1660" cy="840" r="420" fill="url(#paint1_radial)"/>
@@ -8,16 +8,16 @@
   <rect x="0" y="0" width="1920" height="1080" fill="url(#paint3_linear)" opacity="0.55"/>
   <defs>
     <radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(350 260) rotate(90) scale(380)">
-      <stop stop-color="#34d399"/>
-      <stop offset="1" stop-color="#0f766e" stop-opacity="0"/>
+      <stop stop-color="#32610E"/>
+      <stop offset="1" stop-color="#22440A" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1660 840) rotate(90) scale(420)">
-      <stop stop-color="#22d3ee"/>
-      <stop offset="1" stop-color="#0ea5e9" stop-opacity="0"/>
+      <stop stop-color="#32610E"/>
+      <stop offset="1" stop-color="#22440A" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="paint2_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1320 220) rotate(90) scale(300)">
-      <stop stop-color="#a7f3d0"/>
-      <stop offset="1" stop-color="#10b981" stop-opacity="0"/>
+      <stop stop-color="#6F9940"/>
+      <stop offset="1" stop-color="#32610E" stop-opacity="0"/>
     </radialGradient>
     <linearGradient id="paint3_linear" x1="960" y1="0" x2="960" y2="1080" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#04110c" stop-opacity="0"/>

--- a/src/AboutPage.js
+++ b/src/AboutPage.js
@@ -64,7 +64,7 @@ export default function AboutPage() {
         {/* ───────── Hero Figure ───────── */}
         <section className="px-4">
           <div className="mx-auto w-full max-w-6xl space-y-12">
-            <figure className="relative overflow-hidden rounded-[36px] border border-emerald-100 bg-white/90 shadow-[0_40px_110px_rgba(16,185,129,0.18)]">
+            <figure className="relative overflow-hidden rounded-[36px] border border-emerald-100 bg-white/90 shadow-[0_40px_110px_rgba(50,97,14,0.18)]">
               <img
                 src="/uploads/about-hero-finally-home-agents.jpg"
                 alt="Matthew and Landon Mulhall of Finally Home Agents standing on a stylized landscape background at sunset, representing their NorthSide GTA real estate approach."
@@ -129,7 +129,7 @@ export default function AboutPage() {
 
         {/* ───────── Trophy Case ───────── */}
         <section className="px-4 pt-14">
-          <div className="relative mx-auto w-full max-w-6xl overflow-hidden rounded-[36px] border border-emerald-100 bg-gradient-to-br from-white via-emerald-50 to-emerald-100/70 p-[1.5px] shadow-[0_45px_120px_rgba(16,185,129,0.2)]">
+          <div className="relative mx-auto w-full max-w-6xl overflow-hidden rounded-[36px] border border-emerald-100 bg-gradient-to-br from-white via-emerald-50 to-emerald-100/70 p-[1.5px] shadow-[0_45px_120px_rgba(50,97,14,0.2)]">
             <div className="rounded-[34px] bg-white/80 px-6 py-12 backdrop-blur sm:px-12">
               <div className="space-y-4 text-center md:text-left">
                 <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-600">
@@ -146,7 +146,7 @@ export default function AboutPage() {
                 {trophyHighlights.map(({ icon: Icon, title, description }) => (
                   <div
                     key={title}
-                    className="relative flex h-full flex-col gap-5 rounded-[30px] border border-emerald-100 bg-white/90 p-6 shadow-xl shadow-emerald-100/60 transition duration-200 hover:-translate-y-1 hover:shadow-[0_28px_60px_rgba(16,185,129,0.25)]"
+                    className="relative flex h-full flex-col gap-5 rounded-[30px] border border-emerald-100 bg-white/90 p-6 shadow-xl shadow-emerald-100/60 transition duration-200 hover:-translate-y-1 hover:shadow-[0_28px_60px_rgba(50,97,14,0.25)]"
                   >
                     <span className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-emerald-100 to-emerald-200 text-emerald-700 shadow-inner">
                       <Icon className="h-6 w-6" />
@@ -211,7 +211,7 @@ export default function AboutPage() {
 
         {/* ───────── CTA Footer ───────── */}
         <section className="relative mt-16 overflow-hidden rounded-[36px] px-4">
-          <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-6 rounded-[32px] border border-emerald-200 bg-gradient-to-r from-emerald-500 via-emerald-600 to-emerald-700 px-6 py-16 text-center text-white shadow-[0_35px_90px_rgba(16,185,129,0.45)]">
+          <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-6 rounded-[32px] border border-emerald-200 bg-gradient-to-r from-emerald-500 via-emerald-600 to-emerald-700 px-6 py-16 text-center text-white shadow-[0_35px_90px_rgba(50,97,14,0.45)]">
             <h2 className="text-3xl font-semibold sm:text-4xl">
               Ready to make your move?
             </h2>

--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -71,7 +71,7 @@ function ComparisonGrid() {
     "AI-assisted insights tailored to your criteria",
   ];
   return (
-    <div className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/5 shadow-[0_45px_130px_rgba(4,47,35,0.5)]">
+    <div className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/5 shadow-[0_45px_130px_rgba(34,68,10,0.5)]">
       <div className="absolute inset-0 bg-gradient-to-br from-emerald-400/15 via-emerald-500/10 to-emerald-700/5" aria-hidden />
       <div className="relative z-10 grid overflow-hidden md:grid-cols-2">
         {/* Left: On your own */}
@@ -270,8 +270,8 @@ function BuyerSignupForm() {
 
   if (done) {
     return (
-      <div className="relative overflow-hidden rounded-[36px] border border-white/15 bg-emerald-500/20 p-8 text-white shadow-[0_40px_120px_rgba(4,47,35,0.55)]">
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.4),_transparent_65%)]" aria-hidden />
+      <div className="relative overflow-hidden rounded-[36px] border border-white/15 bg-emerald-500/20 p-8 text-white shadow-[0_40px_120px_rgba(34,68,10,0.55)]">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(50,97,14,0.4),_transparent_65%)]" aria-hidden />
         <div className="relative z-10 flex flex-col gap-3 text-center sm:text-left">
           <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-center">
             <span className="flex h-11 w-11 items-center justify-center rounded-full border border-white/30 bg-white/20">
@@ -293,10 +293,10 @@ function BuyerSignupForm() {
   return (
     <div
       id="buyers-registration"
-      className="relative overflow-hidden rounded-[40px] bg-gradient-to-br from-emerald-400/50 via-emerald-500/35 to-emerald-600/45 p-[1.5px] shadow-[0_55px_140px_rgba(4,47,35,0.55)]"
+      className="relative overflow-hidden rounded-[40px] bg-gradient-to-br from-emerald-400/50 via-emerald-500/35 to-emerald-600/45 p-[1.5px] shadow-[0_55px_140px_rgba(34,68,10,0.55)]"
     >
       <div className="relative overflow-hidden rounded-[38px] border border-white/10 bg-slate-900/85 p-6 backdrop-blur-xl md:p-8">
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.28),_transparent_65%)]" aria-hidden />
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(50,97,14,0.28),_transparent_65%)]" aria-hidden />
         <div className="pointer-events-none absolute inset-0 opacity-30 mix-blend-screen" style={{ backgroundImage: "url('/Images/northside-map-grid.png')", backgroundSize: "cover" }} aria-hidden />
 
         <div className="relative z-10">
@@ -693,7 +693,7 @@ export default function BuyersPage() {
       </DynamicMetaTags>
 
       <main className="relative">
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.25),_transparent_65%)]" aria-hidden />
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(50,97,14,0.25),_transparent_65%)]" aria-hidden />
         <div className="pointer-events-none absolute -top-32 left-[-10%] h-[26rem] w-[26rem] rounded-full bg-emerald-400/20 blur-3xl" aria-hidden />
         <div className="pointer-events-none absolute bottom-[-40%] right-[-20%] h-[32rem] w-[32rem] rounded-full bg-emerald-300/20 blur-3xl" aria-hidden />
 
@@ -733,7 +733,7 @@ export default function BuyersPage() {
           </section>
 
           <section className="mt-20">
-            <div className="relative overflow-hidden rounded-[32px] border border-white/15 bg-gradient-to-br from-emerald-500 via-emerald-500/70 to-emerald-600 px-6 py-10 text-center shadow-[0_45px_130px_rgba(4,47,35,0.6)]">
+            <div className="relative overflow-hidden rounded-[32px] border border-white/15 bg-gradient-to-br from-emerald-500 via-emerald-500/70 to-emerald-600 px-6 py-10 text-center shadow-[0_45px_130px_rgba(34,68,10,0.6)]">
               <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.15),_transparent_70%)]" aria-hidden />
               <div className="relative z-10 space-y-4">
                 <h3 className="text-3xl font-semibold md:text-4xl">Don’t Leave Power on the Table</h3>

--- a/src/CommunityGrid.js
+++ b/src/CommunityGrid.js
@@ -40,7 +40,7 @@ export default function CommunityGrid() {
               <p className="text-sm text-gray-600">
                 Learn why {name} is a top choice for buyers moving north of Toronto.
               </p>
-              <button className="mt-4 text-green-700 font-semibold hover:underline">
+              <button className="mt-4 font-semibold text-brand-green hover:underline">
                 Explore {name}
               </button>
             </div>

--- a/src/CommunityPage.js
+++ b/src/CommunityPage.js
@@ -319,7 +319,7 @@ export default function CommunityPage() {
                   onClick={() => setView(option.value)}
                   className={`inline-flex items-center gap-2 rounded-full px-4 py-2 ${
                     view === option.value
-                      ? 'bg-emerald-600 text-white shadow-sm'
+                      ? 'bg-brand-green text-white shadow-sm hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus-visible:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2'
                       : 'text-slate-600 hover:text-slate-900'
                   }`}
                   aria-pressed={view === option.value}

--- a/src/ContactPage.js
+++ b/src/ContactPage.js
@@ -117,7 +117,7 @@ function ContactPageV2() {
                 </div>
               </div>
               <div className="relative flex w-full justify-center">
-                <div className="relative w-full max-w-4xl overflow-hidden rounded-[32px] border border-emerald-100 bg-white shadow-[0_32px_90px_rgba(16,185,129,0.18)] aspect-[4/3] sm:aspect-[5/4] md:aspect-[4/3]">
+                <div className="relative w-full max-w-4xl overflow-hidden rounded-[32px] border border-emerald-100 bg-white shadow-[0_32px_90px_rgba(50,97,14,0.18)] aspect-[4/3] sm:aspect-[5/4] md:aspect-[4/3]">
                   <img
                     src="/uploads/contact-hero-finally-home-agents.jpg"
                     alt="Clean desk scene with a smartphone, notebook, and NorthSide GTA and Finally Home Agents branding, representing how to contact the team."

--- a/src/HomeAnalysisPage.js
+++ b/src/HomeAnalysisPage.js
@@ -669,7 +669,7 @@ export default function HomeAnalysisPage() {
                 <div className="md:col-span-2 mt-2">
                   <button
                     disabled={!requiredOk || sending}
-                    className="w-full rounded-xl bg-emerald-600 px-4 py-3 text-white font-semibold hover:bg-emerald-700 disabled:opacity-50"
+                    className="w-full rounded-xl bg-brand-green px-4 py-3 font-semibold text-white transition-colors hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus-visible:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2 disabled:opacity-50"
                   >
                     {sending ? "Sending…" : "Get My Home Value"}
                   </button>
@@ -705,7 +705,7 @@ export default function HomeAnalysisPage() {
       <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-white p-3 md:hidden">
         <button
           form="homeanalysis-form"
-          className="w-full rounded-xl bg-emerald-600 px-4 py-3 text-white font-semibold"
+          className="w-full rounded-xl bg-brand-green px-4 py-3 font-semibold text-white transition-colors hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus-visible:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2 disabled:opacity-50"
           disabled={!requiredOk || sending}
         >
           {sending ? "Sending…" : "Get My Home Value"}

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -97,14 +97,14 @@ function HomeHero() {
   return (
     <section className="relative overflow-hidden bg-[#04110c] text-white">
       <div className="absolute inset-0 bg-gradient-to-br from-emerald-950 via-emerald-900 to-emerald-700" aria-hidden />
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.4),_transparent_65%)]" aria-hidden />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(50,97,14,0.4),_transparent_65%)]" aria-hidden />
       <div className="pointer-events-none absolute -top-32 left-[-10%] h-[26rem] w-[26rem] rounded-full bg-emerald-400/25 blur-3xl" />
       <div className="pointer-events-none absolute bottom-[-40%] right-[-15%] h-[32rem] w-[32rem] rounded-full bg-emerald-300/25 blur-3xl" />
 
       <div className="relative z-10 mx-auto w-full max-w-[1900px] px-3 pb-12 pt-2 sm:px-5 sm:pt-3 lg:pt-4">
         <div className="relative">
           <div className="rounded-[56px] bg-gradient-to-tr from-emerald-300 via-emerald-400 to-emerald-500 p-[1.5px] shadow-[0_55px_110px_rgba(2,26,20,0.55)]">
-            <div className="rounded-[52px] border border-white/15 bg-black/45 p-3 sm:p-4 shadow-[0_30px_80px_rgba(4,47,35,0.55)] backdrop-blur">
+            <div className="rounded-[52px] border border-white/15 bg-black/45 p-3 sm:p-4 shadow-[0_30px_80px_rgba(34,68,10,0.55)] backdrop-blur">
               <div className="rounded-[44px] border border-white/5 bg-black/25 p-2 sm:p-3">
                 <div className="relative overflow-hidden rounded-[36px] border border-white/10">
                   <MapHero
@@ -180,7 +180,7 @@ function HomeHero() {
 function TownBridge({ className = "" }) {
   return (
     <div
-      className={`flex h-full flex-col gap-5 rounded-[28px] border border-white/12 bg-white/5 p-4 text-white shadow-[0_30px_70px_rgba(4,47,35,0.45)] backdrop-blur-sm sm:p-5 ${className}`}
+      className={`flex h-full flex-col gap-5 rounded-[28px] border border-white/12 bg-white/5 p-4 text-white shadow-[0_30px_70px_rgba(34,68,10,0.45)] backdrop-blur-sm sm:p-5 ${className}`}
     >
       <div className="space-y-2 text-left">
         <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.32em] text-emerald-100">
@@ -207,7 +207,7 @@ function DidYouKnowSection() {
       <div className="absolute inset-0 bg-gradient-to-br from-emerald-950 via-emerald-900 to-emerald-700" aria-hidden />
       <div className="pointer-events-none absolute left-[-18%] top-[-18%] h-[26rem] w-[26rem] rounded-full bg-emerald-400/25 blur-3xl" />
       <div className="pointer-events-none absolute right-[-12%] bottom-[-24%] h-[30rem] w-[30rem] rounded-full bg-emerald-300/25 blur-3xl" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(16,185,129,0.15),_transparent_70%)]" aria-hidden />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(50,97,14,0.15),_transparent_70%)]" aria-hidden />
 
       <div className="relative z-10 mx-auto w-full max-w-6xl px-4">
         <div className="mx-auto max-w-3xl text-center">
@@ -248,7 +248,7 @@ function ConciergeSection() {
             <div className="mt-6 grid gap-3 text-sm text-slate-700 sm:grid-cols-2 sm:text-base">
               {["WhatsApp desk 9am–9pm", "Checklists that adjust as you progress", "Pre-market pings for your saved towns", "Closing team synced with lender + lawyer"].map((item) => (
                 <div key={item} className="flex items-start gap-3 rounded-2xl border border-emerald-200/80 bg-emerald-50/70 px-4 py-3 shadow-sm">
-                  <span className="mt-1 inline-flex h-5 w-5 flex-none items-center justify-center rounded-full bg-emerald-600 text-[10px] font-bold text-white">
+                  <span className="mt-1 inline-flex h-5 w-5 flex-none items-center justify-center rounded-full bg-brand-green text-[10px] font-bold text-white">
                     ✓
                   </span>
                   <span>{item}</span>
@@ -265,7 +265,7 @@ function ConciergeSection() {
               <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
                 <a
                   href="/contact"
-                  className="inline-flex items-center justify-center rounded-xl bg-emerald-700 px-5 py-3 text-base font-semibold text-white shadow-lg shadow-emerald-500/40 transition hover:bg-emerald-800"
+                  className="inline-flex items-center justify-center rounded-xl bg-brand-green px-5 py-3 text-base font-semibold text-white shadow-lg shadow-brand-green/40 transition hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2"
                 >
                   Start the Conversation
                 </a>

--- a/src/InsightsPage.js
+++ b/src/InsightsPage.js
@@ -83,7 +83,7 @@ function InsightsHero() {
           Stories, market updates, and local perspectives from across the NorthSide.
         </p>
       </div>
-      <figure className="relative mx-auto w-full max-w-5xl overflow-hidden rounded-[36px] border border-emerald-100 bg-white/95 shadow-[0_40px_110px_rgba(16,185,129,0.18)]">
+      <figure className="relative mx-auto w-full max-w-5xl overflow-hidden rounded-[36px] border border-emerald-100 bg-white/95 shadow-[0_40px_110px_rgba(50,97,14,0.18)]">
         <img
           src="/uploads/insights-hero-finally-home-agents.jpg"
           alt="Person typing on a laptop that shows the words Community Insights, with a fireplace and coffee in the background, representing NorthSide GTA real estate insights."
@@ -268,7 +268,7 @@ export default function InsightsPage() {
             <button
               type="button"
               onClick={loadMore}
-              className="rounded-full border border-emerald-300 px-5 py-2 text-sm font-semibold text-emerald-700 transition hover:bg-emerald-600 hover:text-white"
+              className="rounded-full border border-brand-green/40 px-5 py-2 text-sm font-semibold text-brand-green transition hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2"
             >
               Load more
             </button>

--- a/src/MapHero.js
+++ b/src/MapHero.js
@@ -356,9 +356,9 @@ const useIsomorphicLayoutEffect =
 const Styles = () => (
   <style>{`
   @keyframes pinPulse {
-    0%   { transform: translate(-50%, -50%) scale(0.95); box-shadow: 0 0 0 0 rgba(16,185,129,0.40); }
-    70%  { transform: translate(-50%, -50%) scale(1);    box-shadow: 0 0 0 14px rgba(16,185,129,0.00); }
-    100% { transform: translate(-50%, -50%) scale(0.95); box-shadow: 0 0 0 0 rgba(16,185,129,0.00); }
+    0%   { transform: translate(-50%, -50%) scale(0.95); box-shadow: 0 0 0 0 rgba(50,97,14,0.35); }
+    70%  { transform: translate(-50%, -50%) scale(1);    box-shadow: 0 0 0 14px rgba(50,97,14,0.00); }
+    100% { transform: translate(-50%, -50%) scale(0.95); box-shadow: 0 0 0 0 rgba(50,97,14,0.00); }
   }
   .pin-wrap {
     position:absolute;
@@ -369,7 +369,7 @@ const Styles = () => (
   .pin {
     position:absolute; left:50%; top:50%; transform:translate(-50%, -50%);
     width:14px; height:14px; border-radius:999px; border:2px solid #fff;
-    background: radial-gradient(65% 65% at 35% 35%, #34d399 0%, #059669 60%, #047857 100%);
+    background: radial-gradient(65% 65% at 35% 35%, #32610E 0%, #28520C 60%, #22440A 100%);
     animation: pinPulse 2s ease-out infinite;
   }
   /* ===== Desktop Hero Layout — 20 | 60 | 20 ===== */
@@ -706,16 +706,16 @@ function RatingRow({ label, value, tone = "emerald", icon: Icon }) {
     : "text-emerald-900";
 
   const iconHaloClass = isPanelDesktop
-    ? "border-white/15 bg-emerald-500/15 text-emerald-100 shadow-[0_4px_12px_rgba(12,74,40,0.45)]"
+    ? "border-white/15 bg-emerald-500/15 text-emerald-100 shadow-[0_4px_12px_rgba(34,68,10,0.45)]"
     : isPanelMobile
-    ? "border-white/25 bg-white/15 text-emerald-50 shadow-[0_3px_10px_rgba(16,185,129,0.4)]"
-    : "border-emerald-200/80 bg-emerald-50 text-emerald-600 shadow-[0_4px_10px_rgba(16,185,129,0.18)]";
+    ? "border-white/25 bg-white/15 text-emerald-50 shadow-[0_3px_10px_rgba(50,97,14,0.4)]"
+    : "border-emerald-200/80 bg-emerald-50 text-emerald-600 shadow-[0_4px_10px_rgba(50,97,14,0.18)]";
 
   const filledDotClass = isPanelDesktop
     ? "bg-gradient-to-br from-emerald-200 via-emerald-300 to-amber-200/90"
     : isPanelMobile
     ? "bg-gradient-to-br from-emerald-200 via-emerald-300 to-amber-200 shadow-[0_0_8px_rgba(94,234,212,0.45)]"
-    : "bg-gradient-to-br from-emerald-400 via-emerald-500 to-amber-300 shadow-[0_0_8px_rgba(16,185,129,0.38)]";
+    : "bg-gradient-to-br from-emerald-400 via-emerald-500 to-amber-300 shadow-[0_0_8px_rgba(50,97,14,0.38)]";
 
   const emptyDotClass = isPanelDesktop
     ? "bg-emerald-900/45"
@@ -739,7 +739,7 @@ function RatingRow({ label, value, tone = "emerald", icon: Icon }) {
     ? "bg-gradient-to-r from-emerald-200 via-emerald-300 to-amber-200"
     : isPanelMobile
     ? "bg-gradient-to-r from-emerald-300 via-emerald-400 to-amber-200 shadow-[0_0_12px_rgba(94,234,212,0.45)]"
-    : "bg-gradient-to-r from-emerald-400 via-emerald-500 to-amber-300 shadow-[0_0_12px_rgba(16,185,129,0.3)]";
+    : "bg-gradient-to-r from-emerald-400 via-emerald-500 to-amber-300 shadow-[0_0_12px_rgba(50,97,14,0.3)]";
 
   const rowLayoutClasses = isPanelDesktop
     ? "grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3"
@@ -1162,7 +1162,7 @@ export default function MapHero({
                         </h3>
                         <button
                           type="button"
-                          className="mobile-accordion-trigger inline-flex w-full items-center justify-center rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-white shadow-[0_4px_12px_rgba(16,185,129,0.35)] transition hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-emerald-950"
+                          className="mobile-accordion-trigger inline-flex w-full items-center justify-center rounded-xl bg-brand-green px-4 py-2 text-sm font-semibold uppercase tracking-wide text-white shadow-[0_4px_12px_rgba(50,97,14,0.35)] transition hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus:ring-2 focus:ring-brand-green/50 focus:ring-offset-2 focus:ring-offset-emerald-950"
                           aria-expanded={mobileMatchOpen}
                           aria-controls={accordionRegionId}
                           onClick={handleMobileAccordionToggle}
@@ -1335,11 +1335,11 @@ function TownInsightCard({
     isDesktopPanel
       ? `pointer-events-auto flex h-full flex-col overflow-hidden rounded-[30px] border transition-colors duration-300 backdrop-blur-xl ${
           isActive
-            ? "border-emerald-300/60 shadow-[0_36px_110px_rgba(6,50,28,0.5)]"
-            : "border-emerald-900/45 shadow-[0_30px_96px_rgba(3,20,12,0.55)]"
+            ? "border-emerald-300/60 shadow-[0_36px_110px_rgba(34,68,10,0.5)]"
+            : "border-emerald-900/45 shadow-[0_30px_96px_rgba(24,47,10,0.55)]"
         }`
       : isPanel
-      ? "flex flex-col overflow-hidden rounded-[26px] border border-white/12 bg-emerald-950/75 shadow-[0_24px_60px_rgba(2,15,10,0.45)] backdrop-blur-xl"
+      ? "flex flex-col overflow-hidden rounded-[26px] border border-white/12 bg-emerald-950/75 shadow-[0_24px_60px_rgba(18,36,12,0.45)] backdrop-blur-xl"
       : isMobile
       ? "rounded-[26px] border border-emerald-200/80 bg-white/96 shadow-xl shadow-emerald-900/10"
       : "pointer-events-auto overflow-hidden rounded-[30px] border border-emerald-200/70 bg-white/96 shadow-[0_24px_60px_rgba(233,24,0.18)] backdrop-blur",
@@ -1356,8 +1356,8 @@ function TownInsightCard({
       ? "flex-none border-b border-white/12 bg-white/10 px-4 py-3 text-white"
       : "flex-none border-b border-white/10 bg-white/8 px-5 py-4 text-white"
     : isMobile
-    ? "flex-none rounded-t-[26px] bg-gradient-to-r from-emerald-600 via-emerald-500 to-teal-400 px-4 py-3 text-white"
-    : "flex-none rounded-t-[30px] bg-gradient-to-r from-emerald-600 via-emerald-500 to-teal-400 px-5 py-4 text-white";
+    ? "flex-none rounded-t-[26px] bg-gradient-to-r from-emerald-600 via-emerald-500 to-emerald-700 px-4 py-3 text-white"
+    : "flex-none rounded-t-[30px] bg-gradient-to-r from-emerald-600 via-emerald-500 to-emerald-700 px-5 py-4 text-white";
 
   const bodyClasses = isDesktopPanel
     ? "flex-1 space-y-5 overflow-y-auto px-5 py-5 text-emerald-50/92 transition-opacity duration-300"
@@ -1514,7 +1514,7 @@ function TownInsightCard({
                 <p className={headerSubtitleClasses}>NorthSide GTA</p>
                 <div className="flex min-w-0 items-center gap-2">
                   {townLogo ? (
-                    <span className="flex h-6 w-6 flex-none items-center justify-center overflow-hidden rounded-full border border-white/20 bg-emerald-500/20 shadow-[0_6px_16px_rgba(12,74,40,0.45)]">
+                    <span className="flex h-6 w-6 flex-none items-center justify-center overflow-hidden rounded-full border border-white/20 bg-emerald-500/20 shadow-[0_6px_16px_rgba(34,68,10,0.45)]">
                       <img
                         src={townLogo}
                         alt={`${town.name} emblem`}
@@ -1546,7 +1546,7 @@ function TownInsightCard({
                 {isDesktopPanel ? (
                   <div className="flex items-center gap-2">
                     {townLogo ? (
-                      <span className="flex h-6 w-6 flex-none items-center justify-center overflow-hidden rounded-full border border-white/20 bg-emerald-500/20 shadow-[0_6px_16px_rgba(12,74,40,0.45)]">
+                      <span className="flex h-6 w-6 flex-none items-center justify-center overflow-hidden rounded-full border border-white/20 bg-emerald-500/20 shadow-[0_6px_16px_rgba(34,68,10,0.45)]">
                         <img
                           src={townLogo}
                           alt={`${town.name} emblem`}

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -62,7 +62,7 @@ export default function Navigation() {
         }
 
         .header-purpose-line {
-          background-image: linear-gradient(90deg, #32610E 0%, #4FAE22 100%);
+          background-image: linear-gradient(90deg, #32610E 0%, #22440A 100%);
           background-size: 0% 2px;
           background-repeat: no-repeat;
           background-position: left bottom;
@@ -129,9 +129,9 @@ export default function Navigation() {
                   className="
                     relative text-[15px] tracking-wide
                     transition duration-200
-                    hover:text-emerald-700
+                    hover:text-brand-green
                     after:content-[''] after:absolute after:-bottom-1 after:left-0
-                    after:w-0 after:h-[2px] after:bg-emerald-600 after:transition-all after:duration-200
+                    after:w-0 after:h-[2px] after:bg-brand-green after:transition-all after:duration-200
                     hover:after:w-full
                   "
                 >
@@ -144,13 +144,14 @@ export default function Navigation() {
             <Link
               to="/contact"
               className="
-                inline-flex items-center
-                rounded-lg bg-emerald-700 px-4 py-2
+                ml-2 inline-flex items-center
+                rounded-lg bg-brand-green px-4 py-2
                 text-white font-semibold shadow-sm
-                transition ml-2
-                hover:bg-emerald-800
+                transition
+                hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)]
                 hover:-translate-y-[1px]
                 hover:shadow-md
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2
               "
               onMouseEnter={(e) => {
                 e.currentTarget.style.animation = "btnLift 200ms ease-out forwards";
@@ -198,7 +199,7 @@ export default function Navigation() {
                 <Link
                   to="/contact"
                   onClick={toggleMenu}
-                  className="block bg-emerald-700 text-white text-center px-4 py-2 rounded-md hover:bg-emerald-800 transition"
+                  className="block rounded-md bg-brand-green px-4 py-2 text-center text-white transition hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2"
                 >
                   Let’s&nbsp;Talk
                 </Link>

--- a/src/QuickContactCard.js
+++ b/src/QuickContactCard.js
@@ -130,8 +130,8 @@ export default function QuickContactCard({
     baseContainer,
     overlay
       ? open
-        ? "flex h-full flex-col overflow-hidden overflow-y-auto border border-white/14 bg-emerald-950/75 p-5 md:p-6 shadow-[0_32px_90px_rgba(2,15,10,0.5)] backdrop-blur-xl"
-        : "flex h-full flex-col justify-between border border-white/14 bg-emerald-950/65 p-5 md:p-6 shadow-[0_32px_90px_rgba(2,15,10,0.45)] backdrop-blur-xl"
+        ? "flex h-full flex-col overflow-hidden overflow-y-auto border border-white/14 bg-emerald-950/75 p-5 md:p-6 shadow-[0_32px_90px_rgba(18,36,12,0.5)] backdrop-blur-xl"
+        : "flex h-full flex-col justify-between border border-white/14 bg-emerald-950/65 p-5 md:p-6 shadow-[0_32px_90px_rgba(18,36,12,0.45)] backdrop-blur-xl"
       : open
       ? "border border-emerald-200 bg-white/95 p-4 md:p-5 shadow-sm"
       : "border border-white/25 bg-white/5 p-4 md:p-5 shadow-sm backdrop-blur-sm",
@@ -225,9 +225,9 @@ export default function QuickContactCard({
               onClick={() => setOpenState(true)}
               className={`
                 px-5 py-2.5 rounded-xl font-bold tracking-wide
-                bg-emerald-700 text-white hover:bg-emerald-800
-                shadow-[0_4px_12px_rgba(16,185,129,0.35)]
-                transition
+                bg-brand-green text-white shadow-[0_4px_12px_rgba(50,97,14,0.35)]
+                transition hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)]
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2
                 w-full ${overlay ? "" : "sm:w-auto"}
               `}
             >
@@ -438,10 +438,10 @@ export default function QuickContactCard({
                       "px-3 py-1.5 rounded-md text-sm font-medium transition",
                       overlay
                         ? pref === opt
-                          ? "bg-emerald-500 text-white shadow-[0_0_14px_rgba(16,185,129,0.45)]"
+                          ? "bg-emerald-500 text-white shadow-[0_0_14px_rgba(50,97,14,0.45)]"
                           : "text-emerald-100 hover:bg-white/10"
                         : pref === opt
-                        ? "bg-emerald-600 text-white"
+                        ? "bg-brand-green text-white hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)]"
                         : "text-gray-700 hover:bg-gray-50",
                     ].join(" ")}
                     onClick={() => setPref(opt)}
@@ -470,10 +470,10 @@ export default function QuickContactCard({
                     "px-3 py-1.5 rounded-full border text-sm transition",
                     overlay
                       ? allChecked
-                        ? "border-emerald-400 bg-emerald-500 text-white shadow-[0_0_14px_rgba(16,185,129,0.45)]"
+                        ? "border-emerald-400 bg-emerald-500 text-white shadow-[0_0_14px_rgba(50,97,14,0.45)]"
                         : "border-white/18 text-emerald-100 hover:bg-white/10"
                       : allChecked
-                      ? "bg-emerald-600 text-white border-emerald-600"
+                      ? "bg-brand-green text-white border-brand-green hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)]"
                       : "border-emerald-300 hover:bg-gray-50",
                   ].join(" ")}
                 >
@@ -491,10 +491,10 @@ export default function QuickContactCard({
                         "px-3 py-1.5 rounded-full border text-sm transition",
                         overlay
                           ? on
-                            ? "border-emerald-400 bg-emerald-500 text-white shadow-[0_0_14px_rgba(16,185,129,0.45)]"
+                            ? "border-emerald-400 bg-emerald-500 text-white shadow-[0_0_14px_rgba(50,97,14,0.45)]"
                             : "border-white/18 text-emerald-100 hover:bg-white/10"
                           : on
-                          ? "bg-emerald-600 text-white border-emerald-600"
+                          ? "bg-brand-green text-white border-brand-green hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)]"
                           : "border-emerald-300 hover:bg-gray-50",
                       ].join(" ")}
                     >
@@ -545,10 +545,10 @@ export default function QuickContactCard({
                 "px-4 py-2 rounded-lg font-semibold transition",
                 overlay
                   ? canSubmit
-                    ? "bg-emerald-500 text-white shadow-[0_0_18px_rgba(16,185,129,0.5)] hover:bg-emerald-400"
+                    ? "bg-emerald-500 text-white shadow-[0_0_18px_rgba(50,97,14,0.5)] hover:bg-emerald-400"
                     : "bg-white/10 text-emerald-100/60 cursor-not-allowed"
                   : canSubmit
-                  ? "bg-emerald-700 text-white hover:bg-emerald-800"
+                  ? "bg-brand-green text-white hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)]"
                   : "bg-emerald-200 text-emerald-900/60 cursor-not-allowed",
               ].join(" ")}
             >

--- a/src/ReferralPartnersPage.js
+++ b/src/ReferralPartnersPage.js
@@ -425,7 +425,7 @@ function ReferralPartnerForm() {
         <button
           type="submit"
           disabled={submitting}
-          className="inline-flex w-full items-center justify-center rounded-2xl bg-emerald-600 px-5 py-3 text-base font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+          className="inline-flex w-full items-center justify-center rounded-2xl bg-brand-green px-5 py-3 text-base font-semibold text-white shadow-lg shadow-brand-green/30 transition disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus-visible:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2"
         >
           {submitting ? "Sending…" : "Send referral details"}
         </button>
@@ -462,7 +462,7 @@ export default function ReferralPartnersPage() {
             style={{ backgroundImage: "url('/Images/northsidegta-map-bg.jpg')" }}
             aria-hidden
           />
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.35),_transparent_60%)]" aria-hidden />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(50,97,14,0.35),_transparent_60%)]" aria-hidden />
           <div className="absolute -left-10 top-10 h-64 w-64 rounded-full bg-emerald-500/30 blur-3xl" aria-hidden />
           <div className="absolute -right-16 bottom-[-40%] h-80 w-80 rounded-full bg-emerald-400/20 blur-3xl" aria-hidden />
           <div className="relative mx-auto max-w-6xl px-4 py-20 sm:px-6 lg:px-8 sm:py-24">

--- a/src/SellersPage.js
+++ b/src/SellersPage.js
@@ -83,7 +83,7 @@ function SellerHero() {
         aria-hidden
       />
       <div
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.35),_transparent_65%)]"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(50,97,14,0.35),_transparent_65%)]"
         aria-hidden
       />
       <div className="pointer-events-none absolute -top-32 left-[-10%] h-[26rem] w-[26rem] rounded-full bg-emerald-400/25 blur-3xl" />
@@ -307,7 +307,7 @@ function SellerLeadCapture() {
             aria-hidden="true"
           />
           <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-100/70 via-white to-teal-100/70"
+            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-100/70 via-white to-emerald-100/70"
             aria-hidden
           />
 
@@ -382,7 +382,7 @@ function SellerLeadCapture() {
           aria-hidden="true"
         />
         <div
-          className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-100/70 via-white to-teal-100/70"
+          className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-100/70 via-white to-emerald-100/70"
           aria-hidden
         />
 
@@ -413,7 +413,7 @@ function SellerLeadCapture() {
           <div className="mt-6">
             <div className="h-2 w-full overflow-hidden rounded-full bg-emerald-100/70">
               <div
-                className="h-full rounded-full bg-gradient-to-r from-emerald-600 via-emerald-500 to-teal-400 transition-all"
+                className="h-full rounded-full bg-gradient-to-r from-emerald-600 via-emerald-500 to-emerald-700 transition-all"
                 style={{ width: `${progressPct}%` }}
               />
             </div>
@@ -504,7 +504,7 @@ function SellerLeadCapture() {
 
               <button
                 type="submit"
-                className="inline-flex items-center justify-center rounded-xl border border-emerald-500/60 bg-gradient-to-r from-emerald-600 via-emerald-500 to-teal-500 px-5 py-3 font-semibold text-white shadow-xl shadow-emerald-900/30 transition hover:from-emerald-500 hover:to-teal-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-2 focus:ring-offset-emerald-50"
+                className="inline-flex items-center justify-center rounded-xl border border-emerald-500/60 bg-gradient-to-r from-emerald-600 via-emerald-500 to-emerald-700 px-5 py-3 font-semibold text-white shadow-xl shadow-emerald-900/30 transition hover:from-emerald-500 hover:to-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-2 focus:ring-offset-emerald-50"
               >
                 Continue to Step 2
               </button>
@@ -583,7 +583,7 @@ function SellerLeadCapture() {
                     max="10"
                     value={form.condition}
                     onChange={update}
-                    className="mt-2 h-2 w-full appearance-none rounded-full bg-emerald-100 [accent-color:#059669]"
+                    className="mt-2 h-2 w-full appearance-none rounded-full bg-emerald-100 [accent-color:#32610E]"
                   />
                   <div className="mt-1 text-xs text-slate-600">{form.condition}/10</div>
                 </label>
@@ -596,7 +596,7 @@ function SellerLeadCapture() {
                     max="10"
                     value={form.upgrades}
                     onChange={update}
-                    className="mt-2 h-2 w-full appearance-none rounded-full bg-emerald-100 [accent-color:#059669]"
+                    className="mt-2 h-2 w-full appearance-none rounded-full bg-emerald-100 [accent-color:#32610E]"
                   />
                   <div className="mt-1 text-xs text-slate-600">{form.upgrades}/10</div>
                 </label>
@@ -799,7 +799,7 @@ function SellerLeadCapture() {
                 <button
                   type="submit"
                   disabled={!requiredOk || sending}
-                  className="inline-flex w-full items-center justify-center rounded-xl border border-emerald-500/60 bg-gradient-to-r from-emerald-600 via-emerald-500 to-teal-500 px-5 py-3 font-semibold text-white shadow-xl shadow-emerald-900/30 transition hover:from-emerald-500 hover:to-teal-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-2 focus:ring-offset-emerald-50 disabled:cursor-not-allowed disabled:border-emerald-200 disabled:from-emerald-400 disabled:to-emerald-400 disabled:opacity-70"
+                  className="inline-flex w-full items-center justify-center rounded-xl border border-emerald-500/60 bg-gradient-to-r from-emerald-600 via-emerald-500 to-emerald-700 px-5 py-3 font-semibold text-white shadow-xl shadow-emerald-900/30 transition hover:from-emerald-500 hover:to-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:ring-offset-2 focus:ring-offset-emerald-50 disabled:cursor-not-allowed disabled:border-emerald-200 disabled:from-emerald-400 disabled:to-emerald-400 disabled:opacity-70"
                 >
                   {sending ? "Sending…" : "Get My Home Value"}
                 </button>
@@ -818,7 +818,7 @@ function SellerTimeline() {
   return (
     <section className="relative overflow-hidden rounded-[36px] border border-emerald-200/70 bg-white/90 p-6 shadow-[0_25px_70px_rgba(15,118,110,0.14)] backdrop-blur md:p-10">
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-100/70 via-white to-teal-100/60"
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-100/70 via-white to-emerald-100/60"
         aria-hidden
       />
       <div className="relative z-10">
@@ -853,7 +853,7 @@ function SellerMediaSection() {
   return (
     <section className="relative overflow-hidden rounded-[36px] border border-emerald-200/70 bg-white/90 p-6 shadow-[0_25px_70px_rgba(15,118,110,0.14)] backdrop-blur md:p-10">
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-100/70 via-white to-teal-100/60"
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-100/70 via-white to-emerald-100/60"
         aria-hidden
       />
       <div className="relative z-10 space-y-6 text-center">

--- a/src/TownCards.js
+++ b/src/TownCards.js
@@ -40,7 +40,7 @@ export default function TownCards() {
               <p className="text-sm text-gray-600">
                 Learn why {name} is a top choice for buyers moving north of Toronto.
               </p>
-              <button className="mt-4 text-green-700 font-semibold hover:underline">
+              <button className="mt-4 font-semibold text-brand-green hover:underline">
                 Explore {name}
               </button>
             </div>

--- a/src/TownPage.js
+++ b/src/TownPage.js
@@ -74,7 +74,7 @@ function DotRow({ value = 0 }) {
         <span
           key={i}
           className={`inline-block h-2.5 w-2.5 rounded-full ${
-            i < v ? "bg-emerald-600" : "bg-gray-300"
+            i < v ? "bg-brand-green" : "bg-gray-300"
           }`}
         />
       ))}
@@ -105,7 +105,7 @@ export default function TownPage() {
           </p>
           <Link
             to="/"
-            className="inline-block bg-emerald-700 text-white px-4 py-2 rounded hover:bg-emerald-800 transition"
+            className="inline-block rounded bg-brand-green px-4 py-2 text-white transition hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2"
           >
             Back to Home
           </Link>

--- a/src/WhatsAppCta.js
+++ b/src/WhatsAppCta.js
@@ -10,11 +10,12 @@ export function WhatsAppCtaOption1() {
       rel="noopener noreferrer"
       className="
         flex items-center justify-center gap-2
-        bg-green-600 text-white font-semibold
+        bg-brand-green text-white font-semibold
         px-5 py-3 rounded-xl shadow-md
-        hover:bg-green-700 hover:scale-[1.02] active:scale-[0.98]
+        hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] hover:scale-[1.02] active:bg-brand-green-dark active:scale-[0.98]
         transition transform duration-200
         w-full text-center
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2
       "
     >
       <FaWhatsapp className="text-xl" />

--- a/src/community/EventCalendar.js
+++ b/src/community/EventCalendar.js
@@ -55,7 +55,7 @@ const CATEGORY_STYLES = {
   },
   Golf: {
     background: 'linear-gradient(135deg, rgba(50, 97, 14, 0.24), rgba(209, 250, 229, 0.5))',
-    dot: '#10B981',
+    dot: '#32610E',
   },
   Markets: {
     background: 'linear-gradient(135deg, rgba(50, 97, 14, 0.18), rgba(245, 158, 11, 0.3))',
@@ -67,7 +67,7 @@ const CATEGORY_STYLES = {
   },
   Outdoors: {
     background: 'linear-gradient(135deg, rgba(50, 97, 14, 0.24), rgba(134, 239, 172, 0.4))',
-    dot: '#047857',
+    dot: '#22440A',
   },
   Other: {
     background: 'linear-gradient(135deg, rgba(50, 97, 14, 0.18), rgba(148, 163, 184, 0.32))',

--- a/src/community/EventDetailPage.js
+++ b/src/community/EventDetailPage.js
@@ -785,7 +785,7 @@ export default function EventDetailPage() {
       </div>
 
       {shareToastVisible && (
-        <div className="fixed inset-x-4 bottom-6 z-50 mx-auto max-w-sm rounded-full bg-emerald-600 px-4 py-2 text-center text-xs font-semibold text-white shadow-lg">
+        <div className="fixed inset-x-4 bottom-6 z-50 mx-auto max-w-sm rounded-full bg-brand-green px-4 py-2 text-center text-xs font-semibold text-white shadow-lg">
           Link copied
         </div>
       )}

--- a/src/community/EventMap.js
+++ b/src/community/EventMap.js
@@ -167,7 +167,7 @@ function ClusterMarker({ cluster, onSelectEvent }) {
   const icon = React.useMemo(() => {
     return L.divIcon({
       className: 'cluster-marker',
-      html: `<div style="background:#059669;color:white;border-radius:50%;width:42px;height:42px;display:flex;align-items:center;justify-content:center;font-weight:600;box-shadow:0 10px 20px rgba(5,150,105,0.25);">${cluster.events.length}</div>`,
+      html: `<div style="background:#32610E;color:white;border-radius:50%;width:42px;height:42px;display:flex;align-items:center;justify-content:center;font-weight:600;box-shadow:0 10px 20px rgba(50,97,14,0.25);">${cluster.events.length}</div>`,
       iconSize: [42, 42],
     })
   }, [cluster.events.length])

--- a/src/community/SubmitEventPage.js
+++ b/src/community/SubmitEventPage.js
@@ -1724,7 +1724,7 @@ export default function SubmitEventPage() {
                   'inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold shadow-lg transition',
                   submitting
                     ? 'cursor-wait border border-emerald-200 bg-emerald-200 text-emerald-800'
-                    : 'border border-emerald-600 bg-emerald-600 text-white hover:border-emerald-700 hover:bg-emerald-700'
+                    : 'border border-brand-green/60 bg-brand-green text-white hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2'
                 )}
               >
                 {submitting ? 'Submitting…' : 'Submit for review'}

--- a/src/community/admin/EventsIndexPage.js
+++ b/src/community/admin/EventsIndexPage.js
@@ -67,7 +67,7 @@ function ToastNotice({ toast, onClose }) {
   const baseStyles =
     tone === 'error'
       ? 'bg-rose-600 shadow-lg shadow-rose-600/30'
-      : 'bg-emerald-600 shadow-lg shadow-emerald-600/30'
+      : 'bg-brand-green shadow-lg shadow-brand-green/30'
 
   return (
     <div className="fixed bottom-6 left-1/2 z-50 w-full max-w-md -translate-x-1/2 px-4 sm:left-auto sm:right-6 sm:translate-x-0">
@@ -975,7 +975,7 @@ export default function EventsIndexPage() {
                 onClick={() => setActiveTab(tab.key)}
                 className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition ${
                   activeTab === tab.key
-                    ? 'bg-emerald-600 text-white shadow'
+                    ? 'bg-brand-green text-white shadow hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)]'
                     : 'border border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:text-slate-900'
                 }`}
               >

--- a/src/community/filters.compact.css
+++ b/src/community/filters.compact.css
@@ -50,7 +50,7 @@
   border: none;
   padding: 0;
   font-size: 14px;
-  color: #0f766e;
+  color: #32610E;
   cursor: pointer;
 }
 .filters-toolbar .btn-link.danger {

--- a/src/components/DidYouKnowCard.jsx
+++ b/src/components/DidYouKnowCard.jsx
@@ -109,7 +109,7 @@ export default function DidYouKnowCard({
       ) : null}
       <div className={`relative overflow-hidden ${container}`}>
         <div
-          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.28),_transparent_65%)]"
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(50,97,14,0.28),_transparent_65%)]"
           aria-hidden
         />
         <div className={inner}>

--- a/src/components/contact/LegacyContactPage.js
+++ b/src/components/contact/LegacyContactPage.js
@@ -109,7 +109,7 @@ export default function LegacyContactPage() {
           <Card className="text-center space-y-4 sm:space-y-5 p-6 sm:p-10">
             <div className="flex justify-center gap-4">
               <FaTrophy   className="w-8 h-8 sm:w-10 sm:h-10 text-yellow-500"/>
-              <FaHandshake className="w-8 h-8 sm:w-10 sm:h-10 text-green-600"/>
+              <FaHandshake className="w-8 h-8 sm:w-10 sm:h-10 text-brand-green"/>
             </div>
 
             <h1 className="text-xl sm:text-3xl md:text-4xl font-bold leading-tight">
@@ -141,7 +141,7 @@ export default function LegacyContactPage() {
             Call, chat, or drop us a quick note — whichever’s easiest. We reply fast.
           </p>
           <p className="flex justify-center">
-            <span className="inline-block bg-green-100 text-green-700 px-3 py-1 rounded-full text-xs sm:text-sm font-medium">
+            <span className="inline-block rounded-full bg-brand-green/10 px-3 py-1 text-xs font-medium text-brand-green sm:text-sm">
               💬 We reply within 1&nbsp;hour&nbsp;(9&nbsp;am&nbsp;–&nbsp;9&nbsp;pm)
             </span>
           </p>
@@ -182,8 +182,8 @@ export default function LegacyContactPage() {
               </Button>
             </form>
           ) : (
-            <Card className="p-6 text-center bg-green-50">
-              <h3 className="text-xl font-semibold text-green-700 mb-2">Thank you!</h3>
+            <Card className="p-6 text-center bg-emerald-50">
+              <h3 className="mb-2 text-xl font-semibold text-brand-green">Thank you!</h3>
               <p className="text-sm text-muted-foreground">
                 Your message is on its way. We’ll respond within the hour.
               </p>

--- a/src/components/reviews/GoogleGradientReviews.js
+++ b/src/components/reviews/GoogleGradientReviews.js
@@ -52,10 +52,10 @@ export default function GoogleGradientReviews({ className = "" }) {
         aria-hidden
       />
 
-      <div className="relative rounded-[36px] bg-gradient-to-br from-emerald-300/70 via-emerald-400/50 to-emerald-600/60 p-[1.5px] shadow-[0_45px_120px_rgba(4,47,35,0.55)]">
+      <div className="relative rounded-[36px] bg-gradient-to-br from-emerald-300/70 via-emerald-400/50 to-emerald-600/60 p-[1.5px] shadow-[0_45px_120px_rgba(34,68,10,0.55)]">
         <div className="relative overflow-hidden rounded-[32px] border border-white/10 bg-slate-950/80 px-6 py-8 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur">
           <div
-            className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.25),_transparent_60%)]"
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(50,97,14,0.25),_transparent_60%)]"
             aria-hidden
           />
 

--- a/src/components/towns/TownPageLayout.js
+++ b/src/components/towns/TownPageLayout.js
@@ -9,8 +9,8 @@ function ButtonLink({ href, label, variant = "primary" }) {
 
   const variantClasses =
     variant === "secondary"
-      ? "bg-white text-emerald-700 border border-emerald-200 hover:bg-emerald-50 focus:ring-emerald-300 focus:ring-offset-emerald-900"
-      : "bg-emerald-600 text-white shadow hover:bg-emerald-500 focus:ring-emerald-200 focus:ring-offset-emerald-900";
+      ? "border border-brand-green/40 bg-white text-brand-green hover:bg-brand-green/10 focus:ring-brand-green/40 focus:ring-offset-emerald-900"
+      : "bg-brand-green text-white shadow transition-colors hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:ring-brand-green/50 focus:ring-offset-emerald-900";
 
   const className = `${baseClasses} ${variantClasses}`;
 
@@ -34,15 +34,15 @@ function ButtonLink({ href, label, variant = "primary" }) {
 function IconBubble({ icon: Icon, label }) {
   if (!Icon) {
     return (
-      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 font-semibold">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-green/10 font-semibold text-brand-green">
         {label ? label.charAt(0) : ""}
       </div>
     );
   }
 
   return (
-    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100">
-      <Icon className="h-6 w-6 text-emerald-700" aria-hidden />
+    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-green/10">
+      <Icon className="h-6 w-6 text-brand-green" aria-hidden />
     </div>
   );
 }

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -8,15 +8,17 @@ export default function Button({
   className = '',
   ...props
 }) {
-  const base = 'font-medium rounded-md inline-block transition duration-200 text-center';
+  const base = 'font-medium rounded-md inline-block transition-colors duration-200 text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2';
   const sizes = {
     sm: 'px-4 py-2 text-sm',
     md: 'px-5 py-2.5',
     lg: 'px-6 py-3 text-lg',
   };
   const variants = {
-    primary: 'bg-green-600 text-white hover:bg-green-700',
-    outline: 'border border-green-600 text-green-600 hover:bg-green-100',
+    primary:
+      'bg-brand-green text-white shadow-sm hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] hover:text-white focus:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] active:bg-brand-green-dark',
+    outline:
+      'border border-brand-green text-brand-green hover:bg-brand-green/10 focus:bg-brand-green/10',
   };
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,11 @@
 @tailwind utilities;
 
 /* Custom styles */
+:root {
+  --ns-green: #32610E;
+  --ns-green-dark: #22440A;
+}
+
 body {
   margin: 0;
   font-family: 'Blinker', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
@@ -15,7 +20,7 @@ body {
 }
 
 .reviews-carousel button:focus-visible {
-  outline: 3px solid #10b981;
+  outline: 3px solid var(--ns-green);
   outline-offset: 2px;
 }
 
@@ -52,14 +57,14 @@ body {
   line-height: 0.9;
   padding-right: 0.2em;
   font-weight: 600;
-  color: #047857;
+  color: var(--ns-green);
 }
 
 .insight-content h2,
 .insight-content h3,
 .insight-content h4 {
   font-weight: 600;
-  color: #022c22;
+  color: var(--ns-green-dark);
   margin: 3rem 0 1.5rem;
 }
 
@@ -85,7 +90,7 @@ body {
 }
 
 .insight-content a {
-  color: #047857;
+  color: var(--ns-green);
   text-decoration: underline;
   text-decoration-thickness: 2px;
   text-underline-offset: 6px;
@@ -93,20 +98,20 @@ body {
 }
 
 .insight-content a:hover {
-  color: #065f46;
+  color: var(--ns-green-dark);
 }
 
 .insight-content blockquote {
   margin: 0;
   padding: 2rem;
   border-radius: 1.75rem;
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(125, 211, 252, 0.1));
-  border: 1px solid rgba(45, 212, 191, 0.35);
-  color: #064e3b;
+  background: linear-gradient(135deg, rgba(50, 97, 14, 0.15), rgba(34, 68, 10, 0.1));
+  border: 1px solid rgba(50, 97, 14, 0.3);
+  color: var(--ns-green-dark);
   font-size: 1.15rem;
   line-height: 1.75;
   font-weight: 500;
-  box-shadow: 0 25px 60px rgba(15, 118, 110, 0.15);
+  box-shadow: 0 25px 60px rgba(34, 68, 10, 0.15);
   font-style: italic;
 }
 
@@ -121,14 +126,14 @@ body {
   width: 100%;
   height: auto;
   border-radius: 1.75rem;
-  box-shadow: 0 35px 80px rgba(15, 118, 110, 0.18);
+  box-shadow: 0 35px 80px rgba(34, 68, 10, 0.2);
   object-fit: cover;
   transition: transform 500ms ease, box-shadow 500ms ease;
 }
 
 .insight-content .insight-figure img:hover {
   transform: scale(1.01);
-  box-shadow: 0 45px 100px rgba(15, 118, 110, 0.22);
+  box-shadow: 0 45px 100px rgba(34, 68, 10, 0.24);
 }
 
 .insight-content .insight-figure__caption {
@@ -150,7 +155,7 @@ body {
   height: auto;
   border-radius: 1.75rem;
   object-fit: cover;
-  box-shadow: 0 30px 80px rgba(15, 118, 110, 0.18);
+  box-shadow: 0 30px 80px rgba(34, 68, 10, 0.2);
 }
 
 .insight-content .insight-inline-media__caption {
@@ -163,9 +168,9 @@ body {
   margin: 0;
   padding: 2.5rem;
   border-radius: 2rem;
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.16), rgba(59, 130, 246, 0.12));
-  border: 1px solid rgba(16, 185, 129, 0.35);
-  box-shadow: 0 35px 90px rgba(15, 118, 110, 0.18);
+  background: linear-gradient(135deg, rgba(50, 97, 14, 0.18), rgba(34, 68, 10, 0.12));
+  border: 1px solid rgba(50, 97, 14, 0.3);
+  box-shadow: 0 35px 90px rgba(34, 68, 10, 0.22);
   display: grid;
   gap: 1.5rem;
   position: relative;
@@ -176,7 +181,7 @@ body {
   font-size: clamp(1.35rem, 1.4vw + 1.2rem, 1.8rem);
   line-height: 1.65;
   font-weight: 600;
-  color: #064e3b;
+  color: var(--ns-green-dark);
   font-style: italic;
   background: none;
   border: none;
@@ -197,7 +202,7 @@ body {
   aspect-ratio: 4 / 5;
   border-radius: 1.5rem;
   overflow: hidden;
-  box-shadow: 0 25px 70px rgba(15, 118, 110, 0.2);
+  box-shadow: 0 25px 70px rgba(34, 68, 10, 0.22);
 }
 
 .insight-content .insight-pull-quote__portrait img {

--- a/src/insights/InsightPage.js
+++ b/src/insights/InsightPage.js
@@ -1135,7 +1135,7 @@ function Hero({ insight, loading, featureImageAlt }) {
         />
       </div>
       <div
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.22),_transparent_60%)]"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(50,97,14,0.22),_transparent_60%)]"
         aria-hidden
       />
       <div

--- a/src/vip.js
+++ b/src/vip.js
@@ -70,7 +70,7 @@ export default function VipPage() {
           style={{ backgroundImage: `url('/vip-bg.png')` }}
         >
           <form onSubmit={handlePasswordSubmit} className="bg-white bg-opacity-90 p-8 rounded-xl shadow-md max-w-md w-full">
-            <h1 className="text-2xl font-bold mb-4 text-center text-green-700">VIP Access Only</h1>
+            <h1 className="text-2xl font-bold mb-4 text-center text-brand-green">VIP Access Only</h1>
             <p className="text-center text-gray-600 mb-6">
               This page is by invitation only. Please enter your password to continue.
             </p>
@@ -81,7 +81,10 @@ export default function VipPage() {
               onChange={(e) => setEnteredPassword(e.target.value)}
               className="w-full px-4 py-2 border rounded mb-4"
             />
-            <button type="submit" className="w-full bg-green-600 text-white py-2 rounded hover:bg-green-700 transition">
+            <button
+              type="submit"
+              className="w-full rounded bg-brand-green py-2 text-white transition-colors hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus-visible:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2"
+            >
               Enter
             </button>
           </form>
@@ -97,7 +100,7 @@ export default function VipPage() {
         <Navigation />
         <div className="min-h-screen bg-white flex items-center justify-center px-4">
           <form onSubmit={handleInfoSubmit} className="bg-gray-100 p-8 rounded-xl shadow-md max-w-md w-full">
-            <h2 className="text-2xl font-bold mb-4 text-center text-green-700">You're In!</h2>
+            <h2 className="text-2xl font-bold mb-4 text-center text-brand-green">You're In!</h2>
             <p className="text-center text-gray-600 mb-6">
               You've been accepted into the VIP Club. Please provide your contact details to unlock your VIP perks.
             </p>
@@ -125,7 +128,10 @@ export default function VipPage() {
               onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
               className="w-full px-4 py-2 border rounded mb-4"
             />
-            <button type="submit" className="w-full bg-green-600 text-white py-2 rounded hover:bg-green-700 transition">
+            <button
+              type="submit"
+              className="w-full rounded bg-brand-green py-2 text-white transition-colors hover:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus-visible:bg-[linear-gradient(90deg,#32610E_0%,#22440A_100%)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green/50 focus-visible:ring-offset-2"
+            >
               Submit
             </button>
           </form>
@@ -167,12 +173,12 @@ export default function VipPage() {
           </ul>
         </section>
 
-        <section className="bg-green-600 text-white py-12 px-6 text-center">
+        <section className="bg-[linear-gradient(180deg,#32610E_0%,#22440A_100%)] text-white py-12 px-6 text-center">
           <h2 className="text-2xl font-bold mb-2">You're In.</h2>
           <p className="mb-6">Explore your VIP tools and stay tuned for what's next.</p>
           <a
             href="/"
-            className="bg-white text-green-700 font-semibold px-6 py-3 rounded-xl hover:bg-gray-100 transition"
+            className="rounded-xl bg-white px-6 py-3 font-semibold text-brand-green transition hover:bg-gray-100"
           >
             Return Home
           </a>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,30 @@
 /** @type {import('tailwindcss').Config} */
+const brandEmeraldPalette = {
+  50:  "#F2F6EB",
+  100: "#E2ECCF",
+  200: "#C8DDA7",
+  300: "#ABC87C",
+  400: "#8FB259",
+  500: "#6F9940",
+  600: "#32610E", // Primary brand green
+  700: "#2C560C",
+  800: "#22440A", // Dark companion green
+  900: "#1A2F06",
+  950: "#101E03",
+};
+
 module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
 
   theme: {
     extend: {
+      colors: {
+        emerald: brandEmeraldPalette,
+        brand: {
+          green: "#32610E",
+          "green-dark": "#22440A",
+        },
+      },
       keyframes: {
         slideDown: {
           "0%": { opacity: 0, transform: "translateY(-0.5rem)" },


### PR DESCRIPTION
## Summary
- redefine the Tailwind emerald palette and global CSS variables around the official NorthSide GTA green tones
- refresh hero overlays, section backgrounds, and prominent CTA buttons to use the new solid-plus-gradient treatment across major pages and shared components
- adjust supporting accents such as map pins, event markers, filters, and placeholder artwork so green highlights consistently match the brand

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a091e67c8324a49ebd451d8ff46b)