### PR TITLE
Add fallback for Uxbridge pizza vote options

### DIFF
--- a/api/rankings/leaderboard.js
+++ b/api/rankings/leaderboard.js
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { loadCommunityPlaces } from '../../lib/community-places'
+import { applyCommunityPlaceFallbacks } from '../../lib/communityRanking/place-fallbacks'
 import { getRedisClient, isRedisConfigured } from '../../lib/communityRanking/kv-client'
 import { normalizeCategory, normalizeTown } from '../../lib/communityRanking/utils'
 
@@ -43,7 +44,10 @@ export default async function handler(req, res) {
       return
     }
 
-    const places = loadCommunityPlaces({ town, category, status: 'published' })
+    const places = applyCommunityPlaceFallbacks(
+      loadCommunityPlaces({ town, category, status: 'published' }),
+      { normalizedTown, normalizedCategory }
+    )
     const pipeline = redis.pipeline()
     const keyPairs = []
 

--- a/api/rankings/vote.js
+++ b/api/rankings/vote.js
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { readJsonBody } from '../../lib/api-helpers'
 import { loadCommunityPlaces } from '../../lib/community-places'
+import { applyCommunityPlaceFallbacks } from '../../lib/communityRanking/place-fallbacks'
 import { getRedisClient, isRedisConfigured } from '../../lib/communityRanking/kv-client'
 import {
   createBallotHash,
@@ -84,6 +85,9 @@ export default async function handler(req, res) {
 
   const { town, category, choice, turnstileToken, honeypot } = parsed.data
 
+  const normalizedTown = normalizeTown(town)
+  const normalizedCategory = normalizeCategory(category)
+
   if (honeypot && honeypot.trim()) {
     res.status(200).json({ ok: true, ignored: true })
     return
@@ -99,7 +103,10 @@ export default async function handler(req, res) {
     return
   }
 
-  const availablePlaces = loadCommunityPlaces({ town, category, status: 'published' })
+  const availablePlaces = applyCommunityPlaceFallbacks(
+    loadCommunityPlaces({ town, category, status: 'published' }),
+    { normalizedTown, normalizedCategory }
+  )
   const selected = availablePlaces.find(
     (place) => String(place.slug || '').toLowerCase() === String(choice).toLowerCase()
   )
@@ -109,8 +116,6 @@ export default async function handler(req, res) {
     return
   }
 
-  const normalizedTown = normalizeTown(town)
-  const normalizedCategory = normalizeCategory(category)
   const ballotHash = createBallotHash(ip, userAgent, dateKey)
   const ballotKey = `rank:${normalizedCategory}:${normalizedTown}:ballot:${ballotHash}`
   const scoreKey = `rank:${normalizedCategory}:${normalizedTown}:score:${selected.slug}`

--- a/lib/communityRanking/place-fallbacks.js
+++ b/lib/communityRanking/place-fallbacks.js
@@ -1,0 +1,30 @@
+import { UXBRIDGE_PIZZA_OPTIONS } from '../../src/data/uxbridgePizzaOptions'
+
+function normalizeSlug(value) {
+  return String(value || '').toLowerCase()
+}
+
+export function applyCommunityPlaceFallbacks(places, { normalizedTown, normalizedCategory }) {
+  const list = Array.isArray(places) ? [...places] : []
+
+  if (normalizedTown === 'uxbridge' && normalizedCategory === 'pizza') {
+    const knownSlugs = new Set(list.map((place) => normalizeSlug(place.slug)))
+
+    for (const option of UXBRIDGE_PIZZA_OPTIONS) {
+      const slug = option?.id
+      if (!slug) continue
+
+      const normalizedSlug = normalizeSlug(slug)
+      if (knownSlugs.has(normalizedSlug)) continue
+
+      list.push({
+        slug,
+        title: option.label,
+      })
+      knownSlugs.add(normalizedSlug)
+    }
+  }
+
+  return list
+}
+


### PR DESCRIPTION
## Summary
- add a shared fallback that injects the Uxbridge pizza ballot options when loading community places
- use the fallback in the rankings vote and leaderboard handlers so the API accepts the new pizza IDs

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163445d4088324a30b87ff84391681)