### PR TITLE
Fix 33 St Augustine inquiry image path

### DIFF
--- a/src/listings/listingInquiryConfig.js
+++ b/src/listings/listingInquiryConfig.js
@@ -52,14 +52,14 @@ export const listingInquiry33StAugustineDriveBrooklin = {
   ogTitle: "33 St Augustine Drive, Brooklin",
   ogDescription:
     "A newer Brooklin family home with a finished basement, flexible bedroom layout, and a standout backyard with pool.",
-  ogImage: "/Images/listings/33-st-augustine-drive-og.jpg",
+  ogImage: "/Images/33-st-augustine-drive-og.jpg",
   canonicalUrl: "https://northsidegta.ca/listings/33-st-augustine-drive-brooklin-inquiry",
   property: {
     headlineAddress: "33 St Augustine Drive",
     cityLine: "Brooklin, Whitby",
     province: "Ontario",
     mls: "E13124552",
-    imageSrc: "/Images/listings/33-st-augustine-drive-og.jpg",
+    imageSrc: "/Images/33-st-augustine-drive-og.jpg",
     imageAlt: "33 St Augustine Drive, Brooklin, ON (placeholder image path; replace with final listing image asset).",
     price: "$1,289,999",
     propertyType: "Detached family home",


### PR DESCRIPTION
### Motivation
- The inquiry page for 33 St Augustine Drive referenced a different image path than the main listing page, causing the inquiry page share/hero image to be inconsistent.

### Description
- Updated `ogImage` and `property.imageSrc` in `src/listings/listingInquiryConfig.js` to use `/Images/33-st-augustine-drive-og.jpg` so the inquiry page uses the same OG/listing image as the main listing.

### Testing
- Inspected the modified file `src/listings/listingInquiryConfig.js` to confirm the two path updates were applied and no other changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07aa80ff6883249d7f7fe84a2c53bf)