### PR TITLE
Rebuild Keswick lower-priced homes page into premium market-intelligence landing

### DIFF
--- a/src/KeswickLowerPricedHomesPage.js
+++ b/src/KeswickLowerPricedHomesPage.js
@@ -6,33 +6,77 @@ import DynamicMetaTags from "./components/seo/DynamicMetaTags";
 import { getStaticRouteMeta } from "./components/seo/staticRouteMetaExports";
 import { getFormEndpoint } from "./components/contact/contactConfig";
 import { trackEvent, trackEventOnce } from "./utils/analytics";
+import { CANONICAL_TESTIMONIALS } from "./data/testimonials";
 
-const priceBands = ["Under $600K", "$600K–$700K", "$700K–$800K", "Price-reduced homes", "First-time buyer options", "Move-up value picks"];
-const listingIntentCards = [
-  { title: "Homes under $700K", propertyType: "Detached / Townhome / Semi", area: "Keswick" },
-  { title: "Price-reduced options", propertyType: "Mixed", area: "Keswick / Georgina" },
-  { title: "Detached homes with upside", propertyType: "Detached", area: "Keswick North" },
-  { title: "Bungalows and smaller homes", propertyType: "Bungalow / Compact detached", area: "Keswick South" },
-];
-const comparisonAreas = ["Newmarket", "Aurora", "East Gwillimbury", "Stouffville", "Bradford", "Innisfil"];
-const faqItems = [
-  ["Are there still homes under $700K in Keswick?", "Availability changes week to week. There are often lower price bands to watch in Keswick and Georgina, but the exact options depend on timing, property type, and condition. Ask for the current list and we’ll verify what is available."],
-  ["Is Keswick cheaper than other York Region communities?", "Keswick and Georgina can offer different value compared with many areas farther south, but pricing depends on the property, neighbourhood, lot, condition, and market timing. Any comparison should be based on current data."],
-  ["Is a lower-priced home always a good deal?", "No. A lower price can reflect size, condition, location, layout, renovation needs, or seller strategy. The goal is to separate real opportunity from costly compromise."],
-  ["What areas should I compare with Keswick?", "Common comparisons include Newmarket, Aurora, East Gwillimbury, Stouffville, Bradford, Innisfil, and parts of Durham depending on commute and lifestyle."],
-  ["Can you send me only homes that match my budget?", "Yes. Use the form and choose your budget range. We can send a focused list instead of everything on the market."],
-  ["Do I need to be ready to buy right now?", "No. Many buyers use this page to monitor the market before they are ready. If you are early, we can help you understand price bands and timing."],
+const priceBands = [
+  { label: "Under $600K", copy: "Smaller homes, condos, townhomes, or properties with trade-offs." },
+  { label: "$600K to $700K", copy: "A key range for buyers watching detached and semi-detached options." },
+  { label: "$700K to $800K", copy: "Often where more detached options begin to appear." },
+  { label: "$800K to $900K", copy: "More room to compare condition, lot, layout, and neighbourhood." },
+  { label: "Price reductions", copy: "Homes where seller expectations may be adjusting." },
+  { label: "First-time buyer options", copy: "Entry-level homes that need proper due diligence." },
 ];
 
-const keswickMarketStats = {
+const buyerInsights = [
+  { title: "More price-band choice", copy: "Buyers who felt boxed out in other York Region communities may find a wider range of asking prices in Keswick and Georgina." },
+  { title: "Some listings need context", copy: "A lower price can reflect size, condition, location, layout, timing, or seller motivation. The key is understanding why the price is lower." },
+  { title: "Detached homes still matter", copy: "Keswick remains especially relevant for buyers who still want a detached home, yard, driveway, or more room than a condo or townhome may offer." },
+  { title: "The best options move differently", copy: "Some homes sit. Some move quickly. The difference is usually price, condition, presentation, and how well the home matches buyer demand." },
+];
+
+const marketStats = {
   lastUpdated: "May 2026",
-  area: "Keswick / Georgina",
-  notes: ["More choice than tighter markets", "Lower-price search demand", "Lake Simcoe lifestyle", "York Region location"],
+  sources: ["REALTOR.ca", "Zolo", "Property.ca", "Town of Georgina", "TRREB where available"],
+  cards: [
+    { label: "Current listing depth", text: "Public portals show meaningful active inventory across Georgina and Keswick, giving buyers more to compare than in tighter markets." },
+    { label: "Lower-price search demand", text: "Buyer searches around homes under $700K and $800K remain highly relevant for Keswick and Georgina." },
+    { label: "More time to compare", text: "Some listings are taking longer to sell, which can create more room for careful review and negotiation." },
+    { label: "Relative affordability", text: "Georgina has been cited by municipal economic development sources as one of York Region’s more approachable detached markets at specific points in time." },
+  ],
 };
+
+const lowerPricedMeaning = [
+  "Smaller detached homes",
+  "Older homes with renovation upside",
+  "Townhomes and semis",
+  "Bungalows and compact layouts",
+  "Homes with location trade-offs",
+  "Homes with condition questions",
+];
+
+const comparisonAreas = [
+  { title: "Keswick vs Newmarket", copy: "Newmarket may offer more central amenities and GO access, while Keswick may open up different price and property-type options." },
+  { title: "Keswick vs Aurora", copy: "Aurora often carries a different price profile. Keswick may be worth comparing for buyers who want York Region but need more room in the budget." },
+  { title: "Keswick vs East Gwillimbury", copy: "Both can appeal to buyers moving north, but the housing mix, commute, and neighbourhood feel can differ significantly." },
+  { title: "Keswick vs Innisfil", copy: "Both connect to Lake Simcoe lifestyle, but they sit in different regional markets with different buyer considerations." },
+  { title: "Keswick vs Stouffville", copy: "Stouffville may appeal to buyers looking east of Markham, while Keswick often becomes relevant for buyers tracking the Highway 404 corridor north." },
+];
+
+const searchIntentBlocks = [
+  ["Homes under $700K in Keswick", "Availability changes week to week, but this is one of the most important price bands for buyers watching Keswick and Georgina. The right options may include smaller detached homes, townhomes, semis, or homes needing updates."],
+  ["Price-reduced homes in Keswick", "A price reduction does not automatically mean a deal. It can signal seller adjustment, market feedback, condition concerns, or a change in strategy. Each home needs to be reviewed individually."],
+  ["First-time buyer homes in Georgina", "Keswick can be relevant for first-time buyers who want to stay within reach of York Region while exploring more approachable home types and price points."],
+  ["Detached homes in Keswick", "Detached homes remain one of the main reasons buyers look at Keswick. The key is comparing lot, layout, condition, age, updates, and resale profile."],
+  ["Keswick North vs Keswick South", "Both areas can appeal to buyers, but the right choice depends on your commute, lifestyle, home type, and specific street. A proper comparison matters."],
+  ["Homes north of Toronto", "For buyers priced out farther south, communities along and beyond the Highway 404 corridor can create different trade-offs. Keswick is one of the areas worth watching."],
+];
+
+const faqItems = [
+  ["Are there still homes under $700K in Keswick?", "Availability changes frequently. There are often lower price bands to watch in Keswick and Georgina, but the exact options depend on timing, property type, condition, and competition."],
+  ["Is Keswick cheaper than Newmarket or Aurora?", "Keswick can offer different price and property-type options than many areas farther south, but the comparison depends on the exact home, neighbourhood, condition, and current market data."],
+  ["Is a lower-priced home always a good deal?", "No. A lower price can reflect size, location, condition, layout, seller strategy, or market feedback. The goal is to separate real opportunity from costly compromise."],
+  ["Why are some homes sitting longer?", "Homes can sit for many reasons, including pricing, presentation, condition, location, seasonality, financing conditions, or buyer demand. Each property needs to be reviewed individually."],
+  ["Can you send me Keswick homes that match my budget?", "Yes. Submit your budget range and we can send a focused list of current Keswick and Georgina homes that match what you are watching."],
+  ["Do I need to be ready to buy right now?", "No. Many buyers start by monitoring price bands and understanding the market before they are ready to make an offer."],
+  ["What should I compare Keswick against?", "Common comparisons include Newmarket, Aurora, East Gwillimbury, Stouffville, Bradford, Innisfil, and parts of Durham depending on budget and commute."],
+];
+
+const trustCards = ["NorthSide GTA market focus", "Buyer strategy and negotiation", "Local comparison guidance", "RECO-compliant advice", "Clear next steps", "No-pressure monitoring"];
+const lifestyleCards = ["Lake Simcoe proximity", "Established neighbourhoods", "Local shops and services", "Room to grow", "North of Toronto without leaving York Region", "Access to Georgina lifestyle"];
 
 export default function KeswickLowerPricedHomesPage() {
   const meta = getStaticRouteMeta("/keswick-lower-priced-homes");
-  const [form, setForm] = useState({ name: "", email: "", phone: "", budget: "", homeType: "", timeline: "", honeypot: "", intent: "General" });
+  const [form, setForm] = useState({ name: "", email: "", phone: "", budget: "", homeType: "", timeline: "", intent: "General", workingWithAgent: "No", honeypot: "" });
   const [success, setSuccess] = useState(false);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState("");
@@ -42,25 +86,14 @@ export default function KeswickLowerPricedHomesPage() {
   useEffect(() => {
     trackEventOnce("keswick_page_view", { route: "/keswick-lower-priced-homes" });
     if (typeof window?.fbq === "function") window.fbq("track", "ViewContent", { content_name: "keswick-lower-priced-homes" });
+    const onScroll = () => {
+      const d = document.documentElement;
+      const p = ((window.scrollY + window.innerHeight) / d.scrollHeight) * 100;
+      if (p >= 75) trackEventOnce("keswick_scroll_75", { route: "/keswick-lower-priced-homes" });
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
   }, []);
-
-  const onSubmit = async (e) => {
-    e.preventDefault();
-    if (!form.name || !form.email) return setError("Please complete name and email.");
-    trackEvent("keswick_form_start", { route: "/keswick-lower-priced-homes" });
-    setSending(true); setError("");
-    try {
-      const payload = new FormData();
-      Object.entries(form).forEach(([k, v]) => v && payload.append(k, v));
-      const res = await fetch(formEndpoint, { method: "POST", body: payload, headers: { Accept: "application/json" } });
-      if (!res.ok) throw new Error("failed");
-      setSuccess(true);
-      trackEvent("keswick_lead_submit", { budget: form.budget, timeline: form.timeline });
-      if (typeof window?.fbq === "function") window.fbq("track", "Lead", { content_name: "keswick-lower-priced-homes" });
-    } catch {
-      setError("Something went wrong. Please try again.");
-    } finally { setSending(false); }
-  };
 
   const jumpToForm = (intent) => {
     setForm((prev) => ({ ...prev, intent }));
@@ -69,20 +102,70 @@ export default function KeswickLowerPricedHomesPage() {
     formRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
-  return <div className="bg-[#f7f6f1] text-[#0f1f17]"><DynamicMetaTags {...meta} />
-    <Helmet><script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"WebPage",name:"Lower-Priced Keswick Homes",url:"https://www.northsidegta.ca/keswick-lower-priced-homes",description:meta.description})}</script>
-    <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"BreadcrumbList",itemListElement:[{"@type":"ListItem",position:1,name:"Home",item:"https://www.northsidegta.ca/"},{"@type":"ListItem",position:2,name:"Keswick lower-priced homes",item:"https://www.northsidegta.ca/keswick-lower-priced-homes"}]})}</script>
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.name || !form.email) return setError("Please complete name and email.");
+    trackEvent("keswick_form_start", { route: "/keswick-lower-priced-homes" });
+    setSending(true);
+    setError("");
+    try {
+      const payload = new FormData();
+      Object.entries(form).forEach(([k, v]) => v && payload.append(k, v));
+      const res = await fetch(formEndpoint, { method: "POST", body: payload, headers: { Accept: "application/json" } });
+      if (!res.ok) throw new Error("failed");
+      setSuccess(true);
+      trackEvent("keswick_lead_submit", { budget: form.budget, timeline: form.timeline, intent: form.intent });
+      if (typeof window?.fbq === "function") window.fbq("track", "Lead", { content_name: "keswick-lower-priced-homes" });
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return <div className="bg-[#f7f6f1] pb-20 text-[#102218] md:pb-0"><DynamicMetaTags {...meta} />
+    <Helmet>
+      {/* TODO: if /Images/seo/keswick-lower-priced-homes-og.jpg is unavailable, configure a safe fallback OG image in staticRouteMetaConfigs.mjs. */}
+      <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"WebPage",name:"More Buyers Are Suddenly Looking at Keswick",url:"https://www.northsidegta.ca/keswick-lower-priced-homes",description:meta.description})}</script>
+      <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"BreadcrumbList",itemListElement:[{"@type":"ListItem",position:1,name:"Home",item:"https://www.northsidegta.ca/"},{"@type":"ListItem",position:2,name:"Keswick Lower Priced Homes",item:"https://www.northsidegta.ca/keswick-lower-priced-homes"}]})}</script>
+      <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"RealEstateAgent",name:"Finally Home Agents",legalName:"Finally Home Agents | HomeLife Optimum Realty, Brokerage",areaServed:["Keswick","Georgina","York Region"],url:"https://www.northsidegta.ca/keswick-lower-priced-homes"})}</script>
     </Helmet>
     <HeaderShell />
