### PR TITLE
Listing: 5670 Thomas — fix social preview metadata and custom-domain redirects

### DIFF
--- a/src/listings/ThomasDriveListingPage.js
+++ b/src/listings/ThomasDriveListingPage.js
@@ -5,10 +5,10 @@ import DynamicMetaTags from "../components/seo/DynamicMetaTags";
 import { getFormEndpoint } from "../components/contact/contactConfig";
 
 const ROUTE = "/listings/5670-thomas-drive-baldwin";
-const CANONICAL = `https://www.northsidegta.ca${ROUTE}`;
+const CANONICAL = `https://northsidegta.ca${ROUTE}`;
 const VIDEO_URL = "https://listings.wylieford.com/videos/019e1822-d5e0-70a4-bcad-11c5e77acb82";
 const BRAND_URL = "https://listings.wylieford.com/sites/5670-thomas-drive-baldwin-on-l0e-1a0-24719268/branded";
-const OG_IMAGE = "https://www.northsidegta.ca/Images/5670-thomas-drive-og.jpg";
+const OG_IMAGE = "https://northsidegta.ca/Images/5670-thomas-drive-og.jpg";
 
 const statPills = [
   ["Bedrooms", "2"],
@@ -122,7 +122,7 @@ export default function ThomasDriveListingPage() {
         provider: {
           "@type": "RealEstateAgent",
           name: "Finally Home Agents",
-          url: "https://www.northsidegta.ca/",
+          url: "https://northsidegta.ca/",
         },
       },
       {
@@ -146,8 +146,8 @@ export default function ThomasDriveListingPage() {
         "@type": "BreadcrumbList",
         "@id": `${CANONICAL}#breadcrumbs`,
         itemListElement: [
-          { "@type": "ListItem", position: 1, name: "Home", item: "https://www.northsidegta.ca/" },
-          { "@type": "ListItem", position: 2, name: "Listings", item: "https://www.northsidegta.ca/listings" },
+          { "@type": "ListItem", position: 1, name: "Home", item: "https://northsidegta.ca/" },
+          { "@type": "ListItem", position: 2, name: "Listings", item: "https://northsidegta.ca/listings" },
           { "@type": "ListItem", position: 3, name: "5670 Thomas Drive, Baldwin", item: CANONICAL },
         ],
       },

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,21 @@
 {
   "redirects": [
+    {
+      "source": "/",
+      "has": [
+        { "type": "host", "value": "5670thomasdr.ca" }
+      ],
+      "destination": "https://northsidegta.ca/listings/5670-thomas-drive-baldwin",
+      "statusCode": 308
+    },
+    {
+      "source": "/",
+      "has": [
+        { "type": "host", "value": "www.5670thomasdr.ca" }
+      ],
+      "destination": "https://northsidegta.ca/listings/5670-thomas-drive-baldwin",
+      "statusCode": 308
+    },
     { "source": "/admin", "destination": "/cms", "statusCode": 308 },
     { "source": "/admin/(.*)", "destination": "/cms/$1", "statusCode": 308 }
   ],


### PR DESCRIPTION
### Motivation
- Social previews for the custom domain `5670thomasdr.ca` were using the site-wide/default metadata instead of the listing-specific metadata, causing incorrect title/image when sharing the custom domain.  
- The listing needs an absolute OG image and canonical/OG URLs on the final live domain to ensure scrapers (Facebook, Twitter, etc.) pick up the listing-specific title and image.  

### Description
- Updated the listing component metadata to use the non-`www` canonical domain by changing `CANONICAL` to `https://northsidegta.ca/listings/5670-thomas-drive-baldwin`.  
- Changed the OG image to the absolute URL `https://northsidegta.ca/Images/5670-thomas-drive-og.jpg` and aligned structured-data/provider URLs and breadcrumbs to the same canonical domain.  
- Ensured the route continues to emit explicit social meta via `DynamicMetaTags` (title, description, `og:*`, `twitter:*`, and `og:url`).  
- Added host-based redirects to `vercel.json` so both `5670thomasdr.ca` and `www.5670thomasdr.ca` route directly to `https://northsidegta.ca/listings/5670-thomas-drive-baldwin` with a `308` redirect.  

### Testing
- Located and inspected the listing component and meta utilities with `rg` to confirm the route has hard-coded page-specific metadata and that `DynamicMetaTags` will emit the expected tags (success).  
- Verified the OG image file exists in the build `public/Images/5670-thomas-drive-og.jpg` (success).  
- Fetched the live page source with `curl` and grepped for social tags using `curl -sL https://northsidegta.ca/listings/5670-thomas-drive-baldwin | rg -n "og:title|og:image|canonical|twitter:title|twitter:description|twitter:image|og:url"` to validate expected tags on production (ran successfully; live output is subject to current deployment state).  
- Inspected `vercel.json` to confirm host-based redirect rules for the custom domain are present (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035bdf5fc8832483c351d6725d76b6)