### PR TITLE
Add dynamic TasteHub poll SEO and sharing metadata

### DIFF
--- a/public/config.yml
+++ b/public/config.yml
@@ -283,18 +283,20 @@ collections:
     identifier_field: 'slug'
     slug: '{{slug}}'
     fields:
-      - { name: 'title', label: 'Title' }
+      - name: 'title'
+        label: 'Poll Title'
+        hint: "This is the name of the poll. Used as the page title, SEO title, and social share title."
       - name: 'slug'
-        label: 'Slug'
+        label: 'Poll Slug (URL)'
         widget: 'string'
         pattern:
           - '^[a-z0-9-]+$'
           - 'Use lowercase letters, numbers, and dashes only'
-        hint: "Used in the poll URL (e.g. 'best-pizza-uxbridge')."
+        hint: "This determines the URL of the poll page (e.g., best-pizza-uxbridge). Keep it short, lowercase, and hyphenated."
       - name: 'town'
         label: 'Town'
         widget: 'select'
-        hint: 'Select where this poll belongs (appears as the location pill).'
+        hint: 'Select the town this poll belongs to. Used for filtering, SEO metadata, and structured data.'
         options:
           - 'Georgina'
           - 'East Gwillimbury'
@@ -304,9 +306,10 @@ collections:
           - 'Uxbridge'
           - 'Scugog'
       - name: 'category'
-        label: 'Category'
+        label: 'Food / Category Type'
         widget: 'select'
         required: true
+        hint: 'Select the category (e.g., Pizza, Sushi, Burgers). Used for filtering, SEO metadata, and structured data.'
         options:
           - 'Pizza'
           - 'Wings'
@@ -338,12 +341,12 @@ collections:
         widget: 'string'
         required: false
         hint: "If you need a category that isn’t in the list above, type it here and we’ll use this instead of the dropdown value."
-      - label: 'Town Area / Hamlet'
+      - label: 'Hamlet / Area (Optional)'
         name: 'town_area'
         widget: 'string'
         required: false
         hint: |
-          Optional area inside the town (hamlet or neighbourhood). Examples:
+          Optional. Select or enter the hamlet/area within the town. Used for structured data and local SEO.
           • Georgina – Keswick, Sutton, Jackson’s Point, Pefferlaw, Virginia, Udora, Baldwin, Roches Point
           • East Gwillimbury – Holland Landing, Sharon, Queensville, Mount Albert, River Drive Park, Brown Hill, Holt
           • Newmarket – Downtown/Main Street, Stonehaven, Glenway, Woodland Hill, Armitage, Summerhill, Bristol-London
@@ -361,18 +364,18 @@ collections:
           - { label: 'Draft', value: 'draft' }
         default: 'draft'
       - name: 'description'
-        label: 'Description'
+        label: 'Poll Description (SEO + Social Preview) (optional)'
         widget: 'text'
-        hint: "Short teaser shown on cards and in the modal (1–2 sentences)."
+        hint: "Optional. If provided, this becomes the SEO description and social preview text. If left empty, a high-engagement TasteHub-style description will be auto-generated from the poll title."
       - name: 'ranking_key'
         label: 'Ranking Key'
         widget: 'string'
         hint: "Unique key shared with Upstash for this poll (e.g. 'tastehub_uxbridge_pizza_2025')."
       - name: 'image'
-        label: 'Feature Image'
+        label: 'Featured Image (Hero + SEO + Social Sharing) (recommended)'
         widget: 'image'
         required: false
-        hint: 'Optional 1600×900 image used on cards and detail headers. Upload JPG/PNG for best quality.'
+        hint: 'Recommended. This image becomes the hero background on the poll page AND the SEO/OG/social preview image. If missing, the default TasteHub Poll fallback image will be used.'
       - name: 'featured'
         label: 'Featured'
         widget: 'boolean'
@@ -388,10 +391,10 @@ collections:
             widget: "hidden"
         hint: "Use the Smart Fill button injected below."
       - name: 'ballot_items'
-        label: 'Ballot Items'
+        label: 'Voting Options'
         widget: 'list'
         allow_add: true
-        hint: 'Add every option voters can choose from. Order is preserved in the voting UI.'
+        hint: 'The list of places users can vote for. These appear on the poll page and in the live rankings.'
         fields:
           - name: 'name'
             label: 'Name'

--- a/src/TasteHubPage.js
+++ b/src/TasteHubPage.js
@@ -17,6 +17,10 @@ const TOWNS = [
   "Scugog",
 ];
 
