### PR TITLE
Render server-side social preview metadata for 5670 Thomas Drive listing

### DIFF
--- a/public/listings/5670-thomas-drive-baldwin/index.html
+++ b/public/listings/5670-thomas-drive-baldwin/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" >
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="facebook-domain-verification" content="1tfwypal0s72obxs9238figl03nk5i" >
+    <!-- Favicons -->
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png">
+    <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png">
+    <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128x128.png">
+    <link rel="icon" type="image/png" sizes="256x256" href="/favicon-256x256.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/favicon-512x512.png">
+
+    <!-- Apple Touch Icons -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" >
+    <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" >
+    <link rel="apple-touch-icon" sizes="167x167" href="/apple-touch-icon-167x167.png" >
+
+    <!-- Android / PWA -->
+    <meta name="theme-color" content="#23470a">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" >
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin >
+    <link       href="https://fonts.googleapis.com/css2?family=Blinker:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    >
+
+  
+    <title>5670 Thomas Drive, Baldwin ON | Detached Bungalow for Sale</title>
+    <meta name="description" content="Explore 5670 Thomas Drive in Baldwin, Georgina. View the walkthrough video, photos, floor plans, listing details, and request a showing with Finally Home Agents." >
+    <link rel="canonical" href="https://northsidegta.ca/listings/5670-thomas-drive-baldwin" >
+    <meta property="og:type" content="website" >
+    <meta property="og:title" content="5670 Thomas Drive, Baldwin ON | Detached Bungalow for Sale" >
+    <meta property="og:description" content="Explore 5670 Thomas Drive in Baldwin, Georgina. View the walkthrough video, photos, floor plans, listing details, and request a showing with Finally Home Agents." >
+    <meta property="og:url" content="https://northsidegta.ca/listings/5670-thomas-drive-baldwin" >
+    <meta property="og:image" content="https://northsidegta.ca/Images/5670-thomas-drive-og.jpg" >
+    <meta property="og:image:width" content="1200" >
+    <meta property="og:image:height" content="630" >
+    <meta property="og:image:alt" content="5670 Thomas Drive in Baldwin, Georgina" >
+    <meta property="og:site_name" content="NorthSide GTA" >
+    <meta name="twitter:card" content="summary_large_image" >
+    <meta name="twitter:title" content="5670 Thomas Drive, Baldwin ON | Detached Bungalow for Sale" >
+    <meta name="twitter:description" content="Explore 5670 Thomas Drive in Baldwin, Georgina. View the walkthrough video, photos, floor plans, listing details, and request a showing with Finally Home Agents." >
+    <meta name="twitter:image" content="https://northsidegta.ca/Images/5670-thomas-drive-og.jpg" >
+    <meta name="twitter:image:alt" content="5670 Thomas Drive in Baldwin, Georgina" >
+    <meta name="keywords" content="NorthSide GTA, real estate, homes for sale North GTA, sell my home, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog" >
+    <meta property="og:image:secure_url" content="https://northsidegta.ca/Images/5670-thomas-drive-og.jpg" ></head>
+  <body>
+    <div id="root"></div>
+    <script src="https://cdn.pulse.is/livechat/loader.js" data-live-chat-id="68fa76a75fc77f1bca09a31a" async></script>
+  </body>
+</html>

