### PR TITLE
Fix TasteHub leaderboard data to use CMS polls

### DIFF
--- a/content/tastehub-polls/best-coffee-newmarket.json
+++ b/content/tastehub-polls/best-coffee-newmarket.json
@@ -10,12 +10,15 @@
   "featured": false,
   "ballot_items": [
     {
+      "id": "pickering-s-coffee-house",
       "name": "Pickering’s Coffee House"
     },
     {
+      "id": "the-maids-cottage-coffee-bar",
       "name": "The Maids’ Cottage Coffee Bar"
     },
     {
+      "id": "stellar-grounds-coffee",
       "name": "Stellar Grounds Coffee"
     }
   ]

--- a/content/tastehub-polls/best-pizza-uxbridge.json
+++ b/content/tastehub-polls/best-pizza-uxbridge.json
@@ -10,13 +10,40 @@
   "featured": true,
   "ballot_items": [
     {
-      "name": "Pizzaville Uxbridge"
+      "id": "boston-pizza-uxbridge",
+      "name": "Boston Pizza – Uxbridge"
     },
     {
-      "name": "Sunny’s Pizzeria"
+      "id": "dominos-pizza-uxbridge",
+      "name": "Domino’s Pizza – Uxbridge"
     },
     {
-      "name": "Domino’s Pizza Uxbridge"
+      "id": "free-topping-pizza",
+      "name": "Free Topping Pizza"
+    },
+    {
+      "id": "canadian-pizza-house",
+      "name": "Canadian Pizza House"
+    },
+    {
+      "id": "pizza-pizza-uxbridge",
+      "name": "Pizza Pizza – Uxbridge"
+    },
+    {
+      "id": "sandford-pizza-house",
+      "name": "Sandford Pizza House"
+    },
+    {
+      "id": "pizza-hut-uxbridge",
+      "name": "Pizza Hut – Uxbridge"
+    },
+    {
+      "id": "papas-pizzaland",
+      "name": "Papa’s Pizzaland"
+    },
+    {
+      "id": "pizzaville-uxbridge",
+      "name": "Pizzaville – Uxbridge"
     }
   ]
 }

--- a/content/tastehub-polls/best-wings-georgina.json
+++ b/content/tastehub-polls/best-wings-georgina.json
@@ -10,12 +10,15 @@
   "featured": true,
   "ballot_items": [
     {
+      "id": "lake-simcoe-arms-pub-restaurant",
       "name": "Lake Simcoe Arms Pub & Restaurant"
     },
     {
+      "id": "tatlows-broiler-bar",
       "name": "Tatlows Broiler Bar"
     },
     {
+      "id": "boston-pizza-keswick",
       "name": "Boston Pizza Keswick"
     }
   ]

--- a/src/components/tastehub/TasteHubPoll.js
+++ b/src/components/tastehub/TasteHubPoll.js
@@ -147,20 +147,28 @@ export default function TasteHubPoll({
   initialLeaderboard,
   onLeaderboardUpdate,
 }) {
-  const { rankingKey, ballotItems = [], status } = poll || {};
+  const rankingKeySource =
+    poll?.rankingKey || poll?.ranking_key || poll?.slug || "";
+  const rankingKey = useMemo(
+    () => rankingKeySource.trim(),
+    [rankingKeySource]
+  );
+
+  const rawBallotItems = poll?.ballotItems || poll?.ballot_items || [];
+  const status = String(poll?.status || "draft").toLowerCase();
   const [selected, setSelected] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [voteStatus, setVoteStatus] = useState("idle");
   const [message, setMessage] = useState("");
 
   const normalizedBallot = useMemo(() => {
-    return Array.isArray(ballotItems)
-      ? ballotItems.map((item) => ({
+    return Array.isArray(rawBallotItems)
+      ? rawBallotItems.map((item) => ({
           ...item,
           id: slugify(item.id || item.name),
         }))
       : [];
-  }, [ballotItems]);
+  }, [rawBallotItems]);
 
   const { data, loading, error, refresh } = useLeaderboard({
     rankingKey,
@@ -318,7 +326,9 @@ export default function TasteHubPoll({
               {message && (
                 <p
                   className={`text-sm ${
-                    voteStatus === "success" || voteStatus === "duplicate"
+                    voteStatus === "success"
+                      ? "inline-flex items-center rounded-full bg-emerald-900/90 px-3 py-1.5 font-semibold text-white shadow-[0_6px_18px_rgba(6,38,21,0.35)]"
+                      : voteStatus === "duplicate"
                       ? "text-emerald-700"
                       : "text-rose-600"
                   }`}


### PR DESCRIPTION
## Summary
- derive TasteHub poll ranking keys and ballot data from the CMS payload so the modal leaderboard can load and refresh reliably
- restyle the success confirmation pill so the “Thanks! Your vote was recorded.” message is readable against the gradient treatment
- migrate the Codex sample polls into the `tastehub_polls` collection with explicit ballot item ids that match the live leaderboard keys

## Testing
- node -e "import('./lib/tastehub/getTasteHubPolls.js').then(async ({getTasteHubPolls}) => {const polls=await getTasteHubPolls(); console.log(JSON.stringify(polls,null,2));})"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176f170e1483249b27ba7b20b16038)