-    <main className="mx-auto max-w-6xl px-4 py-10 md:py-14">
-      <section className="rounded-3xl bg-[#13261c] p-8 text-white"><p className="text-sm uppercase tracking-[0.2em] text-emerald-200">Keswick Buyer Opportunity</p><h1 className="mt-2 text-4xl font-semibold">Lower-Priced Homes in Keswick Are Getting Attention</h1><p className="mt-4 max-w-3xl text-emerald-50">If you’re looking north of Toronto, Keswick is one of the places worth watching. See current lower-priced listings, price-band opportunities, and local guidance before the best options move.</p><div className="mt-6 flex flex-wrap gap-3"><button onClick={()=>jumpToForm("Get list")} className="rounded-full bg-white px-6 py-3 font-semibold text-[#13261c]">Get Today’s Keswick List</button><button onClick={()=>document.getElementById("price-bands")?.scrollIntoView({behavior:"smooth"})} className="rounded-full border border-white/50 px-6 py-3">Browse Price Bands</button></div><p className="mt-4 text-sm text-emerald-100">Listings and prices change frequently. We’ll help you verify what is currently available.</p><p className="mt-4 text-xs tracking-wide text-emerald-200">NorthSide GTA • Finally Home Agents • HomeLife Optimum Realty, Brokerage</p></section>
-      <section id="price-bands" className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{priceBands.map((band)=><button key={band} onClick={()=>jumpToForm(band)} className="rounded-2xl border border-[#1f3b2c]/20 bg-white p-4 text-left font-medium hover:border-[#1f3b2c]">{band}</button>)}</section>
-      <section ref={formRef} className="mt-10 rounded-3xl bg-white p-6 shadow"><h2 className="text-2xl font-semibold">Get the current Keswick lower-price list</h2>{success ? <p className="mt-4 rounded-xl bg-emerald-50 p-4">Request received. We’ll send the current Keswick list and any relevant lower-price opportunities that match your range.</p> : <form onSubmit={onSubmit} className="mt-5 grid gap-4 md:grid-cols-2">{['name','email','phone'].map((f)=><label key={f} className="text-sm">{f[0].toUpperCase()+f.slice(1)}{f==='phone'?' (optional)':''}<input className="mt-1 w-full rounded-lg border p-2" value={form[f]} onChange={(e)=>setForm({...form,[f]:e.target.value})} /></label>)}<label className="text-sm">Budget range<select className="mt-1 w-full rounded-lg border p-2" value={form.budget} onChange={(e)=>setForm({...form,budget:e.target.value})}><option>Under $600K</option><option>$600K–$700K</option><option>$700K–$800K</option><option>$800K–$900K</option><option>Not sure yet</option></select></label><label className="text-sm">Desired home type<select className="mt-1 w-full rounded-lg border p-2" value={form.homeType} onChange={(e)=>setForm({...form,homeType:e.target.value})}><option>Detached</option><option>Townhome</option><option>Semi-detached</option><option>Bungalow</option><option>Investment / rental potential</option><option>Not sure yet</option></select></label><label className="text-sm">Timeline<select className="mt-1 w-full rounded-lg border p-2" value={form.timeline} onChange={(e)=>setForm({...form,timeline:e.target.value})}><option>Now</option><option>1–3 months</option><option>3–6 months</option><option>Just watching</option></select></label><input type="text" className="hidden" value={form.honeypot} onChange={(e)=>setForm({...form,honeypot:e.target.value})}/><div className="md:col-span-2"><p className="text-xs text-gray-600">By submitting this form, you agree that Finally Home Agents may contact you about your home search. You can unsubscribe or opt out anytime.</p>{error && <p className="mt-2 text-sm text-red-700">{error}</p>}<button className="mt-3 rounded-full bg-[#13261c] px-6 py-3 font-semibold text-white">{sending?"Sending...":"Send Me the Keswick List"}</button></div></form>}</section>
-      <section className="mt-12"><h2 className="text-2xl font-semibold">Current Keswick Opportunities by Price Band</h2><div className="mt-4 grid gap-4 md:grid-cols-2">{listingIntentCards.map((card)=><article key={card.title} className="rounded-2xl border bg-white p-5"><h3 className="font-semibold">{card.title}</h3><p className="text-sm">{card.propertyType} • {card.area}</p><button className="mt-3 text-sm underline" onClick={()=>{trackEvent("keswick_listing_intent_click",{intent:card.title});jumpToForm(card.title);}}>Send me matching homes</button></article>)}</div></section>
-      <section className="mt-12"><h2 className="text-2xl font-semibold">Why Keswick Is Showing Up on Buyer Shortlists</h2><p className="mt-3">Keswick is not just a price conversation...</p><div className="mt-4 grid gap-3 md:grid-cols-4">{keswickMarketStats.notes.map((n)=><div key={n} className="rounded-xl border bg-white p-4 text-sm font-medium">{n}</div>)}</div><p className="mt-3 text-xs text-gray-600">Market figures are based on publicly available listing and market data and should be verified before making real estate decisions. Listing availability and prices change frequently. Last updated: {keswickMarketStats.lastUpdated}.</p></section>
-      <section className="mt-12"><h2 className="text-2xl font-semibold">Compared with areas farther south, Keswick can open up different options</h2><p className="mt-2">For many buyers searching across York Region and the north GTA, Keswick can introduce homes and lots that may not be available in the same way farther south.</p><p className="mt-2 text-sm">Compare areas: {comparisonAreas.join(", ")}.</p><button onClick={()=>{trackEvent("keswick_compare_click",{});if(typeof window?.fbq==='function')window.fbq('track','Contact',{content_name:'compare-options'});jumpToForm('Compare options')}} className="mt-3 rounded-full border px-5 py-2">Compare My Options</button></section>
-      <section className="mt-12"><h2 className="text-2xl font-semibold">FAQ</h2><div className="mt-4 space-y-3">{faqItems.map(([q,a])=><details key={q} className="rounded-xl border bg-white p-4"><summary className="font-medium">{q}</summary><p className="mt-2 text-sm">{a}</p></details>)}</div></section>
-      <section className="mt-12 rounded-3xl bg-[#13261c] p-7 text-white"><h2 className="text-2xl font-semibold">Start watching Keswick properly</h2><p className="mt-2 text-emerald-100">Get a focused list of current lower-priced Keswick homes, price reductions, and buyer opportunities that match your budget.</p><div className="mt-4 flex gap-3"><button onClick={()=>jumpToForm('Final CTA')} className="rounded-full bg-white px-5 py-2 text-[#13261c]">Send Me the Current List</button><a href="/contact" onClick={()=>trackEvent("keswick_book_call_click",{})} className="rounded-full border border-white/60 px-5 py-2">Book a Buyer Strategy Call</a></div></section>
-      <section className="mt-10 text-xs text-gray-700">Finally Home Agents | Matthew Mulhall, Real Estate Agent | Landon Mulhall, Real Estate Agent | HomeLife Optimum Realty, Brokerage. Not intended to solicit buyers or sellers currently under contract. Listing data, market figures, and availability are subject to change and should be independently verified.</section>
-    </main><Footer /></div>;
+    <main className="mx-auto max-w-6xl space-y-12 px-4 py-8 md:py-12">
+      <section className="grid gap-6 rounded-3xl bg-[#12261c] p-6 text-white md:grid-cols-2 md:p-10">
+        <div><p className="text-xs uppercase tracking-[0.2em] text-emerald-200">Keswick Buyer Opportunity</p><h1 className="mt-3 text-4xl font-semibold leading-tight md:text-5xl">More Buyers Are Suddenly Looking at Keswick</h1><p className="mt-4 text-emerald-50">Some homes in Keswick and Georgina are now showing up in price ranges many GTA buyers stopped expecting to see in York Region. For buyers who have been priced out farther south, this is one of the NorthSide GTA markets worth watching closely.</p><div className="mt-6 flex flex-wrap gap-3"><button onClick={() => jumpToForm("Get Today’s Lower-Price Keswick List")} className="rounded-full bg-white px-6 py-3 font-semibold text-[#12261c]">Get Today’s Lower-Price Keswick List</button><button onClick={() => document.getElementById("price-bands")?.scrollIntoView({ behavior: "smooth" })} className="rounded-full border border-white/60 px-6 py-3">Browse Price Bands</button></div><p className="mt-4 text-sm text-emerald-100">The right home still needs the right condition, location, and resale profile. Low price alone is not the strategy.</p><p className="mt-4 text-xs text-emerald-200">NorthSide GTA • Finally Home Agents • HomeLife Optimum Realty, Brokerage</p><p className="mt-2 text-xs text-emerald-100">Listings, prices, and availability change frequently. We will help you verify what is currently available before you make decisions.</p></div>
+        <aside className="rounded-2xl border border-white/20 bg-white/10 p-6"><p className="text-xs uppercase tracking-[0.18em] text-emerald-200">Current Buyer Watchlist</p><ul className="mt-4 space-y-2 text-sm">{["Lower price bands", "Price reductions", "Detached options", "First-time buyer fit", "York Region value", "Lake Simcoe lifestyle"].map((item) => <li key={item}>• {item}</li>)}</ul></aside>
+      </section>
+
+      <section id="price-bands"><h2 className="text-3xl font-semibold">Start with your budget</h2><p className="mt-2 max-w-3xl text-[#38453f]">The strongest opportunities usually become clearer when you look by price band, not just by town.</p><div className="mt-5 grid gap-4 md:grid-cols-2 lg:grid-cols-3">{priceBands.map((band) => <article key={band.label} className="rounded-2xl border bg-white p-5"><h3 className="font-semibold">{band.label}</h3><p className="mt-2 text-sm text-[#48534e]">{band.copy}</p><button onClick={() => jumpToForm(band.label)} className="mt-4 text-sm font-medium underline">Send me matching homes</button></article>)}</div></section>
+
+      <section ref={formRef} className="grid gap-6 rounded-3xl bg-white p-6 shadow md:grid-cols-[1.4fr_1fr]"><div><h2 className="text-3xl font-semibold">Get the current Keswick lower-price list</h2><p className="mt-2 text-[#48534e]">Tell us your budget and we will send a focused list of current Keswick and Georgina homes that match what you are watching.</p>{success ? <p className="mt-5 rounded-xl bg-emerald-50 p-4 text-sm">Request received. We will send the current Keswick list and any relevant lower-price opportunities that match your range.</p> : <form onSubmit={onSubmit} className="mt-5 grid gap-3 md:grid-cols-2">{["name", "email", "phone"].map((f) => <label key={f} className="text-sm">{f[0].toUpperCase() + f.slice(1)}{f === "phone" ? " (optional)" : ""}<input required={f !== "phone"} className="mt-1 w-full rounded-lg border p-2" value={form[f]} onChange={(e) => setForm({ ...form, [f]: e.target.value })} /></label>)}<label className="text-sm">Budget range<select className="mt-1 w-full rounded-lg border p-2" value={form.budget} onChange={(e) => setForm({ ...form, budget: e.target.value })}><option value="">Select</option><option>Under $600K</option><option>$600K to $700K</option><option>$700K to $800K</option><option>$800K to $900K</option><option>Not sure yet</option></select></label><label className="text-sm">Desired home type<select className="mt-1 w-full rounded-lg border p-2" value={form.homeType} onChange={(e) => setForm({ ...form, homeType: e.target.value })}><option value="">Select</option><option>Detached</option><option>Semi-detached</option><option>Townhome</option><option>Bungalow</option><option>Condo</option><option>Not sure yet</option></select></label><label className="text-sm">Timeline<select className="mt-1 w-full rounded-lg border p-2" value={form.timeline} onChange={(e) => setForm({ ...form, timeline: e.target.value })}><option value="">Select</option><option>Now</option><option>1–3 months</option><option>3–6 months</option><option>6+ months</option></select></label><label className="text-sm">Are you already working with a real estate agent?<select className="mt-1 w-full rounded-lg border p-2" value={form.workingWithAgent} onChange={(e) => setForm({ ...form, workingWithAgent: e.target.value })}><option>No</option><option>Yes</option></select></label>{form.workingWithAgent === "Yes" && <p className="md:col-span-2 rounded-lg bg-amber-50 p-3 text-sm">If you are already under contract with another real estate professional, please continue working with them directly.</p>}<input type="text" className="hidden" value={form.intent} readOnly name="selected_interest" /><input type="text" className="hidden" value={form.honeypot} onChange={(e) => setForm({ ...form, honeypot: e.target.value })} /><div className="md:col-span-2"><p className="text-xs text-gray-600">By submitting this form, you agree that Finally Home Agents may contact you about your home search. You can unsubscribe or opt out anytime.</p>{error && <p className="mt-1 text-sm text-red-700">{error}</p>}<button className="mt-3 rounded-full bg-[#12261c] px-6 py-3 font-semibold text-white">{sending ? "Sending..." : "Send Me the Keswick List"}</button></div></form>}</div><aside className="rounded-2xl border bg-[#f7f6f1] p-5 text-sm"><p className="font-semibold">Why buyers use this form</p><ul className="mt-3 space-y-2">{["No spam.", "Current listings only.", "Budget-specific.", "Local guidance.", "RECO-compliant advice."].map((item) => <li key={item}>• {item}</li>)}</ul></aside></section>
+
+      <section><h2 className="text-3xl font-semibold">What buyers are noticing in Keswick right now</h2><p className="mt-2 text-[#3d4c45]">The opportunity is not that every home is a deal. It is that more buyers are comparing Keswick because the inventory mix can create options that feel harder to find farther south.</p><div className="mt-5 grid gap-4 md:grid-cols-2">{buyerInsights.map((item) => <article key={item.title} className="rounded-2xl border bg-white p-5"><h3 className="font-semibold">{item.title}</h3><p className="mt-2 text-sm text-[#48534e]">{item.copy}</p></article>)}</div><blockquote className="mt-5 rounded-xl border-l-4 border-[#12261c] bg-white p-4 italic">Low price alone is not the strategy. The strategy is knowing which lower-priced homes are actually worth pursuing.</blockquote></section>
+
+      <section><h2 className="text-3xl font-semibold">The market context behind the opportunity</h2><div className="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-4">{marketStats.cards.map((card) => <article key={card.label} className="rounded-2xl border bg-white p-4"><p className="text-xs uppercase tracking-wide text-[#4f6058]">{card.label}</p><p className="mt-2 text-sm">{card.text}</p></article>)}</div><p className="mt-3 text-xs text-gray-600">Market figures and public listing observations are based on sources available at the time of publication, including public listing portals and municipal market references. Confirm current data before relying on it. Last updated: {marketStats.lastUpdated}. Sources: {marketStats.sources.join(", ")}.</p></section>
+
+      <section><h2 className="text-3xl font-semibold">What “lower-priced” really means in Keswick</h2><p className="mt-2 text-[#3d4c45]">A lower asking price can mean opportunity, but it can also mean trade-offs. Some homes need updates. Some have location compromises. Some are smaller than buyers expect. Some are simply priced closer to where today’s buyers are willing to act.</p><div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{lowerPricedMeaning.map((item) => <div key={item} className="rounded-xl border bg-white p-4 text-sm font-medium">{item}</div>)}</div><button onClick={() => jumpToForm("Help me separate opportunity from risk")} className="mt-4 rounded-full border border-[#12261c] px-5 py-2">Help me separate opportunity from risk</button></section>
+
+      <section><h2 className="text-3xl font-semibold">Where Keswick sits in the NorthSide GTA</h2><p className="mt-2 text-[#3d4c45]">Keswick sits at the north end of the Highway 404 story, near Lake Simcoe and within Georgina. For buyers expanding their search north of Newmarket, it can change what their budget is able to do.</p><div className="mt-4 rounded-2xl border bg-white p-6"><div className="grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">{["Toronto", "Highway 404", "Newmarket", "Aurora", "East Gwillimbury", "Keswick", "Lake Simcoe", "Georgina"].map((n) => <div key={n} className="rounded-lg bg-[#f7f6f1] p-3">{n}</div>)}</div></div><button onClick={() => jumpToForm("Compare my NorthSide options")} className="mt-4 rounded-full border px-5 py-2">Compare my NorthSide options</button></section>
+
+      <section><h2 className="text-3xl font-semibold">Keswick vs. other north GTA options</h2><p className="mt-2 text-[#3d4c45]">The right choice depends on your budget, commute, home type, and lifestyle. Keswick should usually be compared against several nearby markets before you decide.</p><div className="mt-4 grid gap-4 md:grid-cols-2">{comparisonAreas.map((area) => <article key={area.title} className="rounded-2xl border bg-white p-4"><h3 className="font-semibold">{area.title}</h3><p className="mt-2 text-sm">{area.copy}</p></article>)}</div><button onClick={() => { trackEvent("keswick_compare_click", {}); if (typeof window?.fbq === "function") window.fbq("track", "Contact", { content_name: "compare-options" }); jumpToForm("Compare these areas for my budget"); }} className="mt-4 rounded-full border px-5 py-2">Compare these areas for my budget</button></section>
+
+      <section><h2 className="text-3xl font-semibold">Why Keswick is more than a price conversation</h2><div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{lifestyleCards.map((item) => <div key={item} className="rounded-xl border bg-white p-4">{item}</div>)}</div></section>
+
+      <section><h2 className="text-3xl font-semibold">Local guidance from Finally Home Agents</h2><p className="mt-2 text-[#3d4c45]">NorthSide GTA was built to help buyers understand the communities north of Toronto with more clarity. Finally Home Agents guide buyers through pricing, neighbourhood trade-offs, due diligence, offer strategy, and long-term fit.</p><p className="mt-2 text-sm">Matthew Mulhall, Real Estate Agent<br />Landon Mulhall, Real Estate Agent<br />HomeLife Optimum Realty, Brokerage</p><div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{trustCards.map((item) => <div key={item} className="rounded-xl border bg-white p-4 text-sm">{item}</div>)}</div></section>
+
+      <section><h2 className="text-3xl font-semibold">What clients value about working with us</h2><div className="mt-4 grid gap-4 md:grid-cols-2">{CANONICAL_TESTIMONIALS.slice(0, 4).map((item) => <article key={item.id} className="rounded-2xl border bg-white p-5"><p className="text-sm">“{item.quote}”</p><p className="mt-3 text-xs text-gray-600">{item.name} • {item.date}</p></article>)}</div></section>
+
+      <section className="rounded-3xl bg-[#12261c] p-6 text-white"><h2 className="text-3xl font-semibold">Want the actual list instead of scrolling portals?</h2><p className="mt-2 text-emerald-100">Tell us your price range and we will send current Keswick and Georgina homes that match what you are watching.</p><div className="mt-4 flex flex-wrap gap-3"><button onClick={() => jumpToForm("Send Me the Current List")} className="rounded-full bg-white px-5 py-2 font-medium text-[#12261c]">Send Me the Current List</button><a href="/contact" onClick={() => trackEvent("keswick_book_call_click", {})} className="rounded-full border border-white/60 px-5 py-2">Book a Buyer Strategy Call</a></div></section>
+
+      <section><h2 className="text-3xl font-semibold">Popular Keswick searches buyers are making</h2><div className="mt-4 space-y-3">{searchIntentBlocks.map(([q, a]) => <details key={q} className="rounded-xl border bg-white p-4"><summary className="font-medium">{q}</summary><p className="mt-2 text-sm">{a}</p></details>)}</div></section>
+      <section><h2 className="text-3xl font-semibold">FAQ</h2><div className="mt-4 space-y-3">{faqItems.map(([q, a]) => <details key={q} className="rounded-xl border bg-white p-4"><summary className="font-medium">{q}</summary><p className="mt-2 text-sm">{a}</p></details>)}</div></section>
+
+      <section className="rounded-3xl bg-[#12261c] p-7 text-white"><h2 className="text-3xl font-semibold">Start watching Keswick properly</h2><p className="mt-2 text-emerald-100">Get a focused list of current lower-priced Keswick homes, price reductions, and buyer opportunities that match your budget.</p><div className="mt-4 flex flex-wrap gap-3"><button onClick={() => jumpToForm("Get Today’s Keswick List")} className="rounded-full bg-white px-5 py-2 text-[#12261c]">Get Today’s Keswick List</button><button onClick={() => jumpToForm("Talk Through My Budget")} className="rounded-full border border-white/60 px-5 py-2">Talk Through My Budget</button></div><p className="mt-5 text-xs text-emerald-100">Finally Home Agents | Matthew Mulhall, Real Estate Agent | Landon Mulhall, Real Estate Agent | HomeLife Optimum Realty, Brokerage. Not intended to solicit buyers or sellers currently under contract. Listing availability, prices, and market conditions change frequently and should be independently verified.</p></section>
+    </main>
+
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-white p-3 md:hidden"><div className="mx-auto flex max-w-6xl gap-2"><button onClick={() => jumpToForm("Sticky Get List")} className="flex-1 rounded-full bg-[#12261c] px-3 py-2 text-sm font-medium text-white">Get List</button><a href="/contact" onClick={() => { trackEvent("keswick_book_call_click", { type: "phone" }); if (typeof window?.fbq === "function") window.fbq("track", "Contact", { channel: "phone" }); }} className="flex-1 rounded-full border px-3 py-2 text-center text-sm">Call</a><button onClick={() => jumpToForm("Sticky Compare Areas")} className="flex-1 rounded-full border px-3 py-2 text-sm">Compare Areas</button></div></div>
+    <Footer />
+  </div>;
 }

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -43,7 +43,7 @@ const STATIC_ROUTE_META_CONFIGS = [
       documentTitle: "Keswick Homes for Sale at Lower Price Points | NorthSide GTA",
       title: "Lower-Priced Keswick Homes | NorthSide GTA",
       description:
-        "Browse current lower-priced homes in Keswick, Georgina. See price bands, local market notes, and get alerts for new opportunities near Lake Simcoe and north of Toronto.",
+        "Browse current lower-priced homes in Keswick and Georgina. See price bands, local market notes, and get alerts for new opportunities north of Toronto.",
       canonicalUrl: "https://www.northsidegta.ca/keswick-lower-priced-homes",
       ogType: "website",
       ogImage: "https://www.northsidegta.ca/Images/seo/keswick-lower-priced-homes-og.jpg",


### PR DESCRIPTION
### Motivation

- Rebuild the existing Keswick lower-priced homes page into a premium, RECO-compliant market-intelligence asset that converts Facebook, Google, and organic traffic into qualified buyer leads.  
- Provide a locally specific, trustworthy resource for buyers comparing Keswick, Georgina, and NorthSide GTA options while preserving required brokerage and agent disclosures.  
- Make lead capture higher-intent and budget-aware by surfacing price-band pathways, a premium lead form, and actionable market context that buyers will share and save.

### Description

- Replaced `src/KeswickLowerPricedHomesPage.js` with a full multi-section landing page (split hero + buyer watchlist, price-band selector, premium lead form, buyer insights, market context strip, lower-priced meaning cards, geography/map placeholder, comparison section, lifestyle/trust/testimonials, long-tail SEO content, FAQ, mid/final CTAs and sticky mobile CTA).  
- Added local editable data objects and constants for `priceBands`, `buyerInsights`, `marketStats`, `lowerPricedMeaning`, `comparisonAreas`, `searchIntentBlocks`, `faqItems`, `trustCards`, and reused `CANONICAL_TESTIMONIALS` for testimonial output so content can be updated without structural changes.  
- Implemented form-intent preselection, smooth-scroll CTAs, guarded analytics hooks and Meta Pixel calls (`keswick_page_view`, `keswick_price_band_click`, `keswick_form_start`, `keswick_lead_submit`, `keswick_compare_click`, `keswick_book_call_click`, `keswick_listing_intent_click`, `keswick_scroll_75`), JSON-LD for `WebPage`, `BreadcrumbList`, and `RealEstateAgent`, and a mobile sticky CTA bar.  
- Updated SEO meta text in `src/components/seo/staticRouteMetaConfigs.mjs` (route `/keswick-lower-priced-homes`), preserved OG image path with an in-code TODO for fallback, and ensured compliance: brokerage visibility, agent titles, RECO disclaimers, and careful lower-priced phrasing and sourcing guidance.

### Testing

- Ran the production build with `npm run build` and the build completed successfully (site build + postbuild static route generation and sitemap update completed without errors).  
- The build emitted non-blocking warnings for dependency source maps (external `rrule` package) and a stale Browserslist notice, which did not block the build.  
- Static generation steps completed (curated/insight/event/tastehub pages and sitemap updated) as part of the standard build pipeline.  
- No automated unit tests were added or run beyond the app build; verify runtime analytics and form endpoint integration in staging before shipping to production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0882d0b6108324b7aec792b3eefb7b)