### PR TITLE
Add dedicated video page for 45 Ken Bishop Way listing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ import GlobalDefaultMeta from "./components/seo/GlobalDefaultMeta";
 import GlobalStructuredData from "./components/seo/GlobalStructuredData";
 import ThankYou209BarriePage from "./ThankYou209BarriePage";
 import Inquiry209BarrieStreetPage from "./listings/Inquiry209BarrieStreetPage";
+import KenBishopWayVideoPage from "./listings/KenBishopWayVideoPage";
 import EventsReviewPage from "./community/EventsReviewPage";
 import OptionOnePage from "./membership/OptionOnePage";
 import OptionTwoPage from "./membership/OptionTwoPage";
@@ -83,6 +84,7 @@ function App() {
           <Route path="/thank-you"     element={<ThankYouPage />} />
           <Route path="/thank-you-209-barrie-st" element={<ThankYou209BarriePage />} />
           <Route path="/listings/209-barrie-street-thornton-inquiry" element={<Inquiry209BarrieStreetPage />} />
+          <Route path="/listings/45-ken-bishop-way-video" element={<KenBishopWayVideoPage />} />
           <Route path="/about"        element={<AboutPage />} />
           <Route path="/buyers"       element={<BuyersPage />} />
           <Route path="/sellers"      element={<SellersPage />} />

--- a/src/listings/KenBishopWayVideoPage.js
+++ b/src/listings/KenBishopWayVideoPage.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+const VIDEO_URL = "https://videos.aryeo.com/listings/019ddebf-9de8-72b6-8fa3-9b09b23b6b0b/a1ab3e4b-7a23-41c0-9dd3-3d74fa97892c.mp4";
+
+export default function KenBishopWayVideoPage() {
+  return (
+    <main className="min-h-screen bg-black text-white flex items-center justify-center p-4">
+      <section className="w-full max-w-5xl">
+        <h1 className="text-2xl md:text-3xl font-semibold mb-4 text-center">
+          45 Ken Bishop Way — Listing Video
+        </h1>
+        <div className="rounded-xl overflow-hidden shadow-2xl bg-black">
+          <video className="w-full h-auto" controls playsInline preload="metadata" aria-label="Listing video for 45 Ken Bishop Way">
+            <source src={VIDEO_URL} type="video/mp4" />
+            Your browser does not support the video tag.
+          </video>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a single, shareable page that hosts the listing video for 45 Ken Bishop Way so the MP4 can be embedded and played natively in the site.

### Description
- Add a new React component `src/listings/KenBishopWayVideoPage.js` that renders a focused, responsive layout with an HTML5 `<video>` player pointed at the provided Aryeo MP4 URL.
- Wire the component into the client router by importing it in `src/App.js` and registering a route at `/listings/45-ken-bishop-way-video`.
- Keep the implementation minimal and accessible with `controls`, `playsInline`, `preload="metadata"`, and an `aria-label`.

### Testing
- Ran `npm run build`, which completed successfully and produced a production build but emitted non-blocking warnings about source maps and a stale `browserslist` database.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f44467748324bdc5872600273029)