+const PRODUCTION_ORIGIN = "https://northsidegta.ca";
+const DEFAULT_POLL_IMAGE = "/seo/tastehub-default-poll-share.jpg";
+const REGION_NAME = "NorthSide GTA";
+
 const SORT_OPTIONS = [
   { value: "trending", label: "Trending" },
   { value: "votes", label: "Most Votes" },
@@ -30,6 +34,39 @@ function slugify(value) {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/-{2,}/g, "-")
     .replace(/^-+|-+$/g, "");
+}
+
+function getPollImagePath(poll) {
+  const value = poll?.image ? String(poll.image).trim() : "";
+  return value || DEFAULT_POLL_IMAGE;
+}
+
+function generatePollDescription(poll) {
+  const title = poll?.title ? String(poll.title).trim() : "";
+  const town = poll?.town ? String(poll.town).trim() : "";
+  const category = poll?.displayCategory || poll?.category || "";
+  const baseDescription = poll?.description ? String(poll.description).trim() : "";
+
+  if (baseDescription) return baseDescription;
+
+  const locationSnippet = [category, town].filter(Boolean).join(" in ");
+  const focus = locationSnippet || title || "this TasteHub poll";
+
+  return `Help crown ${focus}! Vote now and see live TasteHub community rankings across the ${REGION_NAME}.`;
+}
+
+function toAbsoluteUrl(pathOrUrl, origin = PRODUCTION_ORIGIN) {
+  const value = String(pathOrUrl || "").trim();
+  if (!value) return "";
+  if (/^https?:\/\//i.test(value)) return value;
+  const base = origin || PRODUCTION_ORIGIN;
+  if (value.startsWith("/")) return `${base}${value}`;
+  return `${base}/${value}`;
+}
+
+function getPreviewOrigin() {
+  if (typeof window === "undefined") return "";
+  return window.location?.origin || "";
 }
 
 function buildLeaderboardUrl(rankingKey, ballotItems = []) {
@@ -293,13 +330,12 @@ function PollDetailModal({ poll, leaderboard, onClose, onLeaderboardUpdate }) {
     typeof window !== "undefined"
       ? `${window.location.origin}/tastehub/${poll.slug}`
       : `https://northsidegta.ca/tastehub/${poll.slug}`;
-  const bannerStyles = poll.image
-    ? {
-        backgroundImage: `linear-gradient(145deg, rgba(6, 78, 59, 0.94), rgba(217, 119, 6, 0.75)), url(${poll.image})`,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-      }
-    : undefined;
+  const heroImage = getPollImagePath(poll);
+  const bannerStyles = {
+    backgroundImage: `linear-gradient(145deg, rgba(6, 78, 59, 0.94), rgba(217, 119, 6, 0.75)), url(${heroImage})`,
+    backgroundSize: "cover",
+    backgroundPosition: "center",
+  };
 
   return (
     <div className="fixed inset-0 z-[70] flex items-center justify-center bg-emerald-950/80 px-4 py-12 backdrop-blur-sm">
@@ -351,6 +387,11 @@ export default function TasteHubPage() {
   const navigate = useNavigate();
   const params = useParams();
   const slugParam = (params?.slug || "").toLowerCase();
+
+  const pollForSeo = useMemo(() => {
+    if (!slugParam) return null;
+    return polls.find((poll) => poll.slug === slugParam) || null;
+  }, [polls, slugParam]);
 
   useEffect(() => {
     let cancelled = false;
@@ -510,6 +551,92 @@ export default function TasteHubPage() {
     return scores;
   }, [polls, leaderboards]);
 
+  const pollSeoData = useMemo(() => {
+    if (!pollForSeo) return null;
+
+    const pollTitle = pollForSeo.title || "TasteHub Poll";
+    const documentTitle = `${pollTitle} | TasteHub | NorthSide GTA`;
+    const shareTitle = `${pollTitle} – TasteHub Community Rankings`;
+    const description = generatePollDescription(pollForSeo);
+    const canonicalUrl = `${PRODUCTION_ORIGIN}/tastehub/${pollForSeo.slug}`;
+    const previewOrigin = getPreviewOrigin();
+    const previewUrl = previewOrigin ? `${previewOrigin}/tastehub/${pollForSeo.slug}` : canonicalUrl;
+    const ogUrl = previewOrigin && !previewOrigin.includes("northsidegta.ca") ? previewUrl : canonicalUrl;
+    const imagePath = getPollImagePath(pollForSeo);
+    const absoluteImage = toAbsoluteUrl(imagePath, PRODUCTION_ORIGIN);
+    const townArea = pollForSeo.townArea ? String(pollForSeo.townArea).trim() : "";
+    const townName = pollForSeo.town ? String(pollForSeo.town).trim() : REGION_NAME;
+    const voteCount = leaderboards[pollForSeo.rankingKey]?.totalBallots;
+
+    const schemaObject = {
+      "@context": "https://schema.org",
+      "@type": "CreativeWork",
+      name: pollTitle,
+      description,
+      url: canonicalUrl,
+      image: absoluteImage,
+      identifier: pollForSeo.slug,
+      genre: pollForSeo.displayCategory || pollForSeo.category || "TasteHub poll",
+      about: pollForSeo.displayCategory ? { "@type": "Thing", name: pollForSeo.displayCategory } : undefined,
+      inLanguage: "en-CA",
+      isPartOf: "TasteHub Community Rankings",
+      keywords: [
+        pollForSeo.displayCategory || pollForSeo.category,
+        pollForSeo.town,
+        townArea,
+        "TasteHub",
+        REGION_NAME,
+      ]
+        .filter(Boolean)
+        .join(", "),
+      areaServed: [
+        pollForSeo.town ? { "@type": "AdministrativeArea", name: pollForSeo.town } : null,
+        { "@type": "AdministrativeArea", name: REGION_NAME },
+      ].filter(Boolean),
+      spatialCoverage: {
+        "@type": "Place",
+        name: townArea ? `${townArea}, ${townName}` : townName,
+        address: {
+          "@type": "PostalAddress",
+          addressLocality: townArea || townName,
+          addressRegion: REGION_NAME,
+        },
+      },
+      audience: { "@type": "Audience", audienceType: `${REGION_NAME} food fans` },
+      creator: { "@type": "Organization", name: "TasteHub by NorthSide GTA" },
+    };
+
+    if (typeof voteCount === "number" && voteCount > 0) {
+      schemaObject.interactionStatistic = {
+        "@type": "InteractionCounter",
+        interactionType: "https://schema.org/VoteAction",
+        userInteractionCount: voteCount,
+      };
+    }
+
+    const schema = JSON.stringify(schemaObject, null, 2);
+
+    return {
+      meta: {
+        documentTitle,
+        title: documentTitle,
+        ogTitle: shareTitle,
+        twitterTitle: shareTitle,
+        description,
+        ogDescription: description,
+        twitterDescription: description,
+        canonicalUrl,
+        ogType: "website",
+        ogImage: imagePath,
+        twitterImage: imagePath,
+        siteName: REGION_NAME,
+        twitterCard: "summary_large_image",
+        additionalMeta: [{ property: "og:url", content: ogUrl }],
+      },
+      schema,
+    };
+  }, [leaderboards, pollForSeo]);
+
   const handleOpenPoll = (poll) => {
     setUnknownSlug("");
     setActivePoll(poll);
@@ -539,9 +666,14 @@ export default function TasteHubPage() {
     filtersRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
+  const metaConfig = pollSeoData?.meta || getStaticRouteMeta("/tastehub");
+  const pollSchema = pollSeoData?.schema || "";
+
   return (
     <div className="flex min-h-screen flex-col bg-[#fbfdf8] text-slate-900">
-      <DynamicMetaTags {...getStaticRouteMeta("/tastehub")} />
+      <DynamicMetaTags {...metaConfig}>
+        {pollSchema && <script type="application/ld+json">{pollSchema}</script>}
+      </DynamicMetaTags>
       <HeaderShell />
 
       <main className="flex-1">

--- a/src/components/seo/__generatedSiteSeo.json
+++ b/src/components/seo/__generatedSiteSeo.json
@@ -14,6 +14,11 @@
     "seo_description": "Find your perfect home north of Toronto. Expert guidance, local insight, and personalized support from the NorthSide GTA real estate team | Finally Home Agents",
     "seo_image": "/uploads/buyers-page-seo.jpg"
   },
+  "/cms/tastehub": {
+    "seo_title": "TasteHub CMS | NorthSide GTA",
+    "seo_description": "Access the TasteHub CMS to manage polls, ballots, and community-powered content for the NorthSide GTA.",
+    "seo_image": "/Images/og-home.jpg"
+  },
   "/community": {
     "seo_title": "NorthSide GTA Events & Local Happenings | Finally Home Agents",
     "seo_description": "Find upcoming community events, farmers markets, and local gatherings across the NorthSide GTA — from Uxbridge to Georgina and Stouffville. Explore what’s happening north of Toronto with Finally Home Agents.",
@@ -22,6 +27,11 @@
   "/community/events": {
     "seo_title": "NorthSide GTA Events | What's On Across Aurora, Uxbridge & Beyond",
     "seo_description": "Always-updated guide to NorthSide GTA events across Aurora, Uxbridge, Georgina, Stouffville, East Gwillimbury, Newmarket and Scugog.",
+    "seo_image": "/Images/hero-desktop.jpg"
+  },
+  "/community/submit-event": {
+    "seo_title": "Submit a Community Event | NorthSide GTA",
+    "seo_description": "Share your local event with the NorthSide GTA community. Submit your event details and we’ll help get the word out across our community calendar.",
     "seo_image": "/Images/hero-desktop.jpg"
   },
   "/contact": {


### PR DESCRIPTION
## Summary
- update TasteHub poll pages to source hero/preview imagery from featured images with fallbacks and generate poll-specific SEO metadata
- add structured data and dynamic OG/Twitter tags per poll including preview-aware URLs and generated descriptions
- refresh CMS poll field labels and help text to highlight SEO/social usage and fallback behaviors

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5a24a6bc832493bec645eafb09b8)