### PR TITLE
Prevent global default meta tags on TasteHub routes

### DIFF
--- a/src/components/seo/GlobalDefaultMeta.js
+++ b/src/components/seo/GlobalDefaultMeta.js
@@ -1,11 +1,20 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
+import { useLocation } from "react-router-dom";
 
 import { getMetaTagsFromData } from "./metaTagUtils";
 import renderHelmetTag from "./renderHelmetTag";
 import { DEFAULT_GLOBAL_META_CONFIG } from "./staticRouteMetaExports";
 
 export default function GlobalDefaultMeta() {
+  const location = useLocation();
+  const pathname = location?.pathname || "";
+  const isTasteHubRoute = pathname.startsWith("/tastehub");
+
+  if (isTasteHubRoute) {
+    return null;
+  }
+
   const meta = getMetaTagsFromData(DEFAULT_GLOBAL_META_CONFIG);
   const tags = meta && Array.isArray(meta.tags) ? meta.tags : [];
 


### PR DESCRIPTION
## Summary
- stop rendering the global default meta tags on TasteHub routes so poll-specific SEO remains the only source of social tags

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b60ac5ccc8324a56754916a8d7266)