### PR TITLE
Add 33 St Augustine Drive, Brooklin inquiry page and route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ import GlobalDefaultMeta from "./components/seo/GlobalDefaultMeta";
 import GlobalStructuredData from "./components/seo/GlobalStructuredData";
 import ThankYou209BarriePage from "./ThankYou209BarriePage";
 import Inquiry209BarrieStreetPage from "./listings/Inquiry209BarrieStreetPage";
+import Inquiry33StAugustineDriveBrooklinPage from "./listings/Inquiry33StAugustineDriveBrooklinPage";
 import KenBishopWayVideoPage from "./listings/KenBishopWayVideoPage";
 import ThomasDriveListingPage from "./listings/ThomasDriveListingPage";
 import StAugustineDriveListingPage from "./listings/StAugustineDriveListingPage";
@@ -86,6 +87,7 @@ function App() {
           <Route path="/thank-you"     element={<ThankYouPage />} />
           <Route path="/thank-you-209-barrie-st" element={<ThankYou209BarriePage />} />
           <Route path="/listings/209-barrie-street-thornton-inquiry" element={<Inquiry209BarrieStreetPage />} />
+          <Route path="/listings/33-st-augustine-drive-brooklin-inquiry" element={<Inquiry33StAugustineDriveBrooklinPage />} />
           <Route path="/listings/45-ken-bishop-way-video" element={<KenBishopWayVideoPage />} />
           <Route path="/listings/5670-thomas-drive-baldwin" element={<ThomasDriveListingPage />} />
           <Route path="/listings/33-st-augustine-drive-brooklin" element={<StAugustineDriveListingPage />} />

--- a/src/listings/Inquiry33StAugustineDriveBrooklinPage.js
+++ b/src/listings/Inquiry33StAugustineDriveBrooklinPage.js
@@ -1,0 +1,7 @@
+import React from "react";
+import ListingInquiryPage from "./ListingInquiryPage";
+import { listingInquiry33StAugustineDriveBrooklin } from "./listingInquiryConfig";
+
+export default function Inquiry33StAugustineDriveBrooklinPage() {
+  return <ListingInquiryPage config={listingInquiry33StAugustineDriveBrooklin} />;
+}

--- a/src/listings/ListingInquiryPage.js
+++ b/src/listings/ListingInquiryPage.js
@@ -206,9 +206,9 @@ export default function ListingInquiryPage({ config }) {
       <DynamicMetaTags
         route={config.route}
         documentTitle={config.pageTitle}
-        title={config.pageTitle}
-        description={config.seoDescription}
-        canonicalUrl={`https://northsidegta.ca${config.route}`}
+        title={config.ogTitle || config.pageTitle}
+        description={config.ogDescription || config.seoDescription}
+        canonicalUrl={config.canonicalUrl || `https://northsidegta.ca${config.route}`}
         ogType="website"
         ogImage={config.ogImage}
         twitterCard="summary_large_image"

--- a/src/listings/listingInquiryConfig.js
+++ b/src/listings/listingInquiryConfig.js
@@ -41,3 +41,66 @@ export const listingInquiry209Barrie = {
       "Finally Home Agents help buyers and sellers across the NorthSide GTA with a professional, informed, and straightforward approach.",
   },
 };
+
+
+export const listingInquiry33StAugustineDriveBrooklin = {
+  slug: "33-st-augustine-drive-brooklin-inquiry",
+  route: "/listings/33-st-augustine-drive-brooklin-inquiry",
+  pageTitle: "33 St Augustine Drive, Brooklin | Finally Home Agents",
+  seoDescription:
+    "A newer Brooklin family home with a flexible layout, finished basement with second kitchen, large windows, and a standout backyard with pool.",
+  ogTitle: "33 St Augustine Drive, Brooklin",
+  ogDescription:
+    "A newer Brooklin family home with a finished basement, flexible bedroom layout, and a standout backyard with pool.",
+  ogImage: "/Images/listings/33-st-augustine-drive-og.jpg",
+  canonicalUrl: "https://northsidegta.ca/listings/33-st-augustine-drive-brooklin-inquiry",
+  property: {
+    headlineAddress: "33 St Augustine Drive",
+    cityLine: "Brooklin, Whitby",
+    province: "Ontario",
+    mls: "E13124552",
+    imageSrc: "/Images/listings/33-st-augustine-drive-og.jpg",
+    imageAlt: "33 St Augustine Drive, Brooklin, ON (placeholder image path; replace with final listing image asset).",
+    price: "$1,289,999",
+    propertyType: "Detached family home",
+    bedrooms: "4 + 1 potential/flexible bedroom layout",
+    bathrooms: "4",
+    approxAboveGrade: "2,334 sq ft",
+    highlights: [
+      "Finished basement with second kitchen",
+      "Separate downstairs laundry",
+      "Large windows throughout",
+      "Built in 2020",
+      "Backyard with pool and private family-focused outdoor living",
+    ],
+    brandedMediaUrl: "https://listings.wylieford.com/sites/33-st-augustine-drive-whitby-on-l1m-0l7-24795659/branded",
+    videoUrl: "https://listings.wylieford.com/videos/019e21e9-c6d4-70d6-aa22-a3304fd20507",
+  },
+  intro: {
+    title: "Thanks for your interest in 33 St Augustine Drive",
+    subtitle:
+      "We can send you full details on this newer Brooklin home, answer questions about the flexible layout and finished basement, and help arrange a private showing.",
+    prompt: "Before we do that, we just need to confirm one quick thing.",
+  },
+  team: {
+    brokerage: "HomeLife Optimum Realty",
+    phone: "647-668-4646",
+    email: "contact@finallyhomeagents.com",
+    members: [
+      {
+        name: "Matthew Mulhall",
+        role: "Real Estate Agent",
+        imageSrc: "/Images/matthew.jpg",
+        imageAlt: "Headshot of Matthew Mulhall.",
+      },
+      {
+        name: "Landon Mulhall",
+        role: "Real Estate Agent",
+        imageSrc: "/Images/landon.jpg",
+        imageAlt: "Headshot of Landon Mulhall.",
+      },
+    ],
+    summary:
+      "Finally Home Agents help buyers and sellers across the NorthSide GTA with a professional, informed, and straightforward approach.",
+  },
+};


### PR DESCRIPTION
### Motivation

- Provide a new listing inquiry experience for 33 St Augustine Drive that exactly matches the existing inquiry flow and styling used elsewhere. 
- Ensure the new page has route-specific SEO, OG metadata, canonical URL, and branded/video links for the property. 
- Reuse shared components and preserve the current 209 Barrie inquiry behavior without redesign. 

### Description

- Added a new inquiry page wrapper `src/listings/Inquiry33StAugustineDriveBrooklinPage.js` that renders the shared `ListingInquiryPage` with a new config object. 
- Introduced `listingInquiry33StAugustineDriveBrooklin` in `src/listings/listingInquiryConfig.js` with route, `pageTitle`, `seoDescription`, `ogTitle`, `ogDescription`, `ogImage` (points to `/Images/listings/33-st-augustine-drive-og.jpg`), `canonicalUrl`, property details, and the WylieFord branded media/video URLs. 
- Registered the new route at `/listings/33-st-augustine-drive-brooklin-inquiry` in `src/App.js` so the page is reachable without modifying the existing 209 Barrie route. 
- Updated `src/listings/ListingInquiryPage.js` meta wiring to prefer per-page `ogTitle`, `ogDescription`, and `canonicalUrl` when present while remaining backward-compatible with existing configs. 

### Testing

- Ran the production build with `npm run build`, which completed successfully and produced the optimized `build` output. 
- The build reported only pre-existing warnings (Browserslist age and external `rrule` sourcemap notices) and no new import or runtime errors. 
- Verified the new files `src/listings/Inquiry33StAugustineDriveBrooklinPage.js` and config additions are included and that existing inquiry pages remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a326f3848324a53f4730b7c2e8c8)