### PR TITLE
Add SEO for TasteHub CMS and submit event page

### DIFF
--- a/public/config.yml
+++ b/public/config.yml
@@ -549,6 +549,50 @@ collections:
             hint: 'Image for link previews (ideally 1200x630). Leave blank to use the existing default.'
             media_folder: '/public/uploads'
             public_folder: '/uploads'
+
+      - label: 'Submit Event Page SEO'
+        name: 'community_submit_event'
+        file: 'public/data/seo/community-submit-event.json'
+        fields:
+          - label: 'Route'
+            name: 'route'
+            widget: 'hidden'
+            default: '/community/submit-event'
+          - label: 'SEO Title'
+            name: 'seo_title'
+            widget: 'string'
+          - label: 'SEO Description'
+            name: 'seo_description'
+            widget: 'text'
+          - label: 'SEO Image'
+            name: 'seo_image'
+            widget: 'image'
+            required: false
+            hint: 'Image for link previews (ideally 1200x630). Leave blank to use the existing default.'
+            media_folder: '/public/uploads'
+            public_folder: '/uploads'
+
+      - label: 'TasteHub CMS Page SEO'
+        name: 'cms_tastehub'
+        file: 'public/data/seo/cms-tastehub.json'
+        fields:
+          - label: 'Route'
+            name: 'route'
+            widget: 'hidden'
+            default: '/cms/tastehub'
+          - label: 'SEO Title'
+            name: 'seo_title'
+            widget: 'string'
+          - label: 'SEO Description'
+            name: 'seo_description'
+            widget: 'text'
+          - label: 'SEO Image'
+            name: 'seo_image'
+            widget: 'image'
+            required: false
+            hint: 'Image for link previews (ideally 1200x630). Leave blank to use the existing default.'
+            media_folder: '/public/uploads'
+            public_folder: '/uploads'
   - name: "socials"
     label: "Socials"
     editor: { preview: false }

--- a/public/data/seo/cms-tastehub.json
+++ b/public/data/seo/cms-tastehub.json
@@ -1,0 +1,6 @@
+{
+  "route": "/cms/tastehub",
+  "seo_title": "TasteHub CMS | NorthSide GTA",
+  "seo_description": "Access the TasteHub CMS to manage polls, ballots, and community-powered content for the NorthSide GTA.",
+  "seo_image": "/Images/og-home.jpg"
+}

--- a/public/data/seo/community-submit-event.json
+++ b/public/data/seo/community-submit-event.json
@@ -1,0 +1,6 @@
+{
+  "route": "/community/submit-event",
+  "seo_title": "Submit a Community Event | NorthSide GTA",
+  "seo_description": "Share your local event with the NorthSide GTA community. Submit your event details and we’ll help get the word out across our community calendar.",
+  "seo_image": "/Images/hero-desktop.jpg"
+}

--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,7 @@ import InsightsPage     from "./InsightsPage";
 import ReferralPartnersPage from "./ReferralPartnersPage";
 import TasteHubPage     from "./TasteHubPage";
 import TasteHubSmartListPage from "./TasteHubSmartListPage";
+import TasteHubCmsPage  from "./TasteHubCmsPage";
 import GlobalDefaultMeta from "./components/seo/GlobalDefaultMeta";
 
 // Load the town slugs right here (no helper to avoid any cyclic import)
@@ -71,6 +72,7 @@ function App() {
         <Route path="/community/events/archive" element={<EventsArchivePage />} />
         <Route path="/community/events/:slug" element={<EventDetailPage />} />
         <Route path="/events/:slug" element={<EventDetailPage />} />
+        <Route path="/cms/tastehub" element={<TasteHubCmsPage />} />
         <Route path="/community/submit-event" element={<SubmitEventPage />} />
         <Route path="/events/archive" element={<EventsArchivePage />} />
         <Route path="/community/events-admin" element={<EventsIndexPage />} />

--- a/src/TasteHubCmsPage.js
+++ b/src/TasteHubCmsPage.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+import DynamicMetaTags from "./components/seo/DynamicMetaTags";
+import { getStaticRouteMeta } from "./components/seo/staticRouteMetaExports";
+
+const TASTE_HUB_CMS_META = getStaticRouteMeta("/cms/tastehub") || {};
+
+export default function TasteHubCmsPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <DynamicMetaTags {...TASTE_HUB_CMS_META} />
+      <iframe
+        src="/cms"
+        title="TasteHub CMS"
+        className="min-h-screen w-full border-0"
+        style={{ minHeight: "100vh" }}
+      />
+    </div>
+  );
+}

