### PR TITLE
Create contact hero overlay on background image

### DIFF
--- a/src/ContactPage.js
+++ b/src/ContactPage.js
@@ -67,73 +67,57 @@ function ContactPageV2() {
       </DynamicMetaTags>
       <HeaderShell />
       <main className="bg-slate-50 pb-20">
-        <div className="px-4 pt-10 sm:px-6 sm:pt-12 lg:px-8">
-          <section className="mx-auto max-w-6xl">
-            <div className="flex flex-col items-center gap-10 text-center lg:gap-12">
-              <div className="flex w-full max-w-3xl flex-col items-center gap-6 text-center">
-                <div className="space-y-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-500">
-                    Finally Home Agents
-                  </p>
-                  <h1 className="text-3xl font-semibold tracking-tight text-emerald-950 sm:text-4xl md:text-[2.75rem]">
-                    {config.heroHeadline}
-                  </h1>
-                  <p className="text-base leading-relaxed text-slate-700 sm:text-lg">
-                    {config.heroSubhead}
-                  </p>
-                  {config.responsePledge && (
-                    <p className="text-sm font-medium text-emerald-700 sm:text-base">
-                      {config.responsePledge}
-                    </p>
-                  )}
-                </div>
-                <div className="flex w-full flex-col items-center gap-3 sm:flex-row sm:justify-center">
-                  <Button
-                    size="lg"
-                    onClick={handlePrimary}
-                    className="w-full max-w-xs rounded-2xl sm:w-auto"
-                  >
-                    {config.heroPrimaryCtaLabel || "Send a Message"}
-                  </Button>
-                  {whatsappChannel?.href && (
-                    <a
-                      href={whatsappChannel.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={handleWhatsapp}
-                      className="inline-flex w-full max-w-xs items-center justify-center gap-2 rounded-xl border border-emerald-200 bg-white px-5 py-3 text-base font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-400 hover:text-emerald-800 sm:w-auto"
-                    >
-                      <span className="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-[#25D366] to-[#128C7E] text-white shadow-inner">
-                        <WhatsAppGlyph className="h-5 w-5 text-white" />
-                      </span>
-                      <span className="flex flex-col text-left text-sm leading-tight">
-                        <span>{config.heroSecondaryCtaLabel || "Chat on WhatsApp"}</span>
-                        <span className="text-[11px] font-medium text-emerald-500">
-                          Concierge replies in minutes
-                        </span>
-                      </span>
-                    </a>
-                  )}
-                </div>
-              </div>
-              <div className="relative flex w-full justify-center">
-                <div className="relative w-full max-w-4xl overflow-hidden rounded-[32px] border border-emerald-100 bg-white shadow-[0_32px_90px_rgba(50,97,14,0.18)] aspect-[4/3] sm:aspect-[5/4] md:aspect-[4/3]">
-                  <img
-                    src="/uploads/contact-hero-finally-home-agents.jpg"
-                    alt="Clean desk scene with a smartphone, notebook, and NorthSide GTA and Finally Home Agents branding, representing how to contact the team."
-                    className="h-full w-full object-cover"
-                    loading="lazy"
-                  />
-                </div>
-              </div>
+        <section
+          className="contact-hero"
+          style={{
+            backgroundImage:
+              "url('/uploads/contact-hero-finally-home-agents.jpg')",
+          }}
+        >
+          <div className="contact-hero-content">
+            <p className="contact-hero-eyebrow">Finally Home Agents</p>
+            <h1 className="contact-hero-heading">{config.heroHeadline}</h1>
+            <p className="contact-hero-subhead">{config.heroSubhead}</p>
+            {config.responsePledge && (
+              <p className="contact-hero-response">{config.responsePledge}</p>
+            )}
+            <div className="contact-hero-actions">
+              <Button
+                size="lg"
+                onClick={handlePrimary}
+                className="contact-hero-primary"
+              >
+                {config.heroPrimaryCtaLabel || "Send a Message"}
+              </Button>
+              {whatsappChannel?.href && (
+                <a
+                  href={whatsappChannel.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={handleWhatsapp}
+                  className="contact-hero-secondary"
+                >
+                  <span className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-[#25D366] to-[#128C7E] text-white shadow-inner shadow-black/30 transition-transform duration-200 ease-out hover:scale-105">
+                    <WhatsAppGlyph className="h-5 w-5 text-white" />
+                  </span>
+                  <span className="flex flex-col text-left text-sm leading-tight">
+                    <span>{config.heroSecondaryCtaLabel || "Chat on WhatsApp"}</span>
+                    <span className="text-[11px] font-medium text-emerald-100">
+                      Concierge replies in minutes
+                    </span>
+                  </span>
+                </a>
+              )}
             </div>
-          </section>
+          </div>
+        </section>
 
-          <section className="mx-auto mt-10 max-w-4xl">
+        <div className="px-4 pt-16 sm:px-6 lg:px-8">
+          <section className="mx-auto max-w-4xl">
             <CallbackFormCard />
           </section>
 
-          <section className="mx-auto mt-10 flex max-w-6xl flex-col gap-8 lg:grid lg:grid-cols-[minmax(0,0.65fr)_minmax(0,0.35fr)] lg:items-start lg:gap-12">
+          <section className="mx-auto mt-16 flex max-w-6xl flex-col gap-8 lg:grid lg:grid-cols-[minmax(0,0.65fr)_minmax(0,0.35fr)] lg:items-start lg:gap-12">
             <div className="order-2 space-y-6 lg:order-1" ref={formSectionRef} id="contact-form">
               <div className="relative overflow-hidden rounded-3xl border border-emerald-100 bg-white p-6 pt-10 shadow-xl shadow-emerald-100 sm:p-9 sm:pt-12">
                 <span

--- a/src/index.css
+++ b/src/index.css
@@ -158,6 +158,172 @@ body {
   box-shadow: 0 30px 80px rgba(34, 68, 10, 0.2);
 }
 
+.contact-hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(4rem, 8vw, 6.5rem) clamp(1.5rem, 6vw, 3.5rem);
+  min-height: 72vh;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-radius: 0 0 48px 48px;
+  overflow: hidden;
+  color: #f8fafc;
+}
+
+.contact-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    160deg,
+    rgba(6, 17, 13, 0.78) 0%,
+    rgba(6, 17, 13, 0.62) 45%,
+    rgba(6, 17, 13, 0.75) 100%
+  );
+  z-index: 0;
+}
+
+.contact-hero::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: clamp(8rem, 18vh, 12rem);
+  background: linear-gradient(
+    to bottom,
+    rgba(6, 17, 13, 0.4) 0%,
+    rgba(6, 17, 13, 0.7) 45%,
+    rgba(12, 32, 24, 0.9) 100%
+  );
+  z-index: 0;
+}
+
+.contact-hero-content {
+  position: relative;
+  z-index: 1;
+  width: min(720px, 100%);
+  display: grid;
+  gap: 1.75rem;
+  text-align: center;
+  padding: clamp(2rem, 4vw, 3rem) clamp(1.5rem, 5vw, 3rem);
+  border-radius: 32px;
+  background: rgba(6, 17, 13, 0.52);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 40px 110px rgba(5, 12, 9, 0.55);
+}
+
+.contact-hero-eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: rgba(209, 250, 229, 0.9);
+  margin: 0;
+}
+
+.contact-hero-heading {
+  margin: 0;
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  line-height: 1.1;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: #ffffff;
+}
+
+.contact-hero-subhead {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.3vw, 1.45rem);
+  line-height: 1.7;
+  color: rgba(226, 241, 233, 0.95);
+}
+
+.contact-hero-response {
+  margin: 0;
+  font-size: clamp(0.95rem, 1.9vw, 1.1rem);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: rgba(240, 253, 244, 0.85);
+}
+
+.contact-hero-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.contact-hero-primary {
+  width: 100%;
+  border-radius: 9999px;
+  box-shadow: 0 25px 55px rgba(21, 128, 61, 0.35);
+}
+
+.contact-hero-secondary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.9rem;
+  width: 100%;
+  border-radius: 28px;
+  padding: 0.85rem 1.4rem;
+  border: 1px solid rgba(232, 252, 244, 0.28);
+  background: rgba(15, 46, 32, 0.55);
+  color: #f0fdf4;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 180ms ease, border-color 180ms ease, transform 180ms ease;
+  box-shadow: 0 20px 45px rgba(8, 20, 14, 0.4);
+}
+
+.contact-hero-secondary:hover,
+.contact-hero-secondary:focus-visible {
+  background: rgba(15, 46, 32, 0.7);
+  border-color: rgba(232, 252, 244, 0.45);
+}
+
+.contact-hero-secondary:focus-visible {
+  outline: 3px solid rgba(232, 252, 244, 0.8);
+  outline-offset: 3px;
+}
+
+.contact-hero-secondary span:last-child {
+  color: rgba(240, 253, 244, 0.95);
+}
+
+.contact-hero-secondary span:last-child span:last-child {
+  color: rgba(209, 250, 229, 0.75);
+}
+
+@media (min-width: 640px) {
+  .contact-hero-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .contact-hero-primary,
+  .contact-hero-secondary {
+    width: auto;
+    min-width: 220px;
+  }
+}
+
+@media (max-width: 768px) {
+  .contact-hero {
+    min-height: 62vh;
+    padding: clamp(3.25rem, 8vw, 4rem) clamp(1.25rem, 6vw, 2rem);
+    border-radius: 0 0 32px 32px;
+  }
+
+  .contact-hero-content {
+    gap: 1.35rem;
+    padding: clamp(1.75rem, 6vw, 2.5rem) clamp(1.25rem, 5vw, 2rem);
+  }
+}
+
 .insight-content .insight-inline-media__caption {
   font-size: 0.9rem;
   color: #475569;


### PR DESCRIPTION
## Summary
- restructure the contact hero so the headline and actions sit in an overlay directly on the hero image
- add dedicated styles for the contact hero background, overlay treatment, and responsive layout refinements
- tune the page layout spacing so the image hero leads smoothly into the remaining contact sections

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916476054248324b8cf1d31e3fc4079)