--- a/scripts/generate-static-route-html.js
+++ b/scripts/generate-static-route-html.js
@@ -119,7 +119,6 @@ function mergeMetaTags(baseTags, routeMetaConfig) {
 
 function resolveTagKey(tag) {
   if (!tag || typeof tag !== "object") return "";
-  if (tag.key) return tag.key;
   if (tag.type === "meta") {
     const attrs = tag.attributes || {};
     if (attrs.name) return `meta:name:${attrs.name}`;

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -163,6 +163,34 @@ const STATIC_ROUTE_META_CONFIGS = [
       siteName: "NorthSide GTA",
     },
   },
+
+  {
+    route: "/listings/5670-thomas-drive-baldwin",
+    meta: {
+      route: "/listings/5670-thomas-drive-baldwin",
+      documentTitle: "5670 Thomas Drive, Baldwin ON | Detached Bungalow for Sale",
+      title: "5670 Thomas Drive, Baldwin ON | Detached Bungalow for Sale",
+      description:
+        "Explore 5670 Thomas Drive in Baldwin, Georgina. View the walkthrough video, photos, floor plans, listing details, and request a showing with Finally Home Agents.",
+      canonicalUrl: "https://northsidegta.ca/listings/5670-thomas-drive-baldwin",
+      ogType: "website",
+      ogImage: "https://northsidegta.ca/Images/5670-thomas-drive-og.jpg",
+      ogImageAlt: "5670 Thomas Drive in Baldwin, Georgina",
+      twitterCard: "summary_large_image",
+      twitterTitle: "5670 Thomas Drive, Baldwin ON | Detached Bungalow for Sale",
+      twitterDescription:
+        "Explore 5670 Thomas Drive in Baldwin, Georgina. View the walkthrough video, photos, floor plans, listing details, and request a showing with Finally Home Agents.",
+      twitterImage: "https://northsidegta.ca/Images/5670-thomas-drive-og.jpg",
+      twitterImageAlt: "5670 Thomas Drive in Baldwin, Georgina",
+      siteName: "NorthSide GTA",
+      additionalMeta: [
+        { property: "og:image:secure_url", content: "https://northsidegta.ca/Images/5670-thomas-drive-og.jpg" },
+        { property: "og:image:width", content: "1200" },
+        { property: "og:image:height", content: "630" },
+        { property: "og:url", content: "https://northsidegta.ca/listings/5670-thomas-drive-baldwin" }
+      ],
+    },
+  },
   {
     route: "/media",
     meta: {


### PR DESCRIPTION
### Motivation
- Social crawlers were seeing the site-default preview because listing metadata was injected client-side after React hydration, which many crawlers do not execute. 
- The listing `/listings/5670-thomas-drive-baldwin` must return the exact required title, description, canonical, Open Graph and Twitter tags in the initial raw HTML response so shares show the listing-specific preview.

### Description
- Added a dedicated static route SEO entry for `/listings/5670-thomas-drive-baldwin` in `src/components/seo/staticRouteMetaConfigs.mjs` with the exact `title`, `description`, `canonicalUrl`, `og:image` (and `og:image:secure_url`), `og:image` dimensions, `og:url`, and Twitter tags required.  
- Updated `scripts/generate-static-route-html.js` to dedupe/merge meta tags by semantic identity (`meta:name:...`, `meta:property:...`, `link:rel:...`, and `document-title`) so route-level tags reliably replace defaults and avoid duplicate/conflicting OG tags.  
- Generated a static HTML shell at `public/listings/5670-thomas-drive-baldwin/index.html` that injects the listing metadata into the `<head>` so crawlers receive it before React hydrates.  
- No visual page layout or client-side SEO usage was removed; client-side `DynamicMetaTags` remains for browser behavior.

### Testing
- Ran `node scripts/generate-static-route-html.js` which completed and reported creation of static route pages (success).  
- Verified the generated HTML contains all required tags using `rg -n` and a small Python assertion script against `public/listings/5670-thomas-drive-baldwin/index.html` (checks for `5670 Thomas Drive`, `5670-thomas-drive-og.jpg`, `og:title`, canonical, `og:image:secure_url`, `og:image:width`, `og:image:height`, and Twitter tags) and all assertions passed locally.  
- Attempted live verification with `curl -L https://northsidegta.ca/listings/5670-thomas-drive-baldwin | grep -i "5670-thomas-drive-og\|og:title"` but the environment returned a network tunnel `403`, so live-domain `curl` could not be completed here; the locally generated raw HTML contains the required metadata and should pass post-deploy checks.  
- Build-related generation and tag-merge logic changes were exercised by the static generation script and produced the expected output (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035ed7f9448324a620809e219668af)