--- a/src/community/SubmitEventPage.js
+++ b/src/community/SubmitEventPage.js
@@ -1,10 +1,13 @@
 import React from 'react'
 import classNames from 'classnames'
-import { Helmet } from 'react-helmet-async'
 import { DateTime } from 'luxon'
 import { upload } from '@vercel/blob/client'
 
 import CaptchaWidget from '../components/CaptchaWidget'
+import DynamicMetaTags from '../components/seo/DynamicMetaTags'
+import { getStaticRouteMeta } from '../components/seo/staticRouteMetaExports'
+
+const SUBMIT_EVENT_ROUTE_META = getStaticRouteMeta('/community/submit-event') || {}
 
 const TORONTO_ZONE = 'America/Toronto'
 const MAX_EVENT_DURATION_DAYS = 14
@@ -870,13 +873,7 @@ export default function SubmitEventPage() {
       : []
     return (
       <div className="min-h-screen bg-emerald-950/5 py-12">
-        <Helmet>
-          <title>Submit a Community Event | NorthSide GTA</title>
-          <meta
-            name="description"
-            content="Share your NorthSide GTA community event with Finally Home Agents. Submit your listing for review."
-          />
-        </Helmet>
+        <DynamicMetaTags {...SUBMIT_EVENT_ROUTE_META} />
         <div className="mx-auto max-w-4xl px-4">
           <div className="rounded-3xl border border-emerald-200 bg-white p-8 shadow-xl shadow-emerald-800/10">
             <h1 className="text-3xl font-semibold text-emerald-900">Thanks! Your event is pending review.</h1>
@@ -965,13 +962,7 @@ export default function SubmitEventPage() {
 
   return (
     <div className="min-h-screen bg-emerald-950/5 py-12">
-      <Helmet>
-        <title>Submit a Community Event | NorthSide GTA</title>
-        <meta
-          name="description"
-          content="Share upcoming events happening across Georgina, East Gwillimbury, Aurora, Stouffville, Uxbridge, Scugog, and nearby NorthSide GTA towns."
-        />
-      </Helmet>
+      <DynamicMetaTags {...SUBMIT_EVENT_ROUTE_META} />
       <div className="mx-auto max-w-5xl px-4">
         <div className="mx-auto max-w-3xl text-center">
           <span className="inline-flex items-center rounded-full border border-emerald-300 bg-emerald-50 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-800">

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -116,6 +116,22 @@ const STATIC_ROUTE_META_CONFIGS = [
     },
   },
   {
+    route: "/community/submit-event",
+    meta: {
+      route: "/community/submit-event",
+      documentTitle: "Submit a Community Event | NorthSide GTA",
+      title: "Submit a Community Event | NorthSide GTA",
+      description:
+        "Share your local event with the NorthSide GTA community. Submit your event details and we’ll help get the word out across our community calendar.",
+      canonicalUrl: "https://northsidegta.ca/community/submit-event",
+      ogType: "website",
+      ogImage: "/Images/hero-desktop.jpg",
+      twitterCard: "summary_large_image",
+      twitterImage: "/Images/hero-desktop.jpg",
+      siteName: "NorthSide GTA",
+    },
+  },
+  {
     route: "/media",
     meta: {
       route: "/media",
@@ -200,6 +216,25 @@ const STATIC_ROUTE_META_CONFIGS = [
       twitterCard: "summary_large_image",
       twitterImage: "/Images/og-home.jpg",
       siteName: "NorthSide GTA",
+    },
+  },
+  {
+    route: "/cms/tastehub",
+    meta: {
+      route: "/cms/tastehub",
+      documentTitle: "TasteHub CMS | NorthSide GTA",
+      title: "TasteHub CMS | NorthSide GTA",
+      description:
+        "Access the TasteHub CMS to manage polls, ballots, and community-powered content for the NorthSide GTA.",
+      canonicalUrl: "https://northsidegta.ca/cms/tastehub",
+      ogType: "website",
+      ogImage: "/Images/og-home.jpg",
+      twitterCard: "summary_large_image",
+      twitterImage: "/Images/og-home.jpg",
+      siteName: "NorthSide GTA",
+      additionalMeta: [
+        { name: "robots", content: "noindex,nofollow" },
+      ],
     },
   },
 ];


### PR DESCRIPTION
## Summary
- add static and CMS SEO entries for the TasteHub CMS and community submit event routes
- wire the TasteHub CMS route and submit event form page into the DynamicMetaTags system for consistent metadata

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b36ca419483248f0d4522c87c014a)