### PR TITLE
Convert neighbourhood HTML pages to React components and add routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,6 +48,15 @@ import CoffeePage, { BookCoffeeAliasPage } from "./CoffeePage";
 import PowerOfSaleSupportPage from "./PowerOfSaleSupportPage";
 import KeswickLowerPricedHomesPage from "./KeswickLowerPricedHomesPage";
 
+import AuroraPage from "./AuroraPage";
+import NewmarketPage from "./NewmarketPage";
+import StouffvillePage from "./StouffvillePage";
+import EastGwillimburyPage from "./EastGwillimburyPage";
+import GeorginaPage from "./GeorginaPage";
+import UxbridgePage from "./UxbridgePage";
+import ScugogPage from "./ScugogPage";
+import NeighbourhoodGuidePage from "./NeighbourhoodGuidePage";
+
 // Load the town slugs right here (no helper to avoid any cyclic import)
 import towns from "./towns.json";
 
@@ -131,7 +140,16 @@ function App() {
           <Route path="/northside-pass-preview/option-5" element={<OptionFivePage />} />
           <Route path="/guided/:path" element={<GuidedPathPage />} />
 
+          <Route path="/neighbourhood-guide" element={<NeighbourhoodGuidePage />} />
+
           {/* Town pages — community slugs */}
+          <Route path="/communities/aurora" element={<AuroraPage />} />
+          <Route path="/communities/newmarket" element={<NewmarketPage />} />
+          <Route path="/communities/stouffville" element={<StouffvillePage />} />
+          <Route path="/communities/east-gwillimbury" element={<EastGwillimburyPage />} />
+          <Route path="/communities/georgina" element={<GeorginaPage />} />
+          <Route path="/communities/uxbridge" element={<UxbridgePage />} />
+          <Route path="/communities/scugog" element={<ScugogPage />} />
           <Route path="/communities/:slug" element={<TownPage />} />
 
           {/* Town pages — short URLs like /aurora */}

--- a/src/AuroraPage.js
+++ b/src/AuroraPage.js
@@ -496,7 +496,7 @@ export default function AuroraPage() {
       const em = document.getElementById(`sf_email_${id}`)?.value.trim();
       if (!n || !em) { alert("Please enter your name and email."); return; }
       const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
-      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      fetch("/api/send-lead", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ...payload, casl: true, notRepresented: true, title: `NorthSide GTA local guidance — ${town}`, realmLink: window.location.href }), credentials: "same-origin" }).catch(() => {});
       const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
     };
     window.submitSMSTown = (id, town) => {

--- a/src/AuroraPage.js
+++ b/src/AuroraPage.js
@@ -1,49 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Living in Georgina, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
-<meta name="description" content="Explore Georgina, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Georgina is the right fit for your move north of Toronto.">
-<meta property="og:title" content="Living in Georgina, Ontario | NorthSide GTA Guide">
-<meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Georgina. A practical buyer guide from Finally Home Agents.">
-<meta property="og:type" content="article">
-<meta property="og:url" content="https://northsidegta.ca/communities/georgina">
-<meta property="og:image" content="https://northsidegta.ca/Images/georgina-banner.jpg">
-<link rel="canonical" href="https://northsidegta.ca/communities/georgina">
-<script type="application/ld+json">{
-  "@context":"https://schema.org",
-  "@graph":[
-    {
-      "@type":"Article",
-      "headline":"Living in Georgina, Ontario | Real Estate & Neighbourhood Guide",
-      "description":"Lake Simcoe access, larger lots, and one of the most accessible price points in York Region.",
-      "url":"https://northsidegta.ca/communities/georgina",
-      "dateModified":"2026-05-24",
-      "author":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
-      ],
-      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
-      "about":{"@type":"City","name":"Georgina","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
-    },
-    {
-      "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is Georgina Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Georgina is known for Lake Simcoe waterfront access, recreational fishing (perch and walleye), summer boating, seasonal ice fishing, and communities including Keswick, Sutton, and Jackson's Point. It is the most affordable municipality in York Region by average sale price."}},{"@type":"Question","name":"Is Georgina a good place to live?","acceptedAnswer":{"@type":"Answer","text":"Georgina is a strong option for buyers who want more space, waterfront access, or a different pace — particularly those with remote work arrangements. The primary trade-offs are a longer commute to Toronto and car-dependence for daily needs."}},{"@type":"Question","name":"What communities are in Georgina?","acceptedAnswer":{"@type":"Answer","text":"Georgina includes Keswick (the largest urban centre), Keswick South, Keswick North, Sutton, Jackson's Point, Pefferlaw, Baldwin, Belhaven, Virginia, and historic lakeshore communities along Lake Simcoe."}}]
-    },
-    {
-      "@type":"RealEstateAgent",
-      "name":"Finally Home Agents Team",
-      "url":"https://northsidegta.ca",
-      "employee":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
-      ]
-    }
-  ]
-}</script>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<style>
+import React, { useEffect, useMemo, useRef } from "react";
+import { Helmet } from "react-helmet-async";
+
+const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
   --green:#1e4d0f;--green2:#2d6b18;--green3:#4a8f2a;
@@ -56,7 +14,7 @@
   --shm:0 4px 20px rgba(0,0,0,0.10);--shl:0 12px 40px rgba(0,0,0,0.13);
   --r:8px;--rl:14px;--rxl:20px;
   --fd:'Playfair Display',Georgia,serif;--fb:'Inter',system-ui,sans-serif;--t:0.18s;
-  --town-color:#0a3040;
+  --town-color:#1a4a6b;
 }
 html{scroll-behavior:smooth;}
 body{font-family:var(--fb);background:var(--cream);color:var(--ink);font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;}
@@ -116,7 +74,7 @@ img{max-width:100%;display:block;}
 .hl-check{width:18px;height:18px;background:var(--gpale);border-radius:50%;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
 .hl-check svg{width:10px;height:10px;stroke:var(--green);stroke-width:2.5;fill:none;}
 /* DAY IN LIFE */
-.dil-block{background:linear-gradient(135deg,#0a304012,#0a304006);border-left:3px solid #0a3040;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
+.dil-block{background:linear-gradient(135deg,#1a4a6b12,#1a4a6b06);border-left:3px solid #1a4a6b;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
 /* FAQ */
 .faq-item{border-bottom:1px solid var(--border);}
 .faq-item:last-child{border-bottom:none;}
@@ -153,7 +111,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .pk{color:rgba(255,255,255,0.6);}
 .pv{font-weight:600;color:#fff;}
 .mkt-pill{display:inline-block;font-size:10px;padding:3px 9px;border-radius:8px;background:rgba(255,255,255,0.15);color:#fff;border:1px solid rgba(255,255,255,0.2);font-weight:500;}
-.onemil-box{background:linear-gradient(135deg,#0a304018,#0a304008);border:1px solid #0a304035;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
+.onemil-box{background:linear-gradient(135deg,#1a4a6b18,#1a4a6b08);border:1px solid #1a4a6b35;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
 .onemil-price{font-family:var(--fd);font-size:15px;font-weight:700;color:var(--green);margin-bottom:8px;}
 .onemil-desc{font-size:12.5px;color:var(--ink2);line-height:1.65;}
 /* CTA CARD */
@@ -189,9 +147,39 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-item p{color:var(--ink2);line-height:1.6;}
 @media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
-</style>
-</head>
-<body>
+`;
+const PAGE_SCHEMA = `{
+  "@context":"https://schema.org",
+  "@graph":[
+    {
+      "@type":"Article",
+      "headline":"Living in Aurora, Ontario | Real Estate & Neighbourhood Guide",
+      "description":"Established neighbourhoods, strong schools, heritage streets, and GO Train access.",
+      "url":"https://northsidegta.ca/communities/aurora",
+      "dateModified":"2026-05-24",
+      "author":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
+      ],
+      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
+      "about":{"@type":"City","name":"Aurora","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
+    },
+    {
+      "@type":"FAQPage",
+      "mainEntity":[{"@type":"Question","name":"What is Aurora Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Aurora is known for its heritage downtown on Yonge Street, strong school system including Dr. G.W. Williams Secondary (8.8/10, Fraser Institute 2024), and reliable GO Train service to Union Station via the Barrie line. It is one of York Region's most established residential communities."}},{"@type":"Question","name":"Is Aurora a good place to raise a family?","acceptedAnswer":{"@type":"Answer","text":"Aurora has a strong school catchment, established parks and trails, and a walkable downtown core. Families relocating from North Toronto or the inner GTA often find it offers a similar level of amenity with more space. School boundaries should be verified directly with YRDSB before purchasing."}},{"@type":"Question","name":"What are the different neighbourhoods in Aurora?","acceptedAnswer":{"@type":"Answer","text":"Aurora has approximately ten distinct residential areas. Aurora Heights and Bayview Wellington are popular for mature lots and established streets. Aurora Estates and Hills of St. Andrew offer larger properties. Aurora Village sits close to the heritage downtown and walkable amenities."}}]
+    },
+    {
+      "@type":"RealEstateAgent",
+      "name":"Finally Home Agents Team",
+      "url":"https://northsidegta.ca",
+      "employee":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
+      ]
+    }
+  ]
+}`;
+const PAGE_BODY_HTML = `
 
 <nav class="topnav" role="navigation" aria-label="Site navigation">
   <a href="https://northsidegta.ca" class="topnav-logo">NorthSide <span>GTA</span></a>
@@ -204,20 +192,20 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
 <!-- HERO -->
 <header class="hero" role="banner">
-  <img src="/Images/georgina-banner.jpg" alt="Lake Simcoe shoreline in Georgina" class="hero-img" loading="eager">
+  <img src="/Images/aurora-banner.jpg" alt="Aurora streetscape" class="hero-img" loading="eager">
   <div class="hero-overlay" aria-hidden="true"></div>
   <div class="hero-content">
     <div class="hero-eyebrow">
-      <img src="/Images/towns/georgina.jpg" alt="Georgina NorthSide GTA town badge" class="town-badge">
+      <img src="/Images/towns/aurora.jpg" alt="Aurora NorthSide GTA town badge" class="town-badge">
       <span>York Region &middot; NorthSide GTA</span>
     </div>
-    <h1>Living in Georgina</h1>
-    <p class="hero-sub">Lake Simcoe, more space, shoreline communities, beaches, marinas, and one of York Region's most accessible price points.</p>
+    <h1>Living in Aurora</h1>
+    <p class="hero-sub">Established neighbourhoods, strong schools, heritage streets, GO access, and one of the most complete lifestyles in the NorthSide GTA.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">$875K</div><div class="hstat-lbl">Avg. sold</div></div>
-      <div class="hstat"><div class="hstat-val">65 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">38d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">7.5 mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">$1122K</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">35 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
+      <div class="hstat"><div class="hstat-val">24d</div><div class="hstat-lbl">Avg. on mkt</div></div>
+      <div class="hstat"><div class="hstat-val">4.2 mo</div><div class="hstat-lbl">Inventory</div></div>
     </div>
   </div>
 </header>
@@ -227,7 +215,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <a href="https://northsidegta.ca">Home</a><span>&rsaquo;</span>
     <a href="https://northsidegta.ca/neighbourhood-guide">Neighbourhood guide</a><span>&rsaquo;</span>
-    <span>Georgina</span>
+    <span>Aurora</span>
   </nav>
   <div class="page-grid">
 
@@ -236,8 +224,8 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- INTRO -->
       <div class="sec">
-        <div class="sec-eyebrow">About Georgina</div>
-        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Georgina is a strong option for buyers who want more space, waterfront access, or a different pace — and who are comfortable with the commute trade-off. With 7.5 months of inventory, it is currently a buyer's market with meaningful negotiating room, particularly on non-waterfront properties.</p>
+        <div class="sec-eyebrow">About Aurora</div>
+        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Aurora is one of the NorthSide GTA's most established communities — a town where heritage architecture, walkable streets, and strong schools coexist with practical GO Train access to the city. Buyers choosing Aurora are typically prioritising school catchments, mature neighbourhoods, and a lifestyle that doesn't require giving up much of what the city offers.</p>
         <div style="margin-top:14px;display:flex;gap:6px;flex-wrap:wrap;">
           <a href="#contact" class="btn-primary" style="font-size:13px;padding:10px 20px;">Get local guidance</a>
           <a href="https://northsidegta.ca/neighbourhood-guide" class="btn-secondary" style="font-size:13px;padding:9px 18px;">Compare all towns</a>
@@ -246,9 +234,9 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- SUB-COMMUNITIES -->
       <div class="sec" id="neighbourhoods">
-        <h2>Neighbourhoods &amp; areas in Georgina</h2>
-        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Keswick</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Keswick South</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Keswick North</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Sutton</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Jackson's Point</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Pefferlaw</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Baldwin</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Belhaven</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Virginia</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Historic Lakeshore Communities</span></div>
-        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within Georgina has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
+        <h2>Neighbourhoods &amp; areas in Aurora</h2>
+        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Aurora Village</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Aurora Heights</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Aurora Highlands</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Aurora Estates</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Bayview Wellington</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Hills of St. Andrew</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Rural Aurora</span></div>
+        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within Aurora has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
       </div>
 
       <!-- SCHOOLS & COMMUTE -->
@@ -257,30 +245,38 @@ details[open] .faq-icon{transform:rotate(45deg);}
         <table class="school-table" aria-label="Schools">
       <thead><tr><th>School</th><th>Rating</th><th>Notes</th></tr></thead>
       <tbody><tr>
-      <td><div class="school-name">Keswick High School</div><div class="school-type">Public Secondary</div></td>
-      <td class="school-rating">6.8/10</td>
+      <td><div class="school-name">Dr. G.W. Williams Secondary</div><div class="school-type">Public Secondary</div></td>
+      <td class="school-rating">8.8/10</td>
+      <td class="school-note">Top 30 in Ontario — Fraser Institute 2024</td>
+    </tr><tr>
+      <td><div class="school-name">Aurora High School</div><div class="school-type">Public Secondary</div></td>
+      <td class="school-rating">7.6/10</td>
       <td class="school-note">York Region District School Board</td>
     </tr><tr>
-      <td><div class="school-name">Sutton District High School</div><div class="school-type">Public Secondary</div></td>
-      <td class="school-rating">6.5/10</td>
-      <td class="school-note">York Region District School Board</td>
+      <td><div class="school-name">St. Andrew's College</div><div class="school-type">Private (Boys, Gr. 5–12)</div></td>
+      <td class="school-rating">—</td>
+      <td class="school-note">National profile; boarding available</td>
     </tr><tr>
-      <td><div class="school-name">Our Lady of the Lake Catholic Elem.</div><div class="school-type">Catholic Elementary</div></td>
-      <td class="school-rating">6.9/10</td>
-      <td class="school-note">York Catholic District School Board</td>
+      <td><div class="school-name">St. Anne's School</div><div class="school-type">Private (Girls, Gr. 5–12)</div></td>
+      <td class="school-rating">—</td>
+      <td class="school-note">Sister school to SAC; opened 2022</td>
     </tr><tr>
-      <td><div class="school-name">Keswick Public School</div><div class="school-type">Public Elementary</div></td>
-      <td class="school-rating">6.7/10</td>
-      <td class="school-note">York Region District School Board</td>
+      <td><div class="school-name">Holy Spirit Catholic Elem.</div><div class="school-type">Catholic Elementary</div></td>
+      <td class="school-rating">7.5/10</td>
+      <td class="school-note">Fraser Institute 2024</td>
+    </tr><tr>
+      <td><div class="school-name">Hartman Public School</div><div class="school-type">Public Elementary</div></td>
+      <td class="school-rating">7.4/10</td>
+      <td class="school-note">Fraser Institute 2024</td>
     </tr></tbody>
     </table>
     <p style="font-size:11px;color:var(--ink4);margin-top:10px;line-height:1.65;">Ratings from Fraser Institute Ontario School Report Cards 2024/2025. School boundaries can change — verify directly with the relevant school board before making a property decision.</p>
         <div style="margin-top:18px;">
-          <h2 style="font-size:18px;margin-bottom:10px;">Commute from Georgina</h2>
+          <h2 style="font-size:18px;margin-bottom:10px;">Commute from Aurora</h2>
           <div style="background:var(--cream);border-radius:var(--r);padding:14px 16px;font-size:13px;color:var(--ink2);line-height:1.75;">
-            <div><strong>Distance to DVP/401:</strong> 80 km</div>
-            <div><strong>Off-peak drive time:</strong> approximately 65 minutes</div>
-            <div><strong>Transit:</strong> Car-dependent — no GO Train service</div>
+            <div><strong>Distance to DVP/401:</strong> 46 km</div>
+            <div><strong>Off-peak drive time:</strong> approximately 35 minutes</div>
+            <div><strong>Transit:</strong> GO Train (Barrie line) — ~45 min to Union</div>
             <div style="margin-top:8px;font-size:12px;color:var(--ink4);">Drive times are off-peak estimates. Peak-hour commute times are typically 30–60% longer depending on conditions.</div>
           </div>
         </div>
@@ -290,118 +286,92 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <div class="sec" id="restaurants">
         <h2>Local restaurants &amp; cafés</h2>
         <div class="rest-item">
-      <div><div class="rest-name">Jack's Waterfront Restaurant</div><div class="rest-desc">Lakeside dining — popular summer patio in Keswick</div></div>
+      <div><div class="rest-name">Joia Ristorante & Wine Bar</div><div class="rest-desc">Italian — Aurora institution since 1997</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Cook's Bay Brewhouse</div><div class="rest-desc">Local craft brewery in Keswick</div></div>
+      <div><div class="rest-name">Fishbone Kitchen + Bar</div><div class="rest-desc">Seafood and cocktails on Yonge</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Jackson's Point Bistro</div><div class="rest-desc">Seasonal lakeside dining</div></div>
+      <div><div class="rest-name">FIKA Cafe</div><div class="rest-desc">Café with a strong patio</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Sutton cafés and diners</div><div class="rest-desc">Small-town café culture across Sutton</div></div>
+      <div><div class="rest-name">Beertown Public House</div><div class="rest-desc">Craft beer and pub fare</div></div>
+    </div><div class="rest-item">
+      <div><div class="rest-name">Locale Aurora</div><div class="rest-desc">Modern Canadian comfort food</div></div>
     </div><p style="font-size:11px;color:var(--ink4);margin-top:10px;">Included for community context. Not ranked or endorsed by Finally Home Agents.</p>
       </div>
 
       <!-- TASTEHUB -->
-      <section class="th-section" aria-labelledby="th-h-georgina">
+      <section class="th-section" aria-labelledby="th-h-aurora">
   <div class="th-header">
     <div>
       <div class="sec-eyebrow">Community-powered local food picks</div>
-      <h2 class="sec-h2" id="th-h-georgina" style="font-size:20px;">NorthSide TasteHub Local Favourites in Georgina</h2>
-      <p class="sec-sub" style="font-size:13px;margin-top:6px;">Lake days, casual patios, pizza nights, and local cafés are part of Georgina's appeal. TasteHub helps buyers discover where locals are actually going.</p>
+      <h2 class="sec-h2" id="th-h-aurora" style="font-size:20px;">NorthSide TasteHub Local Favourites in Aurora</h2>
+      <p class="sec-sub" style="font-size:13px;margin-top:6px;">From downtown date-night spots to cafés, patios, and family-friendly restaurants, TasteHub helps buyers see where Aurora locals actually go.</p>
       <p style="font-size:11px;color:var(--ink4);margin-top:6px;">TasteHub results are community-powered and are not paid rankings or endorsements.</p>
     </div>
     <div style="display:flex;flex-direction:column;gap:8px;flex-shrink:0;">
-      <a href="/tastehub?town=georgina" class="btn-primary" style="font-size:12px;padding:9px 18px;">See Georgina favourites</a>
+      <a href="/tastehub?town=aurora" class="btn-primary" style="font-size:12px;padding:9px 18px;">See Aurora favourites</a>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;padding:8px 16px;">Vote on TasteHub</a>
     </div>
   </div>
-  <div id="th-polls-georgina" class="th-cards">
+  <div id="th-polls-aurora" class="th-cards">
     <!-- TasteHub polls load here -->
     <div class="th-fallback">
-      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for Georgina are coming soon.</p>
+      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for Aurora are coming soon.</p>
       <p style="margin-bottom:14px;">Explore live TasteHub voting across the NorthSide GTA.</p>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;">See all TasteHub polls</a>
     </div>
   </div>
 </section>
-<script>
-(function(){
-  var townName = "Georgina";
-  var containerId = "th-polls-georgina";
-  var tasteHubUrl = "/tastehub?town=" + encodeURIComponent(townName.toLowerCase().replace(/ /g,'-'));
-  fetch('/api/tastehub/polls', {credentials:'same-origin'})
-    .then(function(r){if(!r.ok)throw new Error('no polls');return r.json();})
-    .then(function(data){
-      var polls = Array.isArray(data) ? data : (data.polls || []);
-      var live = polls.filter(function(p){
-        return p.status === 'live' && p.town && p.town.toLowerCase() === townName.toLowerCase();
-      }).slice(0,3);
-      if(live.length === 0) return;
-      var container = document.getElementById(containerId);
-      container.innerHTML = live.map(function(p){
-        var href = p.slug ? '/tastehub/' + p.slug : '/tastehub';
-        var img = p.image || '/seo/tastehub-default-poll-share.jpg';
-        return '<a href="' + href + '" class="th-card" style="text-decoration:none;color:inherit;">'
-          + '<img src="' + img + '" alt="' + (p.title||'TasteHub poll') + '" class="th-card-img" loading="lazy">'
-          + '<div class="th-card-body">'
-          + '<div class="th-card-town">' + townName + '</div>'
-          + '<div class="th-card-title">' + (p.title||'Local favourite') + '</div>'
-          + '<div class="th-card-cta">Vote now &rarr;</div>'
-          + '</div></a>';
-      }).join('');
-    })
-    .catch(function(){ /* fallback already shown */ });
-})();
-</script>
+
 
       <!-- WHY PEOPLE CHOOSE -->
       <div class="sec" id="lifestyle">
-        <h2>Why people choose Georgina</h2>
-        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Lake Simcoe shoreline access</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Sibbald Point Provincial Park</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Jackson's Point beach and marina</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Cook's Bay</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Pefferlaw Brook trails</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Boating, fishing, and seasonal ice fishing</span></div></div>
+        <h2>Why people choose Aurora</h2>
+        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Heritage downtown on Yonge St</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Aurora Farmers Market (Saturdays)</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Nokiidaa Trail system</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Magna Golf Club nearby</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>10 distinct neighbourhoods</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Strong library and community facilities</span></div></div>
       </div>
 
       <!-- BUYER FIT -->
       <div class="sec" id="buyer-fit">
-        <h2>Is Georgina the right fit?</h2>
+        <h2>Is Aurora the right fit?</h2>
         <div class="fit-grid">
           <div class="fit-item fit-good">
             <div class="fit-label">Well suited for</div>
-            <p>Buyers with remote work flexibility, waterfront property seekers, buyers who want more space and a different pace at an accessible price point.</p>
+            <p>Families prioritising schools and commute, buyers moving from North Toronto, upsizers from Markham or Richmond Hill.</p>
           </div>
           <div class="fit-item fit-watch">
             <div class="fit-label">Things to weigh up</div>
-            <p>Georgina requires car travel for essentially all daily needs. There is no GO Train service. Commute to central Toronto is approximately 65 minutes off-peak and longer during peak periods.</p>
+            <p>Premium pricing relative to other NorthSide GTA towns. Older homes may require capital improvements.</p>
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
-          <strong>Market note:</strong> Waterfront properties in Georgina have historically held value relative to the broader market. The overall market has 7.5 months of inventory, which gives buyers meaningful negotiating room.
+          <strong>Market note:</strong> Aurora tends to hold value consistently across market cycles. A balanced mix of heritage stock, established neighbourhoods, and ongoing demand.
         </div>
       </div>
 
       <!-- DAY IN LIFE -->
       <div class="sec" id="day-in-life">
-        <h2>A day in Georgina</h2>
-        <div class="dil-block">No fixed alarm on remote work days. Coffee with a view of the lake, then the laptop open by 8:30. Afternoon: paddleboard from the dock or a walk to Keswick Beach with the kids. Evenings at Jack's waterfront patio when the weather cooperates. The trade-off with the commute is something Georgina buyers are conscious of — most have made a deliberate choice about where they want to spend their time.</div>
+        <h2>A day in Aurora</h2>
+        <div class="dil-block">Morning coffee near Yonge St, then a short walk to Aurora GO station. Union Station approximately 45 minutes later. After school, kids walk home from Dr. G.W. Williams while you wrap up the workday. Weekend: Aurora Farmers Market on Saturday morning, Nokiidaa Trail in the afternoon, Sunday round at Magna if you know someone.</div>
       </div>
 
       <!-- FAQ -->
       <div class="sec" id="faq">
         <h2>Frequently asked questions</h2>
         <details class="faq-item">
-      <summary class="faq-summary">What is Georgina Ontario known for? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Georgina is known for Lake Simcoe waterfront access, recreational fishing (perch and walleye), summer boating, seasonal ice fishing, and communities including Keswick, Sutton, and Jackson's Point. It is the most affordable municipality in York Region by average sale price.</div>
+      <summary class="faq-summary">What is Aurora Ontario known for? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Aurora is known for its heritage downtown on Yonge Street, strong school system including Dr. G.W. Williams Secondary (8.8/10, Fraser Institute 2024), and reliable GO Train service to Union Station via the Barrie line. It is one of York Region's most established residential communities.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">Is Georgina a good place to live? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Georgina is a strong option for buyers who want more space, waterfront access, or a different pace — particularly those with remote work arrangements. The primary trade-offs are a longer commute to Toronto and car-dependence for daily needs.</div>
+      <summary class="faq-summary">Is Aurora a good place to raise a family? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Aurora has a strong school catchment, established parks and trails, and a walkable downtown core. Families relocating from North Toronto or the inner GTA often find it offers a similar level of amenity with more space. School boundaries should be verified directly with YRDSB before purchasing.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">What communities are in Georgina? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Georgina includes Keswick (the largest urban centre), Keswick South, Keswick North, Sutton, Jackson's Point, Pefferlaw, Baldwin, Belhaven, Virginia, and historic lakeshore communities along Lake Simcoe.</div>
+      <summary class="faq-summary">What are the different neighbourhoods in Aurora? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Aurora has approximately ten distinct residential areas. Aurora Heights and Bayview Wellington are popular for mature lots and established streets. Aurora Estates and Hills of St. Andrew offer larger properties. Aurora Village sits close to the heritage downtown and walkable amenities.</div>
     </details>
       </div>
 
       <!-- OTHER COMMUNITIES -->
       <div class="sec">
         <h2>Other NorthSide GTA communities</h2>
-        <div class="towns-nav"><a href="/communities/aurora" class="town-nav-chip">
+        <div class="towns-nav"><a href="/communities/aurora" class="town-nav-chip current">
       <img src="/Images/towns/aurora.jpg" alt="Aurora NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Aurora
     </a><a href="/communities/newmarket" class="town-nav-chip">
@@ -413,7 +383,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
     </a><a href="/communities/east-gwillimbury" class="town-nav-chip">
       <img src="/Images/towns/east-gwillimbury.jpg" alt="East Gwillimbury NorthSide GTA town badge" width="20" height="20" loading="lazy">
       East Gwillimbury
-    </a><a href="/communities/georgina" class="town-nav-chip current">
+    </a><a href="/communities/georgina" class="town-nav-chip">
       <img src="/Images/towns/georgina.jpg" alt="Georgina NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Georgina
     </a><a href="/communities/uxbridge" class="town-nav-chip">
@@ -434,37 +404,37 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
         <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$875K</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$910K</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$815K</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$590K</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">38d</span></div>
+        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$1122K</span></div>
+        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$1561K</span></div>
+        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$918K</span></div>
+        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$720K</span></div>
+        <div class="prow"><span class="pk">Days on market</span><span class="pv">24d</span></div>
         <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">97%</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">7.5</span></div>
+        <div class="prow"><span class="pk">Months inventory</span><span class="pv">4.2</span></div>
         <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">Buyer's market</span></span></div>
         <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">TRREB MLS® 2025–2026. Not an appraisal. Confirm with a registered agent before decisions.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->
       <div class="onemil-box">
-        <div class="onemil-price">What does $1M buy in Georgina?</div>
-        <p class="onemil-desc">A 4-bed waterfront or near-waterfront property on Lake Simcoe with a private dock and mature trees. Or a newer 5-bed detached in Keswick North with a triple garage on a large lot. Strong value compared with nearby options anywhere else in York Region at this price.</p>
+        <div class="onemil-price">What does $1M buy in Aurora?</div>
+        <p class="onemil-desc">A well-maintained 3-bed detached on a 40-ft lot in Aurora Heights or Bayview Wellington. Likely a 1980s–90s build on a mature tree-lined street, within walking distance of schools. Expect to budget for updates.</p>
         <p style="font-size:10px;color:var(--ink4);margin-top:8px;">Based on active listings Q1–Q2 2026. Properties vary.</p>
       </div>
 
       <!-- CTA -->
       <div class="cta-card">
         <h3>Talk to a local real estate agent</h3>
-        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether Georgina fits your lifestyle, budget, and timing.</p>
+        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether Aurora fits your lifestyle, budget, and timing.</p>
         <div class="agent-sm">
           <div class="asm"><div class="asm-name">Matthew Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
           <div class="asm"><div class="asm-name">Landon Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
         </div>
         <div class="cta-form">
-          <input type="text" id="sf_name_georgina" placeholder="Your name" autocomplete="name">
-          <input type="email" id="sf_email_georgina" placeholder="Email address" autocomplete="email">
-          <input type="tel" id="sf_phone_georgina" placeholder="Phone (optional)" autocomplete="tel">
-          <select id="sf_tl_georgina">
+          <input type="text" id="sf_name_aurora" placeholder="Your name" autocomplete="name">
+          <input type="email" id="sf_email_aurora" placeholder="Email address" autocomplete="email">
+          <input type="tel" id="sf_phone_aurora" placeholder="Phone (optional)" autocomplete="tel">
+          <select id="sf_tl_aurora">
             <option value="">Timeline</option>
             <option>Ready now</option>
             <option>1–3 months</option>
@@ -472,14 +442,14 @@ details[open] .faq-icon{transform:rotate(45deg);}
             <option>6–12 months</option>
             <option>Just researching</option>
           </select>
-          <button class="cta-submit" onclick="submitTownLead('georgina','Georgina')">Get local guidance &rarr;</button>
+          <button class="cta-submit" onclick="submitTownLead('aurora','Aurora')">Get local guidance &rarr;</button>
         </div>
         <div class="sms-box">
-          <p>Want listings for Georgina? Get quiet text alerts.</p>
+          <p>Want listings for Aurora? Get quiet text alerts.</p>
           <p style="font-size:11px;color:rgba(255,255,255,0.5);margin-bottom:8px;">No spam. Just relevant listings and local updates.</p>
           <div class="sms-row">
-            <input type="tel" id="sms_georgina" placeholder="Your phone number">
-            <button class="sms-btn" onclick="submitSMSTown('georgina','Georgina')">Set alerts</button>
+            <input type="tel" id="sms_aurora" placeholder="Your phone number">
+            <button class="sms-btn" onclick="submitSMSTown('aurora','Aurora')">Set alerts</button>
           </div>
         </div>
         <p class="reco-note">By submitting you consent to being contacted by Matthew Mulhall and Landon Mulhall, Sales Representatives, Finally Home Agents Team, HomeLife Optimum Realty, Brokerage, under TRESA, governed by RECO. For SMS: standard msg &amp; data rates may apply. Reply STOP to unsubscribe.</p>
@@ -495,41 +465,60 @@ details[open] .faq-icon{transform:rotate(45deg);}
   </div>
 </footer>
 
-<script>
-function submitTownLead(id, town) {
-  var n = document.getElementById('sf_name_' + id).value.trim();
-  var em = document.getElementById('sf_email_' + id).value.trim();
-  if (!n || !em) { alert('Please enter your name and email.'); return; }
-  var payload = {
-    name: n, email: em,
-    phone: document.getElementById('sf_phone_' + id).value,
-    timeline: document.getElementById('sf_tl_' + id).value,
-    town: town,
-    source: 'NorthSide GTA Neighbourhood Guide v4 — ' + town + ' town page',
-    timestamp: new Date().toISOString()
-  };
-  fetch('/api/leads', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var btn = document.querySelector('.cta-submit');
-  if (btn) { btn.textContent = '✓ Request sent'; btn.disabled = true; }
+
+`;
+
+export default function AuroraPage() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const townName = "Aurora";
+    const container = containerRef.current?.querySelector("#th-polls-aurora");
+    if (!container) return;
+    fetch("/api/tastehub/polls", { credentials: "same-origin" })
+      .then((r) => { if (!r.ok) throw new Error("no polls"); return r.json(); })
+      .then((data) => {
+        const polls = Array.isArray(data) ? data : data.polls || [];
+        const live = polls.filter((p) => p.status === "live" && p.town && p.town.toLowerCase() === townName.toLowerCase()).slice(0, 3);
+        if (!live.length) return;
+        container.innerHTML = live.map((p) => {
+          const href = p.slug ? `/tastehub/${p.slug}` : "/tastehub";
+          const img = p.image || "/seo/tastehub-default-poll-share.jpg";
+          return `<a href="${href}" class="th-card" style="text-decoration:none;color:inherit;"><img src="${img}" alt="${p.title || "TasteHub poll"}" class="th-card-img" loading="lazy"><div class="th-card-body"><div class="th-card-town">${townName}</div><div class="th-card-title">${p.title || "Local favourite"}</div><div class="th-card-cta">Vote now &rarr;</div></div></a>`;
+        }).join("");
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    window.submitTownLead = (id, town) => {
+      const n = document.getElementById(`sf_name_${id}`)?.value.trim();
+      const em = document.getElementById(`sf_email_${id}`)?.value.trim();
+      if (!n || !em) { alert("Please enter your name and email."); return; }
+      const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
+      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
+    };
+    window.submitSMSTown = (id, town) => {
+      const phone = document.getElementById(`sms_${id}`)?.value.trim();
+      if (!phone) { alert("Please enter your phone number."); return; }
+      const payload = { phone, town, source: `NorthSide SMS opt-in — ${town}`, timestamp: new Date().toISOString() };
+      fetch("/api/sms-optin", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const smsBox = document.getElementById(`sms_${id}`)?.closest(".sms-box");
+      if (smsBox) smsBox.innerHTML = `<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ${town} listings. Reply STOP to unsubscribe.</p>`;
+    };
+    return () => { delete window.submitTownLead; delete window.submitSMSTown; };
+  }, []);
+  const schemaObject = useMemo(() => JSON.parse(PAGE_SCHEMA), []);
+  return (<><Helmet>
+      <title>Living in Aurora, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
+      <meta name="description" content="Explore Aurora, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Aurora is the right fit for your move north of Toronto." />
+      <meta property="og:title" content="Living in Aurora, Ontario | NorthSide GTA Guide" />
+      <meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Aurora. A practical buyer guide from Finally Home Agents." />
+      <meta property="og:type" content="article" />
+      <meta property="og:url" content="https://northsidegta.ca/communities/aurora" />
+      <meta property="og:image" content="https://northsidegta.ca/Images/aurora-banner.jpg" />
+      <link rel="canonical" href="https://northsidegta.ca/communities/aurora" />
+      <script type="application/ld+json">{JSON.stringify(schemaObject)}</script>
+    </Helmet><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /></>);
 }
-function submitSMSTown(id, town) {
-  var phone = document.getElementById('sms_' + id).value.trim();
-  if (!phone) { alert('Please enter your phone number.'); return; }
-  var payload = { phone: phone, town: town, source: 'NorthSide SMS opt-in — ' + town, timestamp: new Date().toISOString() };
-  fetch('/api/sms-optin', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var smsBox = document.getElementById('sms_' + id).closest('.sms-box');
-  if (smsBox) smsBox.innerHTML = '<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ' + town + ' listings. Reply STOP to unsubscribe.</p>';
-}
-</script>
-</body>
-</html>

--- a/src/EastGwillimburyPage.js
+++ b/src/EastGwillimburyPage.js
@@ -486,7 +486,7 @@ export default function EastGwillimburyPage() {
       const em = document.getElementById(`sf_email_${id}`)?.value.trim();
       if (!n || !em) { alert("Please enter your name and email."); return; }
       const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
-      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      fetch("/api/send-lead", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ...payload, casl: true, notRepresented: true, title: `NorthSide GTA local guidance — ${town}`, realmLink: window.location.href }), credentials: "same-origin" }).catch(() => {});
       const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
     };
     window.submitSMSTown = (id, town) => {

--- a/src/EastGwillimburyPage.js
+++ b/src/EastGwillimburyPage.js
@@ -1,49 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Living in Newmarket, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
-<meta name="description" content="Explore Newmarket, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Newmarket is the right fit for your move north of Toronto.">
-<meta property="og:title" content="Living in Newmarket, Ontario | NorthSide GTA Guide">
-<meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Newmarket. A practical buyer guide from Finally Home Agents.">
-<meta property="og:type" content="article">
-<meta property="og:url" content="https://northsidegta.ca/communities/newmarket">
-<meta property="og:image" content="https://northsidegta.ca/Images/newmarket-banner.jpg">
-<link rel="canonical" href="https://northsidegta.ca/communities/newmarket">
-<script type="application/ld+json">{
-  "@context":"https://schema.org",
-  "@graph":[
-    {
-      "@type":"Article",
-      "headline":"Living in Newmarket, Ontario | Real Estate & Neighbourhood Guide",
-      "description":"GO Train access, walkable Main Street, strong schools, and one of the strongest value plays in York Region.",
-      "url":"https://northsidegta.ca/communities/newmarket",
-      "dateModified":"2026-05-24",
-      "author":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
-      ],
-      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
-      "about":{"@type":"City","name":"Newmarket","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
-    },
-    {
-      "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is Newmarket Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Newmarket is known as one of York Region's most connected and active communities. It has a walkable Main Street, direct GO Train service on the Barrie line, Southlake Regional Health Centre, and Upper Canada Mall. It is York Region's highest-volume real estate market."}},{"@type":"Question","name":"Is Newmarket a good place to buy a home in 2026?","acceptedAnswer":{"@type":"Answer","text":"Newmarket's average days on market sat at 17 in early 2026 — the fastest pace in York Region. It offers strong value compared with Aurora while maintaining GO Train access and established neighbourhood stock. Market data from TRREB MLS® 2025–2026."}},{"@type":"Question","name":"What are the best areas in Newmarket?","acceptedAnswer":{"@type":"Answer","text":"Stonehaven-Wyndham is consistently in demand for its school catchment and access to the 404. Armitage and Bristol-London are popular with families. Central Newmarket suits buyers who want walkability and proximity to Main Street amenities."}}]
-    },
-    {
-      "@type":"RealEstateAgent",
-      "name":"Finally Home Agents Team",
-      "url":"https://northsidegta.ca",
-      "employee":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
-      ]
-    }
-  ]
-}</script>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<style>
+import React, { useEffect, useMemo, useRef } from "react";
+import { Helmet } from "react-helmet-async";
+
+const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
   --green:#1e4d0f;--green2:#2d6b18;--green3:#4a8f2a;
@@ -56,7 +14,7 @@
   --shm:0 4px 20px rgba(0,0,0,0.10);--shl:0 12px 40px rgba(0,0,0,0.13);
   --r:8px;--rl:14px;--rxl:20px;
   --fd:'Playfair Display',Georgia,serif;--fb:'Inter',system-ui,sans-serif;--t:0.18s;
-  --town-color:#2a1a50;
+  --town-color:#3a1e0a;
 }
 html{scroll-behavior:smooth;}
 body{font-family:var(--fb);background:var(--cream);color:var(--ink);font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;}
@@ -116,7 +74,7 @@ img{max-width:100%;display:block;}
 .hl-check{width:18px;height:18px;background:var(--gpale);border-radius:50%;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
 .hl-check svg{width:10px;height:10px;stroke:var(--green);stroke-width:2.5;fill:none;}
 /* DAY IN LIFE */
-.dil-block{background:linear-gradient(135deg,#2a1a5012,#2a1a5006);border-left:3px solid #2a1a50;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
+.dil-block{background:linear-gradient(135deg,#3a1e0a12,#3a1e0a06);border-left:3px solid #3a1e0a;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
 /* FAQ */
 .faq-item{border-bottom:1px solid var(--border);}
 .faq-item:last-child{border-bottom:none;}
@@ -153,7 +111,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .pk{color:rgba(255,255,255,0.6);}
 .pv{font-weight:600;color:#fff;}
 .mkt-pill{display:inline-block;font-size:10px;padding:3px 9px;border-radius:8px;background:rgba(255,255,255,0.15);color:#fff;border:1px solid rgba(255,255,255,0.2);font-weight:500;}
-.onemil-box{background:linear-gradient(135deg,#2a1a5018,#2a1a5008);border:1px solid #2a1a5035;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
+.onemil-box{background:linear-gradient(135deg,#3a1e0a18,#3a1e0a08);border:1px solid #3a1e0a35;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
 .onemil-price{font-family:var(--fd);font-size:15px;font-weight:700;color:var(--green);margin-bottom:8px;}
 .onemil-desc{font-size:12.5px;color:var(--ink2);line-height:1.65;}
 /* CTA CARD */
@@ -189,9 +147,39 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-item p{color:var(--ink2);line-height:1.6;}
 @media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
-</style>
-</head>
-<body>
+`;
+const PAGE_SCHEMA = `{
+  "@context":"https://schema.org",
+  "@graph":[
+    {
+      "@type":"Article",
+      "headline":"Living in East Gwillimbury, Ontario | Real Estate & Neighbourhood Guide",
+      "description":"Large lots, new estate builds, fast growth, and Highway 404 access across Sharon, Queensville, and Holland Landing.",
+      "url":"https://northsidegta.ca/communities/east-gwillimbury",
+      "dateModified":"2026-05-24",
+      "author":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
+      ],
+      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
+      "about":{"@type":"City","name":"East Gwillimbury","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
+    },
+    {
+      "@type":"FAQPage",
+      "mainEntity":[{"@type":"Question","name":"What is East Gwillimbury Ontario like?","acceptedAnswer":{"@type":"Answer","text":"East Gwillimbury is York Region's fastest-growing municipality, spanning Sharon, Queensville, Holland Landing, and Mount Albert. It is known for larger new-construction homes, significant infrastructure investment, and the HALP recreation centre opened in 2025."}},{"@type":"Question","name":"Is East Gwillimbury a good place to buy?","acceptedAnswer":{"@type":"Answer","text":"For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. It is currently a buyer's market with approximately 4.5 months of inventory. Daily commuting requires car travel."}},{"@type":"Question","name":"Does East Gwillimbury have GO Train service?","acceptedAnswer":{"@type":"Answer","text":"No — East Gwillimbury does not currently have a GO Train station. The closest stations are in Aurora and Newmarket. Residents primarily commute via Highway 404. The Bradford bypass is improving east-west access."}}]
+    },
+    {
+      "@type":"RealEstateAgent",
+      "name":"Finally Home Agents Team",
+      "url":"https://northsidegta.ca",
+      "employee":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
+      ]
+    }
+  ]
+}`;
+const PAGE_BODY_HTML = `
 
 <nav class="topnav" role="navigation" aria-label="Site navigation">
   <a href="https://northsidegta.ca" class="topnav-logo">NorthSide <span>GTA</span></a>
@@ -204,20 +192,20 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
 <!-- HERO -->
 <header class="hero" role="banner">
-  <img src="/Images/newmarket-banner.jpg" alt="Newmarket Main Street" class="hero-img" loading="eager">
+  <img src="/Images/eastgwillimbury-banner.jpg" alt="Neighbourhood streetscape in East Gwillimbury" class="hero-img" loading="eager">
   <div class="hero-overlay" aria-hidden="true"></div>
   <div class="hero-content">
     <div class="hero-eyebrow">
-      <img src="/Images/towns/newmarket.jpg" alt="Newmarket NorthSide GTA town badge" class="town-badge">
+      <img src="/Images/towns/east-gwillimbury.jpg" alt="East Gwillimbury NorthSide GTA town badge" class="town-badge">
       <span>York Region &middot; NorthSide GTA</span>
     </div>
-    <h1>Living in Newmarket</h1>
-    <p class="hero-sub">A connected NorthSide GTA town with Main Street energy, GO access, established neighbourhoods, shopping, parks, and practical day-to-day convenience.</p>
+    <h1>Living in East Gwillimbury</h1>
+    <p class="hero-sub">Newer communities, larger lots, family-focused growth, and quick access to Highway 404 across Sharon, Queensville, Holland Landing, and Mount Albert.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">$1048K</div><div class="hstat-lbl">Avg. sold</div></div>
-      <div class="hstat"><div class="hstat-val">45 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">17d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">1.6 mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">$1150K</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">50 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
+      <div class="hstat"><div class="hstat-val">30d</div><div class="hstat-lbl">Avg. on mkt</div></div>
+      <div class="hstat"><div class="hstat-val">4.5 mo</div><div class="hstat-lbl">Inventory</div></div>
     </div>
   </div>
 </header>
@@ -227,7 +215,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <a href="https://northsidegta.ca">Home</a><span>&rsaquo;</span>
     <a href="https://northsidegta.ca/neighbourhood-guide">Neighbourhood guide</a><span>&rsaquo;</span>
-    <span>Newmarket</span>
+    <span>East Gwillimbury</span>
   </nav>
   <div class="page-grid">
 
@@ -236,8 +224,8 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- INTRO -->
       <div class="sec">
-        <div class="sec-eyebrow">About Newmarket</div>
-        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Newmarket is the NorthSide GTA's most active real estate market and arguably its most practical town for buyers who want city-level convenience without the city price. A walkable Main Street, reliable GO service, and established neighbourhoods like Stonehaven-Wyndham make it a consistent first choice for families relocating from North Toronto, Thornhill, or Markham.</p>
+        <div class="sec-eyebrow">About East Gwillimbury</div>
+        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">East Gwillimbury is a practical choice for buyers who are prioritising home size, lot size, and newer construction over commute convenience. Communities like Sharon, Queensville, and Holland Landing are growing quickly, with meaningful infrastructure investment underway. The trade-off is clear: daily driving is required, and the local amenity base is still developing.</p>
         <div style="margin-top:14px;display:flex;gap:6px;flex-wrap:wrap;">
           <a href="#contact" class="btn-primary" style="font-size:13px;padding:10px 20px;">Get local guidance</a>
           <a href="https://northsidegta.ca/neighbourhood-guide" class="btn-secondary" style="font-size:13px;padding:9px 18px;">Compare all towns</a>
@@ -246,9 +234,9 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- SUB-COMMUNITIES -->
       <div class="sec" id="neighbourhoods">
-        <h2>Neighbourhoods &amp; areas in Newmarket</h2>
-        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Stonehaven-Wyndham</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Armitage</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Bristol-London</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Glenway Estates</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Central Newmarket</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Gorham-College Manor</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Huron Heights-Leslie Valley</span></div>
-        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within Newmarket has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
+        <h2>Neighbourhoods &amp; areas in East Gwillimbury</h2>
+        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Holland Landing</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Sharon</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Queensville</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Mount Albert</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Rural East Gwillimbury</span></div>
+        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within East Gwillimbury has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
       </div>
 
       <!-- SCHOOLS & COMMUTE -->
@@ -257,34 +245,30 @@ details[open] .faq-icon{transform:rotate(45deg);}
         <table class="school-table" aria-label="Schools">
       <thead><tr><th>School</th><th>Rating</th><th>Notes</th></tr></thead>
       <tbody><tr>
-      <td><div class="school-name">Newmarket High School</div><div class="school-type">Public Secondary</div></td>
-      <td class="school-rating">8.5/10</td>
-      <td class="school-note">Highest-rated in Newmarket — Fraser Institute 2024</td>
+      <td><div class="school-name">Sharon Public School</div><div class="school-type">Public Elementary</div></td>
+      <td class="school-rating">7.8/10</td>
+      <td class="school-note">Highest-rated in EG — Fraser Institute 2024</td>
     </tr><tr>
-      <td><div class="school-name">Dr. John M. Denison SS</div><div class="school-type">Public Secondary</div></td>
-      <td class="school-rating">7.2/10</td>
-      <td class="school-note">YRDSB, approx. 886 students</td>
-    </tr><tr>
-      <td><div class="school-name">Huron Heights Secondary</div><div class="school-type">Public Secondary</div></td>
-      <td class="school-rating">7.0/10</td>
-      <td class="school-note">French Immersion and Arts focus</td>
-    </tr><tr>
-      <td><div class="school-name">Cardinal Carter Catholic SS</div><div class="school-type">Catholic Secondary</div></td>
+      <td><div class="school-name">Queensville Public School</div><div class="school-type">Public Elementary</div></td>
       <td class="school-rating">7.5/10</td>
-      <td class="school-note">York Catholic District School Board</td>
+      <td class="school-note">Newer school serving fast-growing community</td>
     </tr><tr>
-      <td><div class="school-name">Stonehaven Public School</div><div class="school-type">Public Elementary</div></td>
-      <td class="school-rating">8.1/10</td>
-      <td class="school-note">Fraser Institute 2024</td>
+      <td><div class="school-name">Dr. John M. Denison SS</div><div class="school-type">Secondary (Newmarket)</div></td>
+      <td class="school-rating">7.2/10</td>
+      <td class="school-note">Primary secondary school for EG residents</td>
+    </tr><tr>
+      <td><div class="school-name">Sacred Heart Catholic Elementary</div><div class="school-type">Catholic Elementary</div></td>
+      <td class="school-rating">7.6/10</td>
+      <td class="school-note">York Catholic District School Board</td>
     </tr></tbody>
     </table>
     <p style="font-size:11px;color:var(--ink4);margin-top:10px;line-height:1.65;">Ratings from Fraser Institute Ontario School Report Cards 2024/2025. School boundaries can change — verify directly with the relevant school board before making a property decision.</p>
         <div style="margin-top:18px;">
-          <h2 style="font-size:18px;margin-bottom:10px;">Commute from Newmarket</h2>
+          <h2 style="font-size:18px;margin-bottom:10px;">Commute from East Gwillimbury</h2>
           <div style="background:var(--cream);border-radius:var(--r);padding:14px 16px;font-size:13px;color:var(--ink2);line-height:1.75;">
-            <div><strong>Distance to DVP/401:</strong> 55 km</div>
-            <div><strong>Off-peak drive time:</strong> approximately 45 minutes</div>
-            <div><strong>Transit:</strong> GO Train (Barrie line) + YRT/Viva BRT</div>
+            <div><strong>Distance to DVP/401:</strong> 60 km</div>
+            <div><strong>Off-peak drive time:</strong> approximately 50 minutes</div>
+            <div><strong>Transit:</strong> Highway 404 and Bradford bypass — no GO Train station</div>
             <div style="margin-top:8px;font-size:12px;color:var(--ink4);">Drive times are off-peak estimates. Peak-hour commute times are typically 30–60% longer depending on conditions.</div>
           </div>
         </div>
@@ -294,113 +278,83 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <div class="sec" id="restaurants">
         <h2>Local restaurants &amp; cafés</h2>
         <div class="rest-item">
-      <div><div class="rest-name">Ground Burger Bar</div><div class="rest-desc">Local favourite on Main St — quality ingredients</div></div>
+      <div><div class="rest-name">Sharon village cafés</div><div class="rest-desc">Independent cafés in the heritage village core</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Hungry Brew Hops</div><div class="rest-desc">Craft beer focus with a strong food menu</div></div>
+      <div><div class="rest-name">Holland Landing diners</div><div class="rest-desc">Small-town diner options along Yonge St</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Luna Ristorante</div><div class="rest-desc">Italian — well-regarded by locals</div></div>
+      <div><div class="rest-name">HALP Aquatics Café</div><div class="rest-desc">Café inside the HALP recreation centre (opened 2025)</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Flaming Stove</div><div class="rest-desc">Modern Indian and Asian-inspired menu</div></div>
-    </div><div class="rest-item">
-      <div><div class="rest-name">Poached Dreams Diner</div><div class="rest-desc">Weekend brunch — expect a wait</div></div>
+      <div><div class="rest-name">Newmarket dining — 15 min south</div><div class="rest-desc">Full restaurant and retail corridor</div></div>
     </div><p style="font-size:11px;color:var(--ink4);margin-top:10px;">Included for community context. Not ranked or endorsed by Finally Home Agents.</p>
       </div>
 
       <!-- TASTEHUB -->
-      <section class="th-section" aria-labelledby="th-h-newmarket">
+      <section class="th-section" aria-labelledby="th-h-east-gwillimbury">
   <div class="th-header">
     <div>
       <div class="sec-eyebrow">Community-powered local food picks</div>
-      <h2 class="sec-h2" id="th-h-newmarket" style="font-size:20px;">NorthSide TasteHub Local Favourites in Newmarket</h2>
-      <p class="sec-sub" style="font-size:13px;margin-top:6px;">Main Street, cafés, casual restaurants, patios, and family favourites are part of what makes Newmarket feel complete. TasteHub brings those local picks into the guide.</p>
+      <h2 class="sec-h2" id="th-h-east-gwillimbury" style="font-size:20px;">NorthSide TasteHub Local Favourites in East Gwillimbury</h2>
+      <p class="sec-sub" style="font-size:13px;margin-top:6px;">From Sharon to Queensville, Holland Landing, and Mount Albert, TasteHub helps buyers discover local cafés, takeout spots, and community favourites.</p>
       <p style="font-size:11px;color:var(--ink4);margin-top:6px;">TasteHub results are community-powered and are not paid rankings or endorsements.</p>
     </div>
     <div style="display:flex;flex-direction:column;gap:8px;flex-shrink:0;">
-      <a href="/tastehub?town=newmarket" class="btn-primary" style="font-size:12px;padding:9px 18px;">See Newmarket favourites</a>
+      <a href="/tastehub?town=east-gwillimbury" class="btn-primary" style="font-size:12px;padding:9px 18px;">See East Gwillimbury favourites</a>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;padding:8px 16px;">Vote on TasteHub</a>
     </div>
   </div>
-  <div id="th-polls-newmarket" class="th-cards">
+  <div id="th-polls-east-gwillimbury" class="th-cards">
     <!-- TasteHub polls load here -->
     <div class="th-fallback">
-      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for Newmarket are coming soon.</p>
+      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for East Gwillimbury are coming soon.</p>
       <p style="margin-bottom:14px;">Explore live TasteHub voting across the NorthSide GTA.</p>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;">See all TasteHub polls</a>
     </div>
   </div>
 </section>
-<script>
-(function(){
-  var townName = "Newmarket";
-  var containerId = "th-polls-newmarket";
-  var tasteHubUrl = "/tastehub?town=" + encodeURIComponent(townName.toLowerCase().replace(/ /g,'-'));
-  fetch('/api/tastehub/polls', {credentials:'same-origin'})
-    .then(function(r){if(!r.ok)throw new Error('no polls');return r.json();})
-    .then(function(data){
-      var polls = Array.isArray(data) ? data : (data.polls || []);
-      var live = polls.filter(function(p){
-        return p.status === 'live' && p.town && p.town.toLowerCase() === townName.toLowerCase();
-      }).slice(0,3);
-      if(live.length === 0) return;
-      var container = document.getElementById(containerId);
-      container.innerHTML = live.map(function(p){
-        var href = p.slug ? '/tastehub/' + p.slug : '/tastehub';
-        var img = p.image || '/seo/tastehub-default-poll-share.jpg';
-        return '<a href="' + href + '" class="th-card" style="text-decoration:none;color:inherit;">'
-          + '<img src="' + img + '" alt="' + (p.title||'TasteHub poll') + '" class="th-card-img" loading="lazy">'
-          + '<div class="th-card-body">'
-          + '<div class="th-card-town">' + townName + '</div>'
-          + '<div class="th-card-title">' + (p.title||'Local favourite') + '</div>'
-          + '<div class="th-card-cta">Vote now &rarr;</div>'
-          + '</div></a>';
-      }).join('');
-    })
-    .catch(function(){ /* fallback already shown */ });
-})();
-</script>
+
 
       <!-- WHY PEOPLE CHOOSE -->
       <div class="sec" id="lifestyle">
-        <h2>Why people choose Newmarket</h2>
-        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Main Street shops and dining</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Southlake Regional Health Centre</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Upper Canada Mall</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Highway 404 and 400 access</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Fairy Lake Park</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Weekly Farmers Market</span></div></div>
+        <h2>Why people choose East Gwillimbury</h2>
+        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>HALP Aquatic and Recreation Centre (opened 2025)</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Sharon heritage village</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Bradford bypass road improvements</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Estate subdivisions in Sharon</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Fastest-growing municipality in York Region</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Holland Landing Conservation Area</span></div></div>
       </div>
 
       <!-- BUYER FIT -->
       <div class="sec" id="buyer-fit">
-        <h2>Is Newmarket the right fit?</h2>
+        <h2>Is East Gwillimbury the right fit?</h2>
         <div class="fit-grid">
           <div class="fit-item fit-good">
             <div class="fit-label">Well suited for</div>
-            <p>First-time buyers, Toronto-based families relocating north, commuters, buyers downsizing from larger GTA homes.</p>
+            <p>Buyers prioritising space, newer construction, and home size. Families with flexible or remote work arrangements. Upsizers from Newmarket, Aurora, or Barrie.</p>
           </div>
           <div class="fit-item fit-watch">
             <div class="fit-label">Things to weigh up</div>
-            <p>With average days on market at 17, well-priced listings in strong school zones move quickly. Budget preparation matters here.</p>
+            <p>East Gwillimbury is car-dependent. There is no GO Train station. Daily commuting requires highway driving, typically 45 to 60 minutes off-peak to central Toronto.</p>
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
-          <strong>Market note:</strong> Newmarket consistently posts the highest transaction volume in York Region. Rental demand from GO commuters provides a practical floor for investment properties.
+          <strong>Market note:</strong> Significant municipal infrastructure investment underway. The HALP recreation centre opened in 2025. Long-term value picture is positive as the area matures, though the current market offers buyer-side leverage.
         </div>
       </div>
 
       <!-- DAY IN LIFE -->
       <div class="sec" id="day-in-life">
-        <h2>A day in Newmarket</h2>
-        <div class="dil-block">Walk to Newmarket GO station in about 9 minutes. Union Station roughly 55 minutes later. Kids are often independent on foot or bike — the neighbourhood has real pedestrian culture. Dinner on Main Street a few nights a week. Weekend: Fairy Lake by kayak, Sunday farmers market, hockey at Ray Twinney Arena.</div>
+        <h2>A day in East Gwillimbury</h2>
+        <div class="dil-block">Morning school drop-off is around the corner — the subdivision layout makes it quick. The 404 south takes 45 to 60 minutes off-peak depending on where you're headed in the city. Pull into the three-car garage in the evening. After dinner: HALP Aquatics with the kids, or a walk in the new trails behind the Sharon expansion. The home is larger and newer than most of what's available further south at this price.</div>
       </div>
 
       <!-- FAQ -->
       <div class="sec" id="faq">
         <h2>Frequently asked questions</h2>
         <details class="faq-item">
-      <summary class="faq-summary">What is Newmarket Ontario known for? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Newmarket is known as one of York Region's most connected and active communities. It has a walkable Main Street, direct GO Train service on the Barrie line, Southlake Regional Health Centre, and Upper Canada Mall. It is York Region's highest-volume real estate market.</div>
+      <summary class="faq-summary">What is East Gwillimbury Ontario like? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">East Gwillimbury is York Region's fastest-growing municipality, spanning Sharon, Queensville, Holland Landing, and Mount Albert. It is known for larger new-construction homes, significant infrastructure investment, and the HALP recreation centre opened in 2025.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">Is Newmarket a good place to buy a home in 2026? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Newmarket's average days on market sat at 17 in early 2026 — the fastest pace in York Region. It offers strong value compared with Aurora while maintaining GO Train access and established neighbourhood stock. Market data from TRREB MLS® 2025–2026.</div>
+      <summary class="faq-summary">Is East Gwillimbury a good place to buy? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. It is currently a buyer's market with approximately 4.5 months of inventory. Daily commuting requires car travel.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">What are the best areas in Newmarket? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Stonehaven-Wyndham is consistently in demand for its school catchment and access to the 404. Armitage and Bristol-London are popular with families. Central Newmarket suits buyers who want walkability and proximity to Main Street amenities.</div>
+      <summary class="faq-summary">Does East Gwillimbury have GO Train service? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">No — East Gwillimbury does not currently have a GO Train station. The closest stations are in Aurora and Newmarket. Residents primarily commute via Highway 404. The Bradford bypass is improving east-west access.</div>
     </details>
       </div>
 
@@ -410,13 +364,13 @@ details[open] .faq-icon{transform:rotate(45deg);}
         <div class="towns-nav"><a href="/communities/aurora" class="town-nav-chip">
       <img src="/Images/towns/aurora.jpg" alt="Aurora NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Aurora
-    </a><a href="/communities/newmarket" class="town-nav-chip current">
+    </a><a href="/communities/newmarket" class="town-nav-chip">
       <img src="/Images/towns/newmarket.jpg" alt="Newmarket NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Newmarket
     </a><a href="/communities/stouffville" class="town-nav-chip">
       <img src="/Images/towns/stouffville.jpg" alt="Stouffville NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Stouffville
-    </a><a href="/communities/east-gwillimbury" class="town-nav-chip">
+    </a><a href="/communities/east-gwillimbury" class="town-nav-chip current">
       <img src="/Images/towns/east-gwillimbury.jpg" alt="East Gwillimbury NorthSide GTA town badge" width="20" height="20" loading="lazy">
       East Gwillimbury
     </a><a href="/communities/georgina" class="town-nav-chip">
@@ -440,37 +394,37 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
         <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$1048K</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$1142K</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$820K</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$544K</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">17d</span></div>
+        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$1150K</span></div>
+        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$1550K</span></div>
+        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$890K</span></div>
+        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$680K</span></div>
+        <div class="prow"><span class="pk">Days on market</span><span class="pv">30d</span></div>
         <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">98%</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">1.6</span></div>
-        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">Balanced market</span></span></div>
+        <div class="prow"><span class="pk">Months inventory</span><span class="pv">4.5</span></div>
+        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">Buyer's market</span></span></div>
         <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">TRREB MLS® 2025–2026. Not an appraisal. Confirm with a registered agent before decisions.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->
       <div class="onemil-box">
-        <div class="onemil-price">What does $1M buy in Newmarket?</div>
-        <p class="onemil-desc">A 4-bed detached in Stonehaven-Wyndham or Armitage — typically a 2000s build with a double garage, finished basement, and solid school catchment. Often includes a pool. Strong value compared with nearby options in Aurora or Richmond Hill.</p>
+        <div class="onemil-price">What does $1M buy in East Gwillimbury?</div>
+        <p class="onemil-desc">A 4 to 5 bed estate detached on a 50 to 60 ft lot in Queensville or Sharon — typically 2,600 to 3,200 sq ft, three-car garage, large backyard, built within the last five years. More home per dollar than most of York Region.</p>
         <p style="font-size:10px;color:var(--ink4);margin-top:8px;">Based on active listings Q1–Q2 2026. Properties vary.</p>
       </div>
 
       <!-- CTA -->
       <div class="cta-card">
         <h3>Talk to a local real estate agent</h3>
-        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether Newmarket fits your lifestyle, budget, and timing.</p>
+        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether East Gwillimbury fits your lifestyle, budget, and timing.</p>
         <div class="agent-sm">
           <div class="asm"><div class="asm-name">Matthew Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
           <div class="asm"><div class="asm-name">Landon Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
         </div>
         <div class="cta-form">
-          <input type="text" id="sf_name_newmarket" placeholder="Your name" autocomplete="name">
-          <input type="email" id="sf_email_newmarket" placeholder="Email address" autocomplete="email">
-          <input type="tel" id="sf_phone_newmarket" placeholder="Phone (optional)" autocomplete="tel">
-          <select id="sf_tl_newmarket">
+          <input type="text" id="sf_name_east-gwillimbury" placeholder="Your name" autocomplete="name">
+          <input type="email" id="sf_email_east-gwillimbury" placeholder="Email address" autocomplete="email">
+          <input type="tel" id="sf_phone_east-gwillimbury" placeholder="Phone (optional)" autocomplete="tel">
+          <select id="sf_tl_east-gwillimbury">
             <option value="">Timeline</option>
             <option>Ready now</option>
             <option>1–3 months</option>
@@ -478,14 +432,14 @@ details[open] .faq-icon{transform:rotate(45deg);}
             <option>6–12 months</option>
             <option>Just researching</option>
           </select>
-          <button class="cta-submit" onclick="submitTownLead('newmarket','Newmarket')">Get local guidance &rarr;</button>
+          <button class="cta-submit" onclick="submitTownLead('east-gwillimbury','East Gwillimbury')">Get local guidance &rarr;</button>
         </div>
         <div class="sms-box">
-          <p>Want listings for Newmarket? Get quiet text alerts.</p>
+          <p>Want listings for East Gwillimbury? Get quiet text alerts.</p>
           <p style="font-size:11px;color:rgba(255,255,255,0.5);margin-bottom:8px;">No spam. Just relevant listings and local updates.</p>
           <div class="sms-row">
-            <input type="tel" id="sms_newmarket" placeholder="Your phone number">
-            <button class="sms-btn" onclick="submitSMSTown('newmarket','Newmarket')">Set alerts</button>
+            <input type="tel" id="sms_east-gwillimbury" placeholder="Your phone number">
+            <button class="sms-btn" onclick="submitSMSTown('east-gwillimbury','East Gwillimbury')">Set alerts</button>
           </div>
         </div>
         <p class="reco-note">By submitting you consent to being contacted by Matthew Mulhall and Landon Mulhall, Sales Representatives, Finally Home Agents Team, HomeLife Optimum Realty, Brokerage, under TRESA, governed by RECO. For SMS: standard msg &amp; data rates may apply. Reply STOP to unsubscribe.</p>
@@ -501,41 +455,60 @@ details[open] .faq-icon{transform:rotate(45deg);}
   </div>
 </footer>
 
-<script>
-function submitTownLead(id, town) {
-  var n = document.getElementById('sf_name_' + id).value.trim();
-  var em = document.getElementById('sf_email_' + id).value.trim();
-  if (!n || !em) { alert('Please enter your name and email.'); return; }
-  var payload = {
-    name: n, email: em,
-    phone: document.getElementById('sf_phone_' + id).value,
-    timeline: document.getElementById('sf_tl_' + id).value,
-    town: town,
-    source: 'NorthSide GTA Neighbourhood Guide v4 — ' + town + ' town page',
-    timestamp: new Date().toISOString()
-  };
-  fetch('/api/leads', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var btn = document.querySelector('.cta-submit');
-  if (btn) { btn.textContent = '✓ Request sent'; btn.disabled = true; }
+
+`;
+
+export default function EastGwillimburyPage() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const townName = "East Gwillimbury";
+    const container = containerRef.current?.querySelector("#th-polls-east-gwillimbury");
+    if (!container) return;
+    fetch("/api/tastehub/polls", { credentials: "same-origin" })
+      .then((r) => { if (!r.ok) throw new Error("no polls"); return r.json(); })
+      .then((data) => {
+        const polls = Array.isArray(data) ? data : data.polls || [];
+        const live = polls.filter((p) => p.status === "live" && p.town && p.town.toLowerCase() === townName.toLowerCase()).slice(0, 3);
+        if (!live.length) return;
+        container.innerHTML = live.map((p) => {
+          const href = p.slug ? `/tastehub/${p.slug}` : "/tastehub";
+          const img = p.image || "/seo/tastehub-default-poll-share.jpg";
+          return `<a href="${href}" class="th-card" style="text-decoration:none;color:inherit;"><img src="${img}" alt="${p.title || "TasteHub poll"}" class="th-card-img" loading="lazy"><div class="th-card-body"><div class="th-card-town">${townName}</div><div class="th-card-title">${p.title || "Local favourite"}</div><div class="th-card-cta">Vote now &rarr;</div></div></a>`;
+        }).join("");
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    window.submitTownLead = (id, town) => {
+      const n = document.getElementById(`sf_name_${id}`)?.value.trim();
+      const em = document.getElementById(`sf_email_${id}`)?.value.trim();
+      if (!n || !em) { alert("Please enter your name and email."); return; }
+      const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
+      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
+    };
+    window.submitSMSTown = (id, town) => {
+      const phone = document.getElementById(`sms_${id}`)?.value.trim();
+      if (!phone) { alert("Please enter your phone number."); return; }
+      const payload = { phone, town, source: `NorthSide SMS opt-in — ${town}`, timestamp: new Date().toISOString() };
+      fetch("/api/sms-optin", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const smsBox = document.getElementById(`sms_${id}`)?.closest(".sms-box");
+      if (smsBox) smsBox.innerHTML = `<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ${town} listings. Reply STOP to unsubscribe.</p>`;
+    };
+    return () => { delete window.submitTownLead; delete window.submitSMSTown; };
+  }, []);
+  const schemaObject = useMemo(() => JSON.parse(PAGE_SCHEMA), []);
+  return (<><Helmet>
+      <title>Living in East Gwillimbury, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
+      <meta name="description" content="Explore East Gwillimbury, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether East Gwillimbury is the right fit for your move north of Toronto." />
+      <meta property="og:title" content="Living in East Gwillimbury, Ontario | NorthSide GTA Guide" />
+      <meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in East Gwillimbury. A practical buyer guide from Finally Home Agents." />
+      <meta property="og:type" content="article" />
+      <meta property="og:url" content="https://northsidegta.ca/communities/east-gwillimbury" />
+      <meta property="og:image" content="https://northsidegta.ca/Images/eastgwillimbury-banner.jpg" />
+      <link rel="canonical" href="https://northsidegta.ca/communities/east-gwillimbury" />
+      <script type="application/ld+json">{JSON.stringify(schemaObject)}</script>
+    </Helmet><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /></>);
 }
-function submitSMSTown(id, town) {
-  var phone = document.getElementById('sms_' + id).value.trim();
-  if (!phone) { alert('Please enter your phone number.'); return; }
-  var payload = { phone: phone, town: town, source: 'NorthSide SMS opt-in — ' + town, timestamp: new Date().toISOString() };
-  fetch('/api/sms-optin', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var smsBox = document.getElementById('sms_' + id).closest('.sms-box');
-  if (smsBox) smsBox.innerHTML = '<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ' + town + ' listings. Reply STOP to unsubscribe.</p>';
-}
-</script>
-</body>
-</html>

--- a/src/GeorginaPage.js
+++ b/src/GeorginaPage.js
@@ -1,49 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Living in Scugog, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
-<meta name="description" content="Explore Scugog, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Scugog is the right fit for your move north of Toronto.">
-<meta property="og:title" content="Living in Scugog, Ontario | NorthSide GTA Guide">
-<meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Scugog. A practical buyer guide from Finally Home Agents.">
-<meta property="og:type" content="article">
-<meta property="og:url" content="https://northsidegta.ca/communities/scugog">
-<meta property="og:image" content="https://northsidegta.ca/Images/scugog-banner.jpg">
-<link rel="canonical" href="https://northsidegta.ca/communities/scugog">
-<script type="application/ld+json">{
-  "@context":"https://schema.org",
-  "@graph":[
-    {
-      "@type":"Article",
-      "headline":"Living in Scugog, Ontario | Real Estate & Neighbourhood Guide",
-      "description":"Port Perry heritage streets, Lake Scugog waterfront, century homes, and a genuinely distinct small-town character.",
-      "url":"https://northsidegta.ca/communities/scugog",
-      "dateModified":"2026-05-24",
-      "author":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
-      ],
-      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
-      "about":{"@type":"City","name":"Scugog","containedInPlace":{"@type":"AdministrativeArea","name":"Durham Region, Ontario"}}
-    },
-    {
-      "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is Port Perry Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Port Perry, the main centre of Scugog Township, is known for its Victorian Main Street, Lake Scugog waterfront, Heritage Festival, antique shops on Water Street, and a well-preserved small-town character. It is one of the more visually distinctive communities in Ontario."}},{"@type":"Question","name":"Is Scugog a good place to buy a home?","acceptedAnswer":{"@type":"Answer","text":"For buyers who want heritage properties, waterfront access, or a genuine small-town character — and who have flexible work arrangements — Scugog offers distinctive properties at Durham Region pricing. The commute to Toronto is the principal consideration: approximately 75 minutes off-peak, more during peak periods."}},{"@type":"Question","name":"What communities are in Scugog Township?","acceptedAnswer":{"@type":"Answer","text":"Scugog includes Port Perry (the main commercial and residential centre), Blackstock, Caesarea, Prince Albert, Nestleton, and extensive rural areas."}}]
-    },
-    {
-      "@type":"RealEstateAgent",
-      "name":"Finally Home Agents Team",
-      "url":"https://northsidegta.ca",
-      "employee":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
-      ]
-    }
-  ]
-}</script>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<style>
+import React, { useEffect, useMemo, useRef } from "react";
+import { Helmet } from "react-helmet-async";
+
+const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
   --green:#1e4d0f;--green2:#2d6b18;--green3:#4a8f2a;
@@ -56,7 +14,7 @@
   --shm:0 4px 20px rgba(0,0,0,0.10);--shl:0 12px 40px rgba(0,0,0,0.13);
   --r:8px;--rl:14px;--rxl:20px;
   --fd:'Playfair Display',Georgia,serif;--fb:'Inter',system-ui,sans-serif;--t:0.18s;
-  --town-color:#2a1208;
+  --town-color:#0a3040;
 }
 html{scroll-behavior:smooth;}
 body{font-family:var(--fb);background:var(--cream);color:var(--ink);font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;}
@@ -116,7 +74,7 @@ img{max-width:100%;display:block;}
 .hl-check{width:18px;height:18px;background:var(--gpale);border-radius:50%;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
 .hl-check svg{width:10px;height:10px;stroke:var(--green);stroke-width:2.5;fill:none;}
 /* DAY IN LIFE */
-.dil-block{background:linear-gradient(135deg,#2a120812,#2a120806);border-left:3px solid #2a1208;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
+.dil-block{background:linear-gradient(135deg,#0a304012,#0a304006);border-left:3px solid #0a3040;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
 /* FAQ */
 .faq-item{border-bottom:1px solid var(--border);}
 .faq-item:last-child{border-bottom:none;}
@@ -153,7 +111,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .pk{color:rgba(255,255,255,0.6);}
 .pv{font-weight:600;color:#fff;}
 .mkt-pill{display:inline-block;font-size:10px;padding:3px 9px;border-radius:8px;background:rgba(255,255,255,0.15);color:#fff;border:1px solid rgba(255,255,255,0.2);font-weight:500;}
-.onemil-box{background:linear-gradient(135deg,#2a120818,#2a120808);border:1px solid #2a120835;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
+.onemil-box{background:linear-gradient(135deg,#0a304018,#0a304008);border:1px solid #0a304035;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
 .onemil-price{font-family:var(--fd);font-size:15px;font-weight:700;color:var(--green);margin-bottom:8px;}
 .onemil-desc{font-size:12.5px;color:var(--ink2);line-height:1.65;}
 /* CTA CARD */
@@ -189,9 +147,39 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-item p{color:var(--ink2);line-height:1.6;}
 @media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
-</style>
-</head>
-<body>
+`;
+const PAGE_SCHEMA = `{
+  "@context":"https://schema.org",
+  "@graph":[
+    {
+      "@type":"Article",
+      "headline":"Living in Georgina, Ontario | Real Estate & Neighbourhood Guide",
+      "description":"Lake Simcoe access, larger lots, and one of the most accessible price points in York Region.",
+      "url":"https://northsidegta.ca/communities/georgina",
+      "dateModified":"2026-05-24",
+      "author":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
+      ],
+      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
+      "about":{"@type":"City","name":"Georgina","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
+    },
+    {
+      "@type":"FAQPage",
+      "mainEntity":[{"@type":"Question","name":"What is Georgina Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Georgina is known for Lake Simcoe waterfront access, recreational fishing (perch and walleye), summer boating, seasonal ice fishing, and communities including Keswick, Sutton, and Jackson's Point. It is the most affordable municipality in York Region by average sale price."}},{"@type":"Question","name":"Is Georgina a good place to live?","acceptedAnswer":{"@type":"Answer","text":"Georgina is a strong option for buyers who want more space, waterfront access, or a different pace — particularly those with remote work arrangements. The primary trade-offs are a longer commute to Toronto and car-dependence for daily needs."}},{"@type":"Question","name":"What communities are in Georgina?","acceptedAnswer":{"@type":"Answer","text":"Georgina includes Keswick (the largest urban centre), Keswick South, Keswick North, Sutton, Jackson's Point, Pefferlaw, Baldwin, Belhaven, Virginia, and historic lakeshore communities along Lake Simcoe."}}]
+    },
+    {
+      "@type":"RealEstateAgent",
+      "name":"Finally Home Agents Team",
+      "url":"https://northsidegta.ca",
+      "employee":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
+      ]
+    }
+  ]
+}`;
+const PAGE_BODY_HTML = `
 
 <nav class="topnav" role="navigation" aria-label="Site navigation">
   <a href="https://northsidegta.ca" class="topnav-logo">NorthSide <span>GTA</span></a>
@@ -204,20 +192,20 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
 <!-- HERO -->
 <header class="hero" role="banner">
-  <img src="/Images/scugog-banner.jpg" alt="Port Perry waterfront in Scugog" class="hero-img" loading="eager">
+  <img src="/Images/georgina-banner.jpg" alt="Lake Simcoe shoreline in Georgina" class="hero-img" loading="eager">
   <div class="hero-overlay" aria-hidden="true"></div>
   <div class="hero-content">
     <div class="hero-eyebrow">
-      <img src="/Images/towns/scugog.jpg" alt="Scugog NorthSide GTA town badge" class="town-badge">
-      <span>Durham Region &middot; NorthSide GTA</span>
+      <img src="/Images/towns/georgina.jpg" alt="Georgina NorthSide GTA town badge" class="town-badge">
+      <span>York Region &middot; NorthSide GTA</span>
     </div>
-    <h1>Living in Scugog</h1>
-    <p class="hero-sub">Port Perry heritage, Lake Scugog waterfront, small-town character, and a slower pace within reach of the GTA.</p>
+    <h1>Living in Georgina</h1>
+    <p class="hero-sub">Lake Simcoe, more space, shoreline communities, beaches, marinas, and one of York Region's most accessible price points.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">$960K</div><div class="hstat-lbl">Avg. sold</div></div>
-      <div class="hstat"><div class="hstat-val">75 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">36d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">5.5 mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">$875K</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">65 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
+      <div class="hstat"><div class="hstat-val">38d</div><div class="hstat-lbl">Avg. on mkt</div></div>
+      <div class="hstat"><div class="hstat-val">7.5 mo</div><div class="hstat-lbl">Inventory</div></div>
     </div>
   </div>
 </header>
@@ -227,7 +215,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <a href="https://northsidegta.ca">Home</a><span>&rsaquo;</span>
     <a href="https://northsidegta.ca/neighbourhood-guide">Neighbourhood guide</a><span>&rsaquo;</span>
-    <span>Scugog</span>
+    <span>Georgina</span>
   </nav>
   <div class="page-grid">
 
@@ -236,8 +224,8 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- INTRO -->
       <div class="sec">
-        <div class="sec-eyebrow">About Scugog</div>
-        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Scugog is a deliberate choice. Buyers who move here are typically not compromising — they are choosing Port Perry's character, Lake Scugog's waterfront, and a pace that the closer suburbs cannot offer. The commute trade-off is real and should be factored into any decision. The heritage property stock, particularly on and near Main Street, is irreplaceable.</p>
+        <div class="sec-eyebrow">About Georgina</div>
+        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Georgina is a strong option for buyers who want more space, waterfront access, or a different pace — and who are comfortable with the commute trade-off. With 7.5 months of inventory, it is currently a buyer's market with meaningful negotiating room, particularly on non-waterfront properties.</p>
         <div style="margin-top:14px;display:flex;gap:6px;flex-wrap:wrap;">
           <a href="#contact" class="btn-primary" style="font-size:13px;padding:10px 20px;">Get local guidance</a>
           <a href="https://northsidegta.ca/neighbourhood-guide" class="btn-secondary" style="font-size:13px;padding:9px 18px;">Compare all towns</a>
@@ -246,9 +234,9 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- SUB-COMMUNITIES -->
       <div class="sec" id="neighbourhoods">
-        <h2>Neighbourhoods &amp; areas in Scugog</h2>
-        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Port Perry</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Blackstock</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Caesarea</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Prince Albert</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Rural Scugog</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Nestleton</span></div>
-        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within Scugog has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
+        <h2>Neighbourhoods &amp; areas in Georgina</h2>
+        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Keswick</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Keswick South</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Keswick North</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Sutton</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Jackson's Point</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Pefferlaw</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Baldwin</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Belhaven</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Virginia</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Historic Lakeshore Communities</span></div>
+        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within Georgina has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
       </div>
 
       <!-- SCHOOLS & COMMUTE -->
@@ -257,26 +245,30 @@ details[open] .faq-icon{transform:rotate(45deg);}
         <table class="school-table" aria-label="Schools">
       <thead><tr><th>School</th><th>Rating</th><th>Notes</th></tr></thead>
       <tbody><tr>
-      <td><div class="school-name">Port Perry High School</div><div class="school-type">Public Secondary</div></td>
-      <td class="school-rating">6.5/10</td>
-      <td class="school-note">Durham District School Board</td>
-    </tr><tr>
-      <td><div class="school-name">Scugog Central Public School</div><div class="school-type">Public Elementary</div></td>
+      <td><div class="school-name">Keswick High School</div><div class="school-type">Public Secondary</div></td>
       <td class="school-rating">6.8/10</td>
-      <td class="school-note">Fraser Institute 2024</td>
+      <td class="school-note">York Region District School Board</td>
     </tr><tr>
-      <td><div class="school-name">St. Theresa Catholic Elementary</div><div class="school-type">Catholic Elementary</div></td>
+      <td><div class="school-name">Sutton District High School</div><div class="school-type">Public Secondary</div></td>
+      <td class="school-rating">6.5/10</td>
+      <td class="school-note">York Region District School Board</td>
+    </tr><tr>
+      <td><div class="school-name">Our Lady of the Lake Catholic Elem.</div><div class="school-type">Catholic Elementary</div></td>
+      <td class="school-rating">6.9/10</td>
+      <td class="school-note">York Catholic District School Board</td>
+    </tr><tr>
+      <td><div class="school-name">Keswick Public School</div><div class="school-type">Public Elementary</div></td>
       <td class="school-rating">6.7/10</td>
-      <td class="school-note">Durham Catholic District School Board</td>
+      <td class="school-note">York Region District School Board</td>
     </tr></tbody>
     </table>
     <p style="font-size:11px;color:var(--ink4);margin-top:10px;line-height:1.65;">Ratings from Fraser Institute Ontario School Report Cards 2024/2025. School boundaries can change — verify directly with the relevant school board before making a property decision.</p>
         <div style="margin-top:18px;">
-          <h2 style="font-size:18px;margin-bottom:10px;">Commute from Scugog</h2>
+          <h2 style="font-size:18px;margin-bottom:10px;">Commute from Georgina</h2>
           <div style="background:var(--cream);border-radius:var(--r);padding:14px 16px;font-size:13px;color:var(--ink2);line-height:1.75;">
-            <div><strong>Distance to DVP/401:</strong> 88 km</div>
-            <div><strong>Off-peak drive time:</strong> approximately 75 minutes</div>
-            <div><strong>Transit:</strong> Car-dependent — Durham Transit only</div>
+            <div><strong>Distance to DVP/401:</strong> 80 km</div>
+            <div><strong>Off-peak drive time:</strong> approximately 65 minutes</div>
+            <div><strong>Transit:</strong> Car-dependent — no GO Train service</div>
             <div style="margin-top:8px;font-size:12px;color:var(--ink4);">Drive times are off-peak estimates. Peak-hour commute times are typically 30–60% longer depending on conditions.</div>
           </div>
         </div>
@@ -286,113 +278,83 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <div class="sec" id="restaurants">
         <h2>Local restaurants &amp; cafés</h2>
         <div class="rest-item">
-      <div><div class="rest-name">Simcoe Street Grill</div><div class="rest-desc">Waterfront dining — well-regarded locally</div></div>
+      <div><div class="rest-name">Jack's Waterfront Restaurant</div><div class="rest-desc">Lakeside dining — popular summer patio in Keswick</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">St. Andrew's Pub</div><div class="rest-desc">Heritage pub in a 150-year-old building</div></div>
+      <div><div class="rest-name">Cook's Bay Brewhouse</div><div class="rest-desc">Local craft brewery in Keswick</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Princess Street Cafe</div><div class="rest-desc">Weekend brunch — busy by 9 AM</div></div>
+      <div><div class="rest-name">Jackson's Point Bistro</div><div class="rest-desc">Seasonal lakeside dining</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Fiesta Gardens</div><div class="rest-desc">Coffee and gelato on the main strip</div></div>
-    </div><div class="rest-item">
-      <div><div class="rest-name">Inn at Port Perry (dining)</div><div class="rest-desc">Sit-down dining in a historic inn</div></div>
+      <div><div class="rest-name">Sutton cafés and diners</div><div class="rest-desc">Small-town café culture across Sutton</div></div>
     </div><p style="font-size:11px;color:var(--ink4);margin-top:10px;">Included for community context. Not ranked or endorsed by Finally Home Agents.</p>
       </div>
 
       <!-- TASTEHUB -->
-      <section class="th-section" aria-labelledby="th-h-scugog">
+      <section class="th-section" aria-labelledby="th-h-georgina">
   <div class="th-header">
     <div>
       <div class="sec-eyebrow">Community-powered local food picks</div>
-      <h2 class="sec-h2" id="th-h-scugog" style="font-size:20px;">NorthSide TasteHub Local Favourites in Scugog</h2>
-      <p class="sec-sub" style="font-size:13px;margin-top:6px;">Port Perry's restaurants, cafés, bakeries, patios, and lake-town favourites are a major part of Scugog's lifestyle. TasteHub shows what locals are voting for.</p>
+      <h2 class="sec-h2" id="th-h-georgina" style="font-size:20px;">NorthSide TasteHub Local Favourites in Georgina</h2>
+      <p class="sec-sub" style="font-size:13px;margin-top:6px;">Lake days, casual patios, pizza nights, and local cafés are part of Georgina's appeal. TasteHub helps buyers discover where locals are actually going.</p>
       <p style="font-size:11px;color:var(--ink4);margin-top:6px;">TasteHub results are community-powered and are not paid rankings or endorsements.</p>
     </div>
     <div style="display:flex;flex-direction:column;gap:8px;flex-shrink:0;">
-      <a href="/tastehub?town=scugog" class="btn-primary" style="font-size:12px;padding:9px 18px;">See Scugog favourites</a>
+      <a href="/tastehub?town=georgina" class="btn-primary" style="font-size:12px;padding:9px 18px;">See Georgina favourites</a>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;padding:8px 16px;">Vote on TasteHub</a>
     </div>
   </div>
-  <div id="th-polls-scugog" class="th-cards">
+  <div id="th-polls-georgina" class="th-cards">
     <!-- TasteHub polls load here -->
     <div class="th-fallback">
-      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for Scugog are coming soon.</p>
+      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for Georgina are coming soon.</p>
       <p style="margin-bottom:14px;">Explore live TasteHub voting across the NorthSide GTA.</p>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;">See all TasteHub polls</a>
     </div>
   </div>
 </section>
-<script>
-(function(){
-  var townName = "Scugog";
-  var containerId = "th-polls-scugog";
-  var tasteHubUrl = "/tastehub?town=" + encodeURIComponent(townName.toLowerCase().replace(/ /g,'-'));
-  fetch('/api/tastehub/polls', {credentials:'same-origin'})
-    .then(function(r){if(!r.ok)throw new Error('no polls');return r.json();})
-    .then(function(data){
-      var polls = Array.isArray(data) ? data : (data.polls || []);
-      var live = polls.filter(function(p){
-        return p.status === 'live' && p.town && p.town.toLowerCase() === townName.toLowerCase();
-      }).slice(0,3);
-      if(live.length === 0) return;
-      var container = document.getElementById(containerId);
-      container.innerHTML = live.map(function(p){
-        var href = p.slug ? '/tastehub/' + p.slug : '/tastehub';
-        var img = p.image || '/seo/tastehub-default-poll-share.jpg';
-        return '<a href="' + href + '" class="th-card" style="text-decoration:none;color:inherit;">'
-          + '<img src="' + img + '" alt="' + (p.title||'TasteHub poll') + '" class="th-card-img" loading="lazy">'
-          + '<div class="th-card-body">'
-          + '<div class="th-card-town">' + townName + '</div>'
-          + '<div class="th-card-title">' + (p.title||'Local favourite') + '</div>'
-          + '<div class="th-card-cta">Vote now &rarr;</div>'
-          + '</div></a>';
-      }).join('');
-    })
-    .catch(function(){ /* fallback already shown */ });
-})();
-</script>
+
 
       <!-- WHY PEOPLE CHOOSE -->
       <div class="sec" id="lifestyle">
-        <h2>Why people choose Scugog</h2>
-        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Port Perry Victorian Main Street</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Lake Scugog waterfront</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Heritage Festival (annual summer event)</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Boutique shops and galleries on Water St</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Antiques on Water Street</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Fireworks on the lake, July 1st</span></div></div>
+        <h2>Why people choose Georgina</h2>
+        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Lake Simcoe shoreline access</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Sibbald Point Provincial Park</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Jackson's Point beach and marina</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Cook's Bay</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Pefferlaw Brook trails</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Boating, fishing, and seasonal ice fishing</span></div></div>
       </div>
 
       <!-- BUYER FIT -->
       <div class="sec" id="buyer-fit">
-        <h2>Is Scugog the right fit?</h2>
+        <h2>Is Georgina the right fit?</h2>
         <div class="fit-grid">
           <div class="fit-item fit-good">
             <div class="fit-label">Well suited for</div>
-            <p>Heritage home buyers, waterfront property seekers, buyers with remote work flexibility, buyers approaching or in retirement.</p>
+            <p>Buyers with remote work flexibility, waterfront property seekers, buyers who want more space and a different pace at an accessible price point.</p>
           </div>
           <div class="fit-item fit-watch">
             <div class="fit-label">Things to weigh up</div>
-            <p>Scugog has the longest commute of the seven NorthSide GTA communities — approximately 75 minutes off-peak to central Toronto, and considerably longer during peak hours. Remote or hybrid work is a practical prerequisite for most buyers.</p>
+            <p>Georgina requires car travel for essentially all daily needs. There is no GO Train service. Commute to central Toronto is approximately 65 minutes off-peak and longer during peak periods.</p>
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
-          <strong>Market note:</strong> Waterfront and heritage properties have historically held value relative to the broader local market. Non-waterfront inventory is soft, with 5.5 months available and buyers holding meaningful negotiating room.
+          <strong>Market note:</strong> Waterfront properties in Georgina have historically held value relative to the broader market. The overall market has 7.5 months of inventory, which gives buyers meaningful negotiating room.
         </div>
       </div>
 
       <!-- DAY IN LIFE -->
       <div class="sec" id="day-in-life">
-        <h2>A day in Scugog</h2>
-        <div class="dil-block">Morning walk along Water Street — Port Perry's Main Street is genuinely one of the most well-preserved Victorian streetscapes in Ontario. Work from home, or commit to the long drive. Evenings on the dock in summer. Weekend: Port Perry Farmers Market, kayaking on the lake, antique browsing on Water Street. The Heritage Festival in late summer brings the whole region in.</div>
+        <h2>A day in Georgina</h2>
+        <div class="dil-block">No fixed alarm on remote work days. Coffee with a view of the lake, then the laptop open by 8:30. Afternoon: paddleboard from the dock or a walk to Keswick Beach with the kids. Evenings at Jack's waterfront patio when the weather cooperates. The trade-off with the commute is something Georgina buyers are conscious of — most have made a deliberate choice about where they want to spend their time.</div>
       </div>
 
       <!-- FAQ -->
       <div class="sec" id="faq">
         <h2>Frequently asked questions</h2>
         <details class="faq-item">
-      <summary class="faq-summary">What is Port Perry Ontario known for? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Port Perry, the main centre of Scugog Township, is known for its Victorian Main Street, Lake Scugog waterfront, Heritage Festival, antique shops on Water Street, and a well-preserved small-town character. It is one of the more visually distinctive communities in Ontario.</div>
+      <summary class="faq-summary">What is Georgina Ontario known for? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Georgina is known for Lake Simcoe waterfront access, recreational fishing (perch and walleye), summer boating, seasonal ice fishing, and communities including Keswick, Sutton, and Jackson's Point. It is the most affordable municipality in York Region by average sale price.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">Is Scugog a good place to buy a home? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">For buyers who want heritage properties, waterfront access, or a genuine small-town character — and who have flexible work arrangements — Scugog offers distinctive properties at Durham Region pricing. The commute to Toronto is the principal consideration: approximately 75 minutes off-peak, more during peak periods.</div>
+      <summary class="faq-summary">Is Georgina a good place to live? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Georgina is a strong option for buyers who want more space, waterfront access, or a different pace — particularly those with remote work arrangements. The primary trade-offs are a longer commute to Toronto and car-dependence for daily needs.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">What communities are in Scugog Township? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Scugog includes Port Perry (the main commercial and residential centre), Blackstock, Caesarea, Prince Albert, Nestleton, and extensive rural areas.</div>
+      <summary class="faq-summary">What communities are in Georgina? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Georgina includes Keswick (the largest urban centre), Keswick South, Keswick North, Sutton, Jackson's Point, Pefferlaw, Baldwin, Belhaven, Virginia, and historic lakeshore communities along Lake Simcoe.</div>
     </details>
       </div>
 
@@ -411,13 +373,13 @@ details[open] .faq-icon{transform:rotate(45deg);}
     </a><a href="/communities/east-gwillimbury" class="town-nav-chip">
       <img src="/Images/towns/east-gwillimbury.jpg" alt="East Gwillimbury NorthSide GTA town badge" width="20" height="20" loading="lazy">
       East Gwillimbury
-    </a><a href="/communities/georgina" class="town-nav-chip">
+    </a><a href="/communities/georgina" class="town-nav-chip current">
       <img src="/Images/towns/georgina.jpg" alt="Georgina NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Georgina
     </a><a href="/communities/uxbridge" class="town-nav-chip">
       <img src="/Images/towns/uxbridge.jpg" alt="Uxbridge NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Uxbridge
-    </a><a href="/communities/scugog" class="town-nav-chip current">
+    </a><a href="/communities/scugog" class="town-nav-chip">
       <img src="/Images/towns/scugog.jpg" alt="Scugog NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Scugog
     </a></div>
@@ -432,37 +394,37 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
         <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$960K</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$1099K</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$762K</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$800K</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">36d</span></div>
-        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">98%</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">5.5</span></div>
+        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$875K</span></div>
+        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$910K</span></div>
+        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$815K</span></div>
+        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$590K</span></div>
+        <div class="prow"><span class="pk">Days on market</span><span class="pv">38d</span></div>
+        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">97%</span></div>
+        <div class="prow"><span class="pk">Months inventory</span><span class="pv">7.5</span></div>
         <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">Buyer's market</span></span></div>
         <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">TRREB MLS® 2025–2026. Not an appraisal. Confirm with a registered agent before decisions.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->
       <div class="onemil-box">
-        <div class="onemil-price">What does $1M buy in Scugog?</div>
-        <p class="onemil-desc">A well-preserved Victorian century home on a double lot steps from Port Perry's Main Street and the waterfront, or a contemporary 4-bed on Lake Scugog with dock access. Heritage properties of this character are rare and not replicable at this price elsewhere in the GTA orbit.</p>
+        <div class="onemil-price">What does $1M buy in Georgina?</div>
+        <p class="onemil-desc">A 4-bed waterfront or near-waterfront property on Lake Simcoe with a private dock and mature trees. Or a newer 5-bed detached in Keswick North with a triple garage on a large lot. Strong value compared with nearby options anywhere else in York Region at this price.</p>
         <p style="font-size:10px;color:var(--ink4);margin-top:8px;">Based on active listings Q1–Q2 2026. Properties vary.</p>
       </div>
 
       <!-- CTA -->
       <div class="cta-card">
         <h3>Talk to a local real estate agent</h3>
-        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether Scugog fits your lifestyle, budget, and timing.</p>
+        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether Georgina fits your lifestyle, budget, and timing.</p>
         <div class="agent-sm">
           <div class="asm"><div class="asm-name">Matthew Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
           <div class="asm"><div class="asm-name">Landon Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
         </div>
         <div class="cta-form">
-          <input type="text" id="sf_name_scugog" placeholder="Your name" autocomplete="name">
-          <input type="email" id="sf_email_scugog" placeholder="Email address" autocomplete="email">
-          <input type="tel" id="sf_phone_scugog" placeholder="Phone (optional)" autocomplete="tel">
-          <select id="sf_tl_scugog">
+          <input type="text" id="sf_name_georgina" placeholder="Your name" autocomplete="name">
+          <input type="email" id="sf_email_georgina" placeholder="Email address" autocomplete="email">
+          <input type="tel" id="sf_phone_georgina" placeholder="Phone (optional)" autocomplete="tel">
+          <select id="sf_tl_georgina">
             <option value="">Timeline</option>
             <option>Ready now</option>
             <option>1–3 months</option>
@@ -470,14 +432,14 @@ details[open] .faq-icon{transform:rotate(45deg);}
             <option>6–12 months</option>
             <option>Just researching</option>
           </select>
-          <button class="cta-submit" onclick="submitTownLead('scugog','Scugog')">Get local guidance &rarr;</button>
+          <button class="cta-submit" onclick="submitTownLead('georgina','Georgina')">Get local guidance &rarr;</button>
         </div>
         <div class="sms-box">
-          <p>Want listings for Scugog? Get quiet text alerts.</p>
+          <p>Want listings for Georgina? Get quiet text alerts.</p>
           <p style="font-size:11px;color:rgba(255,255,255,0.5);margin-bottom:8px;">No spam. Just relevant listings and local updates.</p>
           <div class="sms-row">
-            <input type="tel" id="sms_scugog" placeholder="Your phone number">
-            <button class="sms-btn" onclick="submitSMSTown('scugog','Scugog')">Set alerts</button>
+            <input type="tel" id="sms_georgina" placeholder="Your phone number">
+            <button class="sms-btn" onclick="submitSMSTown('georgina','Georgina')">Set alerts</button>
           </div>
         </div>
         <p class="reco-note">By submitting you consent to being contacted by Matthew Mulhall and Landon Mulhall, Sales Representatives, Finally Home Agents Team, HomeLife Optimum Realty, Brokerage, under TRESA, governed by RECO. For SMS: standard msg &amp; data rates may apply. Reply STOP to unsubscribe.</p>
@@ -493,41 +455,60 @@ details[open] .faq-icon{transform:rotate(45deg);}
   </div>
 </footer>
 
-<script>
-function submitTownLead(id, town) {
-  var n = document.getElementById('sf_name_' + id).value.trim();
-  var em = document.getElementById('sf_email_' + id).value.trim();
-  if (!n || !em) { alert('Please enter your name and email.'); return; }
-  var payload = {
-    name: n, email: em,
-    phone: document.getElementById('sf_phone_' + id).value,
-    timeline: document.getElementById('sf_tl_' + id).value,
-    town: town,
-    source: 'NorthSide GTA Neighbourhood Guide v4 — ' + town + ' town page',
-    timestamp: new Date().toISOString()
-  };
-  fetch('/api/leads', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var btn = document.querySelector('.cta-submit');
-  if (btn) { btn.textContent = '✓ Request sent'; btn.disabled = true; }
+
+`;
+
+export default function GeorginaPage() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const townName = "Georgina";
+    const container = containerRef.current?.querySelector("#th-polls-georgina");
+    if (!container) return;
+    fetch("/api/tastehub/polls", { credentials: "same-origin" })
+      .then((r) => { if (!r.ok) throw new Error("no polls"); return r.json(); })
+      .then((data) => {
+        const polls = Array.isArray(data) ? data : data.polls || [];
+        const live = polls.filter((p) => p.status === "live" && p.town && p.town.toLowerCase() === townName.toLowerCase()).slice(0, 3);
+        if (!live.length) return;
+        container.innerHTML = live.map((p) => {
+          const href = p.slug ? `/tastehub/${p.slug}` : "/tastehub";
+          const img = p.image || "/seo/tastehub-default-poll-share.jpg";
+          return `<a href="${href}" class="th-card" style="text-decoration:none;color:inherit;"><img src="${img}" alt="${p.title || "TasteHub poll"}" class="th-card-img" loading="lazy"><div class="th-card-body"><div class="th-card-town">${townName}</div><div class="th-card-title">${p.title || "Local favourite"}</div><div class="th-card-cta">Vote now &rarr;</div></div></a>`;
+        }).join("");
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    window.submitTownLead = (id, town) => {
+      const n = document.getElementById(`sf_name_${id}`)?.value.trim();
+      const em = document.getElementById(`sf_email_${id}`)?.value.trim();
+      if (!n || !em) { alert("Please enter your name and email."); return; }
+      const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
+      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
+    };
+    window.submitSMSTown = (id, town) => {
+      const phone = document.getElementById(`sms_${id}`)?.value.trim();
+      if (!phone) { alert("Please enter your phone number."); return; }
+      const payload = { phone, town, source: `NorthSide SMS opt-in — ${town}`, timestamp: new Date().toISOString() };
+      fetch("/api/sms-optin", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const smsBox = document.getElementById(`sms_${id}`)?.closest(".sms-box");
+      if (smsBox) smsBox.innerHTML = `<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ${town} listings. Reply STOP to unsubscribe.</p>`;
+    };
+    return () => { delete window.submitTownLead; delete window.submitSMSTown; };
+  }, []);
+  const schemaObject = useMemo(() => JSON.parse(PAGE_SCHEMA), []);
+  return (<><Helmet>
+      <title>Living in Georgina, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
+      <meta name="description" content="Explore Georgina, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Georgina is the right fit for your move north of Toronto." />
+      <meta property="og:title" content="Living in Georgina, Ontario | NorthSide GTA Guide" />
+      <meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Georgina. A practical buyer guide from Finally Home Agents." />
+      <meta property="og:type" content="article" />
+      <meta property="og:url" content="https://northsidegta.ca/communities/georgina" />
+      <meta property="og:image" content="https://northsidegta.ca/Images/georgina-banner.jpg" />
+      <link rel="canonical" href="https://northsidegta.ca/communities/georgina" />
+      <script type="application/ld+json">{JSON.stringify(schemaObject)}</script>
+    </Helmet><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /></>);
 }
-function submitSMSTown(id, town) {
-  var phone = document.getElementById('sms_' + id).value.trim();
-  if (!phone) { alert('Please enter your phone number.'); return; }
-  var payload = { phone: phone, town: town, source: 'NorthSide SMS opt-in — ' + town, timestamp: new Date().toISOString() };
-  fetch('/api/sms-optin', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var smsBox = document.getElementById('sms_' + id).closest('.sms-box');
-  if (smsBox) smsBox.innerHTML = '<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ' + town + ' listings. Reply STOP to unsubscribe.</p>';
-}
-</script>
-</body>
-</html>

--- a/src/GeorginaPage.js
+++ b/src/GeorginaPage.js
@@ -486,7 +486,7 @@ export default function GeorginaPage() {
       const em = document.getElementById(`sf_email_${id}`)?.value.trim();
       if (!n || !em) { alert("Please enter your name and email."); return; }
       const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
-      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      fetch("/api/send-lead", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ...payload, casl: true, notRepresented: true, title: `NorthSide GTA local guidance — ${town}`, realmLink: window.location.href }), credentials: "same-origin" }).catch(() => {});
       const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
     };
     window.submitSMSTown = (id, town) => {

--- a/src/NeighbourhoodGuidePage.js
+++ b/src/NeighbourhoodGuidePage.js
@@ -1,51 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>NorthSide GTA Neighbourhood Guide | Compare Aurora, Newmarket, Stouffville, East Gwillimbury, Georgina, Uxbridge & Scugog | Finally Home Agents</title>
-<meta name="description" content="A practical neighbourhood guide for buyers looking north of Toronto. Compare home prices, commute times, schools, lifestyle, and local favourites for Aurora, Newmarket, Stouffville, East Gwillimbury, Georgina, Uxbridge, and Scugog.">
-<meta property="og:title" content="NorthSide GTA Neighbourhood Guide | Finally Home Agents">
-<meta property="og:description" content="Compare Aurora, Newmarket, Stouffville, East Gwillimbury, Georgina, Uxbridge, and Scugog. Prices, commutes, schools, and the trade-offs that matter.">
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://northsidegta.ca/neighbourhood-guide">
-<meta property="og:image" content="https://northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg">
-<link rel="canonical" href="https://northsidegta.ca/neighbourhood-guide">
-<script type="application/ld+json">{
-  "@context":"https://schema.org",
-  "@graph":[
-    {
-      "@type":"WebPage",
-      "name":"NorthSide GTA Neighbourhood Guide",
-      "description":"A practical neighbourhood guide for buyers looking north of Toronto. Compare Aurora, Newmarket, Stouffville, East Gwillimbury, Georgina, Uxbridge, and Scugog.",
-      "url":"https://northsidegta.ca/neighbourhood-guide",
-      "dateModified":"2026-05-24",
-      "publisher":{
-        "@type":"RealEstateAgent",
-        "name":"Finally Home Agents Team",
-        "url":"https://northsidegta.ca",
-        "employee":[
-          {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
-          {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
-        ]
-      }
-    },
-    {
-      "@type":"FAQPage",
-      "mainEntity":[
-        {"@type":"Question","name":"What is the average home price in Aurora Ontario 2026?","acceptedAnswer":{"@type":"Answer","text":"The average sold price in Aurora is approximately $1,122,000 across all home types (TRREB MLS Q1 2026). Detached homes average around $1,561,000. It is currently a buyer's market with approximately 4.2 months of inventory."}},
-        {"@type":"Question","name":"Which towns north of Toronto have GO Train access?","acceptedAnswer":{"@type":"Answer","text":"Aurora and Newmarket are served by the GO Barrie line with service to Union Station. Stouffville is served by the GO Stouffville line. East Gwillimbury, Georgina, Uxbridge, and Scugog are car-dependent for Toronto commuting."}},
-        {"@type":"Question","name":"What is Georgina Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Georgina is known for Lake Simcoe waterfront living across communities including Keswick, Sutton, and Jackson's Point. It is one of York Region's most affordable municipalities and is popular with remote workers and buyers seeking waterfront access."}},
-        {"@type":"Question","name":"What is the most affordable town north of Toronto?","acceptedAnswer":{"@type":"Answer","text":"Georgina has the lowest average sold price among the NorthSide GTA communities at approximately $875,000 (TRREB 2025–2026). Scugog ($960,000) and Uxbridge ($990,000) are also below the $1M average mark."}},
-        {"@type":"Question","name":"What is Uxbridge Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge is officially Canada's Trail Capital, with over 300 kilometres of trails on the Oak Ridges Moraine. It is also known for its equestrian community, heritage downtown, Dagmar Ski Resort, and active arts and theatre scene."}}
-      ]
-    }
-  ]
-}</script>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<style>
+import React, { useEffect, useMemo, useRef } from "react";
+import { Helmet } from "react-helmet-async";
+
+const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
   --green:#1e4d0f;--green2:#2d6b18;--green3:#4a8f2a;
@@ -368,9 +324,39 @@ details[open] .faq-icon{transform:rotate(45deg);}
   .lead-section{padding:40px 16px;}
   .form-card{padding:20px;}
 }
-</style>
-</head>
-<body>
+`;
+const PAGE_SCHEMA = `{
+  "@context":"https://schema.org",
+  "@graph":[
+    {
+      "@type":"WebPage",
+      "name":"NorthSide GTA Neighbourhood Guide",
+      "description":"A practical neighbourhood guide for buyers looking north of Toronto. Compare Aurora, Newmarket, Stouffville, East Gwillimbury, Georgina, Uxbridge, and Scugog.",
+      "url":"https://northsidegta.ca/neighbourhood-guide",
+      "dateModified":"2026-05-24",
+      "publisher":{
+        "@type":"RealEstateAgent",
+        "name":"Finally Home Agents Team",
+        "url":"https://northsidegta.ca",
+        "employee":[
+          {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
+          {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
+        ]
+      }
+    },
+    {
+      "@type":"FAQPage",
+      "mainEntity":[
+        {"@type":"Question","name":"What is the average home price in Aurora Ontario 2026?","acceptedAnswer":{"@type":"Answer","text":"The average sold price in Aurora is approximately $1,122,000 across all home types (TRREB MLS Q1 2026). Detached homes average around $1,561,000. It is currently a buyer's market with approximately 4.2 months of inventory."}},
+        {"@type":"Question","name":"Which towns north of Toronto have GO Train access?","acceptedAnswer":{"@type":"Answer","text":"Aurora and Newmarket are served by the GO Barrie line with service to Union Station. Stouffville is served by the GO Stouffville line. East Gwillimbury, Georgina, Uxbridge, and Scugog are car-dependent for Toronto commuting."}},
+        {"@type":"Question","name":"What is Georgina Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Georgina is known for Lake Simcoe waterfront living across communities including Keswick, Sutton, and Jackson's Point. It is one of York Region's most affordable municipalities and is popular with remote workers and buyers seeking waterfront access."}},
+        {"@type":"Question","name":"What is the most affordable town north of Toronto?","acceptedAnswer":{"@type":"Answer","text":"Georgina has the lowest average sold price among the NorthSide GTA communities at approximately $875,000 (TRREB 2025–2026). Scugog ($960,000) and Uxbridge ($990,000) are also below the $1M average mark."}},
+        {"@type":"Question","name":"What is Uxbridge Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge is officially Canada's Trail Capital, with over 300 kilometres of trails on the Oak Ridges Moraine. It is also known for its equestrian community, heritage downtown, Dagmar Ski Resort, and active arts and theatre scene."}}
+      ]
+    }
+  ]
+}`;
+const PAGE_BODY_HTML = `
 
 <div id="maptip" role="tooltip" aria-live="polite"></div>
 
@@ -830,445 +816,41 @@ details[open] .faq-icon{transform:rotate(45deg);}
   </div>
 </footer>
 
-<script>
-// ── DATA ────────────────────────────────────────────────────────────────────
-var HOODS=[
-  {id:'aurora',name:'Aurora',region:'York Region',type:'urban',slug:'aurora',
-   banner:'/Images/aurora-banner.jpg',badge:'/Images/towns/aurora.jpg',
-   positioning:'Established neighbourhoods, strong schools, heritage streets, and direct GO Train access.',
-   avgPrice:1122,det:1561,town:918,condo:720,dvpKm:46,driveMin:35,
-   transit:'GO Train (Barrie line) — approx. 45 min to Union',walk:52,school:8.5,
-   dom:24,spl:97,inv:4.2,pop:'~62,000',lot:'Varied — small to large',newdev:'Moderate',
-   mkt:"Buyer's",bestFor:'Families, upsizers, commuters',
-   watch:'Premium pricing; older homes may need updates',
-   invest:'Market tends to hold value consistently across cycles',
-   pills:[['p-go','GO Train'],['p-school','Strong schools'],['p-her','Heritage downtown']],
-   subs:['Aurora Village','Aurora Heights','Aurora Highlands','Aurora Estates','Bayview Wellington','Hills of St. Andrew','Rural Aurora'],
-   schools:[['Dr. G.W. Williams Secondary','Public Secondary','8.8/10','Top 30 Ontario — Fraser 2024'],['Aurora High School','Public Secondary','7.6/10','YRDSB'],["St. Andrew's College",'Private Boys Gr.5–12','—','National profile; boarding available'],["St. Anne's School",'Private Girls Gr.5–12','—','Founded 2022'],['Holy Spirit Catholic Elem.','Catholic Elem.','7.5/10','Fraser 2024'],['Hartman Public School','Public Elem.','7.4/10','Fraser 2024']],
-   rests:[['Joia Ristorante & Wine Bar','Italian — Aurora institution since 1997'],['Fishbone Kitchen + Bar','Seafood and cocktails on Yonge'],['FIKA Cafe','Café with a strong patio'],['Beertown Public House','Craft beer and pub fare'],['Locale Aurora','Modern Canadian comfort food']],
-   dil:'Morning coffee near Yonge St, then a short walk to Aurora GO. Union Station approximately 45 minutes. After school, kids walk home from Dr. G.W. Williams. Weekend: Aurora Farmers Market on Saturday, Nokiidaa Trail in the afternoon.',
-   mapX:455,mapY:322},
-  {id:'newmarket',name:'Newmarket',region:'York Region',type:'urban',slug:'newmarket',
-   banner:'/Images/newmarket-banner.jpg',badge:'/Images/towns/newmarket.jpg',
-   positioning:'GO Train access, walkable Main Street, established neighbourhoods, and practical day-to-day convenience.',
-   avgPrice:1048,det:1142,town:820,condo:544,dvpKm:55,driveMin:45,
-   transit:'GO Train (Barrie line) + YRT/Viva BRT',walk:58,school:7.9,
-   dom:17,spl:98,inv:1.6,pop:'~88,000',lot:'Small to medium',newdev:'Moderate',
-   mkt:'Balanced',bestFor:'First-time buyers, commuters, downsizers',
-   watch:'Average 17 days on market — well-priced homes move quickly',
-   invest:'Highest sales volume in York Region; strong rental demand',
-   pills:[['p-go','GO Train'],['p-val','Strong value vs Aurora'],['p-school','Strong schools']],
-   subs:['Stonehaven-Wyndham','Armitage','Bristol-London','Glenway Estates','Central Newmarket','Gorham-College Manor','Huron Heights-Leslie Valley'],
-   schools:[['Newmarket High School','Public Secondary','8.5/10','Fraser 2024'],['Dr. John M. Denison SS','Public Secondary','7.2/10','YRDSB'],['Huron Heights Secondary','Public Secondary','7.0/10','French Immersion + Arts'],['Cardinal Carter Catholic SS','Catholic Secondary','7.5/10','York Catholic DSB'],['Stonehaven Public School','Public Elem.','8.1/10','Fraser 2024']],
-   rests:[['Ground Burger Bar','Wagyu burgers on Main St — local favourite'],['Hungry Brew Hops','Craft beer and pub food'],['Luna Ristorante','Authentic Italian'],['Flaming Stove','Indian and Asian fusion'],['Poached Dreams Diner','Brunch — busy on weekends']],
-   dil:'Walk to Newmarket GO in 9 minutes. Union Station roughly 55 minutes later. Kids walk home from school. Dinner on Main Street. Weekend: Fairy Lake, farmers market, hockey at Ray Twinney Arena.',
-   mapX:443,mapY:298},
-  {id:'stouffville',name:'Stouffville',region:'York Region',type:'suburb',slug:'stouffville',
-   banner:'/Images/stouffville-banner.jpg',badge:'/Images/towns/stouffville.jpg',
-   positioning:'GO access, newer homes on reasonable lots, strong schools, and a Main Street that still feels local.',
-   avgPrice:1114,det:1280,town:890,condo:680,dvpKm:48,driveMin:40,
-   transit:'GO Train (Stouffville line) — approx. 65 min to Union',walk:42,school:8.1,
-   dom:28,spl:99,inv:6.0,pop:'~50,000',lot:'Medium — newer subdivisions',newdev:'High — projects completing 2026',
-   mkt:"Buyer's",bestFor:'Young families, new-build buyers, GTA movers',
-   watch:'6 months of inventory — buyers are currently in a strong negotiating position',
-   invest:'Long-term upside as GO service improves and amenities mature',
-   pills:[['p-go','GO Train'],['p-new','New construction'],['p-school','Strong schools']],
-   subs:['Stouffville town','Ballantrae','Claremont','Gormley','Vandorf','Rural Whitchurch'],
-   schools:[['Stouffville District Secondary','Public Secondary','7.9/10','Fraser 2024'],['All Saints Catholic SS','Catholic Secondary','7.7/10','York Catholic DSB'],['Barbara Reid Public School','Public Elem.','7.7/10','Fraser 2024'],['Glad Park Public School','Public Elem.','7.3/10','Fraser 2024'],['St. Mark Catholic Elem.','Catholic Elem.','7.5/10','York Catholic DSB']],
-   rests:[['Maki Japanese Restaurant','AYCE sushi — popular with locals'],['Cork & Barrel','Wine bar on Main St'],['Ballantrae Golf & CC','Clubhouse dining'],['Stone Road Grille','Casual neighbourhood spot'],['Main St. cafés','Several independent options']],
-   dil:'School drop-off, then GO Stouffville line — 65 minutes to Union. New build with a proper garage. Weekend: Ballantrae Golf, Bruce\'s Mill Conservation Area, Sunday farmers market.',
-   mapX:520,mapY:332},
-  {id:'eastgwillimbury',name:'East Gwillimbury',region:'York Region',type:'suburb',slug:'east-gwillimbury',
-   banner:'/Images/eastgwillimbury-banner.jpg',badge:'/Images/towns/east-gwillimbury.jpg',
-   positioning:'Newer communities, larger lots, and faster growth across Sharon, Queensville, Holland Landing, and Mount Albert.',
-   avgPrice:1150,det:1550,town:890,condo:680,dvpKm:60,driveMin:50,
-   transit:'Hwy 404 + Bradford bypass — no GO station',walk:22,school:7.8,
-   dom:30,spl:98,inv:4.5,pop:'~32,000',lot:'Large — some of the best lot sizes in York Region',newdev:'Very high — ongoing through 2026',
-   mkt:"Buyer's",bestFor:'Upsizers, families needing space, new-home buyers',
-   watch:'Car-dependent — residents drive for all errands',
-   invest:'Infrastructure investment ongoing; market expected to mature',
-   pills:[['p-new','New builds'],['p-val','Largest lots in York']],
-   subs:['Holland Landing','Sharon','Queensville','Mount Albert','Rural East Gwillimbury'],
-   schools:[['Sharon Public School','Public Elem.','7.8/10','Fraser 2024'],['Queensville Public School','Public Elem.','7.5/10','YRDSB'],['Dr. John M. Denison SS','Secondary — Newmarket','7.2/10','Closest secondary'],['Sacred Heart Catholic Elem.','Catholic Elem.','7.6/10','York Catholic DSB']],
-   rests:[['Sharon village cafés','Independent spots in the heritage village'],['Holland Landing diners','Classic small-town dining'],['HALP Aquatics Café','New café inside the rec centre (2025)'],['15 min to Newmarket','Full dining scene accessible by car']],
-   dil:'School drop-off around the corner. Hwy 404 south — 45–60 minutes depending on traffic. Home to a 3-car garage and a yard big enough to use. HALP recreation centre with the kids after school.',
-   mapX:468,mapY:274},
-  {id:'georgina',name:'Georgina',region:'York Region',type:'rural',slug:'georgina',
-   banner:'/Images/georgina-banner.jpg',badge:'/Images/towns/georgina.jpg',
-   positioning:'Lake Simcoe, more space, shoreline communities, and one of York Region\'s most accessible price points.',
-   avgPrice:875,det:910,town:815,condo:590,dvpKm:80,driveMin:65,
-   transit:'Car-dependent — no GO Train',walk:18,school:6.8,
-   dom:38,spl:97,inv:7.5,pop:'~46,000',lot:'Large — many waterfront and oversized',newdev:'Low to moderate',
-   mkt:"Buyer's",bestFor:'Remote workers, waterfront buyers, buyers seeking more space',
-   watch:'Longer commute to Toronto; car required for all daily errands',
-   invest:'Waterfront properties tend to hold value over the long term',
-   pills:[['p-lake','Lake Simcoe'],['p-val','Accessible price point'],['p-trail','Outdoors']],
-   subs:["Keswick","Keswick South","Keswick North","Sutton","Jackson's Point","Pefferlaw","Baldwin","Belhaven","Virginia","Historic Lakeshore Communities"],
-   schools:[['Keswick High School','Public Secondary','6.8/10','YRDSB'],['Sutton District High School','Public Secondary','6.5/10','YRDSB'],['Our Lady of the Lake Catholic','Catholic Elem.','6.9/10','York Catholic DSB'],['Keswick Public School','Public Elem.','6.7/10','YRDSB']],
-   rests:[["Jack's Waterfront Restaurant",'Keswick waterfront patio — seasonal'],["Cook's Bay Brewhouse",'Local craft brewery'],["Jackson's Point Bistro",'Seasonal lakeside dining'],['Sutton cafés','Small-town cafés and diners']],
-   dil:'Remote work from home with Lake Simcoe in the background. Noon paddleboard from the dock. Kids to the beach after school. Dinner on a waterfront patio. A different pace.',
-   mapX:490,mapY:154},
-  {id:'uxbridge',name:'Uxbridge',region:'Durham Region',type:'rural',slug:'uxbridge',
-   banner:'/Images/uxbridge-banner.jpg',badge:'/Images/towns/uxbridge.jpg',
-   positioning:'Trail networks, rolling countryside, heritage streets, and a quieter lifestyle with room to breathe.',
-   avgPrice:990,det:1200,town:750,condo:527,dvpKm:75,driveMin:60,
-   transit:'Car-dependent — Durham Transit only',walk:28,school:7.2,
-   dom:34,spl:97,inv:4.0,pop:'~22,000',lot:'Large to estate — rural character',newdev:'Low',
-   mkt:'Balanced',bestFor:'Nature lovers, equestrians, artists, remote workers',
-   watch:'No GO Train access; commute is longer — car is essential',
-   invest:'Stable balanced market; 85% homeownership rate; buyers can negotiate',
-   pills:[['p-trail',"Canada's Trail Capital"],['p-arts','Arts & culture'],['p-her','Heritage character']],
-   subs:['Uxbridge town','Goodwood','Leaskdale','Sandford','Udora','Zephyr','Siloam','Vivian'],
-   schools:[['Uxbridge Secondary School','Public Secondary','7.2/10','DDSB — arts program'],['Uxbridge Public School','Public Elem.','7.4/10','Fraser 2024'],['St. Joseph Catholic Elem.','Catholic Elem.','7.0/10','Durham Catholic DSB']],
-   rests:[['Tin Can Coffee','Independent café — consistently busy'],['Uxbridge Brewing Co.','Small-batch craft beer, town square patio'],["Frankie D's Ristorante",'Italian — book ahead on weekends'],['Headwater Farms store','Local beef and provisions'],['Tin Cup Pub','Neighbourhood pub']],
-   dil:'Early morning trail run through Durham Forest before the day starts. Car to Toronto — 60–75 minutes via Hwy 48/404. Half-acre lot, quiet street. Theatre Uxbridge or Uxbridge Brewing Co. in the evening.',
-   mapX:598,mapY:335},
-  {id:'scugog',name:'Scugog',region:'Durham Region',type:'rural',slug:'scugog',
-   banner:'/Images/scugog-banner.jpg',badge:'/Images/towns/scugog.jpg',
-   positioning:'Port Perry heritage, Lake Scugog waterfront, small-town character, and a pace that is genuinely different from the city.',
-   avgPrice:960,det:1099,town:762,condo:800,dvpKm:88,driveMin:75,
-   transit:'Car-dependent — Durham Transit only',walk:20,school:6.5,
-   dom:36,spl:98,inv:5.5,pop:'~22,000',lot:'Large — many on acreage',newdev:'Very low',
-   mkt:"Buyer's",bestFor:'Heritage buyers, waterfront seekers, retirees, remote workers',
-   watch:'Longest drive to Toronto of these seven communities',
-   invest:'Waterfront and heritage properties tend to hold value; broader market is soft',
-   pills:[['p-lake','Lake Scugog'],['p-her','Century homes'],['p-arts','Boutique downtown']],
-   subs:['Port Perry','Blackstock','Caesarea','Prince Albert','Rural Scugog','Nestleton'],
-   schools:[['Port Perry High School','Public Secondary','6.5/10','DDSB'],['Scugog Central Public School','Public Elem.','6.8/10','DDSB'],['St. Theresa Catholic Elem.','Catholic Elem.','6.7/10','Durham Catholic DSB']],
-   rests:[['Simcoe Street Grill','Waterfront dining'],["St. Andrew's Pub",'Heritage pub building'],['Princess Street Cafe','Brunch — busy weekends'],['Fiesta Gardens','Coffee and gelato on Main St'],['Inn at Port Perry (dining)','Weekend destination dining']],
-   dil:'Sunrise walk along Water Street. Remote work with Lake Scugog nearby. Weekend: Port Perry Farmers Market, kayaking on the lake, antiques on Water St, fireworks on the water July 1st.',
-   mapX:718,mapY:345},
-];
 
-var FILTERS=[
-  {id:'all',label:'All 7 towns'},
-  {id:'york',label:'York Region',fn:function(h){return h.region==='York Region';}},
-  {id:'durham',label:'Durham Region',fn:function(h){return h.region==='Durham Region';}},
-  {id:'under1m',label:'Under $1M avg',fn:function(h){return h.avgPrice<1000;}},
-  {id:'go',label:'GO Train',fn:function(h){return h.pills.some(function(p){return p[0]==='p-go';});}},
-  {id:'water',label:'Waterfront',fn:function(h){return h.pills.some(function(p){return p[0]==='p-lake';});}},
-  {id:'new',label:'New builds',fn:function(h){return h.pills.some(function(p){return p[0]==='p-new';});}},
-];
+`;
 
-var activeFilter='all',selected=[],viewMode='cards',expanded={};
+export default function NeighbourhoodGuidePage() {
+  const containerRef = useRef(null);
 
-function getList(){
-  var f=FILTERS.find(function(x){return x.id===activeFilter;});
-  var list=f&&f.fn?HOODS.filter(f.fn):HOODS.slice();
-  var v=document.getElementById('sortSel').value;
-  if(v==='price-asc')list.sort(function(a,b){return a.avgPrice-b.avgPrice;});
-  else if(v==='price-desc')list.sort(function(a,b){return b.avgPrice-a.avgPrice;});
-  else if(v==='commute')list.sort(function(a,b){return a.driveMin-b.driveMin;});
-  else list.sort(function(a,b){return a.name.localeCompare(b.name);});
-  return list;
+  useEffect(() => {
+    window.submitTownLead = (id, town) => {
+      const n = document.getElementById(`sf_name_${id}`)?.value.trim();
+      const em = document.getElementById(`sf_email_${id}`)?.value.trim();
+      if (!n || !em) { alert("Please enter your name and email."); return; }
+      const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
+      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
+    };
+    window.submitSMSTown = (id, town) => {
+      const phone = document.getElementById(`sms_${id}`)?.value.trim();
+      if (!phone) { alert("Please enter your phone number."); return; }
+      const payload = { phone, town, source: `NorthSide SMS opt-in — ${town}`, timestamp: new Date().toISOString() };
+      fetch("/api/sms-optin", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const smsBox = document.getElementById(`sms_${id}`)?.closest(".sms-box");
+      if (smsBox) smsBox.innerHTML = `<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ${town} listings. Reply STOP to unsubscribe.</p>`;
+    };
+    return () => { delete window.submitTownLead; delete window.submitSMSTown; };
+  }, []);
+  const schemaObject = useMemo(() => JSON.parse(PAGE_SCHEMA), []);
+  return (<><Helmet>
+      <title>NorthSide GTA Neighbourhood Guide | Compare Aurora, Newmarket, Stouffville, East Gwillimbury, Georgina, Uxbridge & Scugog | Finally Home Agents</title>
+      <meta name="description" content="A practical neighbourhood guide for buyers looking north of Toronto. Compare home prices, commute times, schools, lifestyle, and local favourites for Aurora, Newmarket, Stouffville, East Gwillimbury, Georgina, Uxbridge, and Scugog." />
+      <meta property="og:title" content="NorthSide GTA Neighbourhood Guide | Finally Home Agents" />
+      <meta property="og:description" content="Compare Aurora, Newmarket, Stouffville, East Gwillimbury, Georgina, Uxbridge, and Scugog. Prices, commutes, schools, and the trade-offs that matter." />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="https://northsidegta.ca/neighbourhood-guide" />
+      <meta property="og:image" content="https://northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg" />
+      <link rel="canonical" href="https://northsidegta.ca/neighbourhood-guide" />
+      <script type="application/ld+json">{JSON.stringify(schemaObject)}</script>
+    </Helmet><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /></>);
 }
-function bestIn(vals,lower){
-  var b=lower?Math.min.apply(null,vals):Math.max.apply(null,vals);
-  return vals.map(function(v){return v===b;});
-}
-
-function renderCards(){
-  var list=getList();
-  if(!list.length)return '<div class="empty">No communities match this filter.</div>';
-  var html='<div class="card-grid" id="town-cards">';
-  list.forEach(function(h){
-    var isSel=selected.indexOf(h.id)>-1;
-    var isExp=!!expanded[h.id];
-    var mktClass=h.mkt.indexOf('Buyer')>-1?'p-buyer':'p-bal';
-    var mktLabel=h.mkt+' market';
-    var regionClass=h.region.indexOf('York')>-1?'region-york':'region-durham';
-    // Schools mini
-    var schoolsMini='<div class="school-mini">';
-    h.schools.slice(0,4).forEach(function(s){
-      schoolsMini+='<div class="school-mini-row"><div><div class="school-mini-name">'+s[0]+'</div><div class="school-mini-type">'+s[1]+'</div></div><div class="school-mini-r">'+s[2]+'</div></div>';
-    });
-    schoolsMini+='<p style="font-size:10px;color:var(--ink4);margin-top:6px;">Fraser Institute 2024/2025. Verify boundaries with school board.</p></div>';
-    // Rests mini
-    var restsMini='<div class="rest-mini">';
-    h.rests.forEach(function(r){
-      restsMini+='<div class="rest-mini-row"><div><div class="rest-mini-name">'+r[0]+'</div><div class="rest-mini-desc">'+r[1]+'</div></div></div>';
-    });
-    restsMini+='<p style="font-size:10px;color:var(--ink4);margin-top:6px;">Included for community context only — not a ranking or endorsement.</p></div>';
-    // Subs
-    var subsBadges='<div class="subs">'+h.subs.map(function(s){return'<span class="sub">'+s+'</span>';}).join('')+'</div>';
-    // Expanded data
-    var xpanel='';
-    if(isExp){
-      xpanel='<div class="tc-expanded">'
-        +'<div class="xdata-grid">'
-        +'<div><div class="xrow"><span class="xk">Detached avg.</span><span class="xv">$'+h.det+'K</span></div>'
-        +'<div class="xrow"><span class="xk">Townhouse avg.</span><span class="xv">$'+h.town+'K</span></div>'
-        +'<div class="xrow"><span class="xk">Condo/apt avg.</span><span class="xv">$'+h.condo+'K</span></div>'
-        +'<div class="xrow"><span class="xk">Sale/list ratio</span><span class="xv">'+h.spl+'%</span></div></div>'
-        +'<div><div class="xrow"><span class="xk">Months inventory</span><span class="xv">'+h.inv+'</span></div>'
-        +'<div class="xrow"><span class="xk">Walk score</span><span class="xv">'+h.walk+'/100</span></div>'
-        +'<div class="xrow"><span class="xk">Population</span><span class="xv">'+h.pop+'</span></div>'
-        +'<div class="xrow"><span class="xk">Lot size</span><span class="xv" style="text-align:right;max-width:120px;font-size:11px;">'+h.lot+'</span></div></div></div>'
-        +'<div class="xalert xalert-warn" style="margin-top:10px;"><strong>Consider:</strong> '+h.watch+'</div>'
-        +'<div class="xalert xalert-inv" style="margin-top:6px;"><strong>Market note:</strong> '+h.invest+'</div>'
-        +'</div>';
-    }
-    html+='<article class="tc'+(isSel?' sel':'')+'" id="card-'+h.id+'" aria-label="'+h.name+' — '+h.region+'">'
-      // Image
-      +'<div class="tc-img-wrap" onclick="toggleSel(\''+h.id+'\')" style="cursor:pointer;">'
-      +'<img src="'+h.banner+'" alt="'+h.name+' neighbourhood" class="tc-img" loading="lazy">'
-      +'<div class="tc-img-overlay" aria-hidden="true"></div>'
-      +'<div class="tc-badge-wrap">'
-      +'<img src="'+h.badge+'" alt="'+h.name+' NorthSide GTA town badge" class="tc-badge" loading="lazy">'
-      +'<span class="tc-badge-name">'+h.name+'</span>'
-      +'</div>'
-      +'<span class="tc-region '+regionClass+'">'+h.region+'</span>'
-      +(isSel?'<span class="selbadge">Selected</span>':'')
-      +'</div>'
-      // Body
-      +'<div class="tc-body" onclick="toggleSel(\''+h.id+'\')" style="cursor:pointer;">'
-      +'<div class="tc-top">'
-      +'<div style="flex:1;"><p style="font-size:12px;color:var(--ink3);margin-bottom:3px;">'+h.type+' community</p>'
-      +'<p style="font-size:13px;color:var(--ink2);line-height:1.5;">'+h.positioning+'</p></div>'
-      +'<div style="text-align:right;flex-shrink:0;margin-left:12px;"><div style="font-family:var(--fd);font-size:20px;font-weight:700;color:var(--green);">$'+h.avgPrice+'K</div><div style="font-size:10px;color:var(--ink4);">avg. sold</div></div>'
-      +'</div>'
-      +'<div class="tc-meta">'
-      +'<div class="tc-stat"><div class="tc-stat-val">'+h.dvpKm+' km</div><div class="tc-stat-lbl">to DVP/401</div></div>'
-      +'<div class="tc-stat"><div class="tc-stat-val">'+h.driveMin+' min</div><div class="tc-stat-lbl">off-peak drive</div></div>'
-      +'<div class="tc-stat"><div class="tc-stat-val">'+h.dom+'d</div><div class="tc-stat-lbl">avg. on market</div></div>'
-      +'</div>'
-      +'<div class="tc-pills">'+h.pills.map(function(p){return'<span class="pill '+p[0]+'">'+p[1]+'</span>';}).join('')
-      +'<span class="pill '+mktClass+'">'+mktLabel+'</span></div>'
-      +'</div>'
-      // Sub-communities
-      +subsBadges
-      // Tabs
-      +'<div class="tc-tabs" role="tablist">'
-      +'<button class="tc-tab on" onclick="stab(this,\''+h.id+'\',\'ov\')" role="tab">Overview</button>'
-      +'<button class="tc-tab" onclick="stab(this,\''+h.id+'\',\'sc\')" role="tab">Schools</button>'
-      +'<button class="tc-tab" onclick="stab(this,\''+h.id+'\',\'re\')" role="tab">Dining</button>'
-      +'<button class="tc-tab" onclick="stab(this,\''+h.id+'\',\'dl\')" role="tab">Day in life</button>'
-      +'</div>'
-      +'<div id="tp-ov-'+h.id+'" class="tc-panel on"><div class="dil-mini">'+h.positioning+' <a href="/communities/'+h.slug+'" style="font-size:12px;font-weight:500;">Read the full '+h.name+' guide &rarr;</a></div></div>'
-      +'<div id="tp-sc-'+h.id+'" class="tc-panel">'+schoolsMini+'</div>'
-      +'<div id="tp-re-'+h.id+'" class="tc-panel">'+restsMini+'</div>'
-      +'<div id="tp-dl-'+h.id+'" class="tc-panel"><div class="dil-mini">'+h.dil+'</div></div>'
-      // Expand button
-      +(xpanel||'')
-      +'<button class="tc-expand-btn" onclick="toggleExp(\''+h.id+'\')">'+(isExp?'Show less ▲':'Full data: prices, inventory, transit &amp; more ▼')+'</button>'
-      // View guide link
-      +'<a href="/communities/'+h.slug+'" class="town-page-link" style="display:block;text-align:center;font-size:12px;font-weight:500;color:var(--green);padding:9px 0;border-top:1px solid var(--border);background:var(--gpale);transition:background 0.18s;">View '+h.name+' neighbourhood guide &rarr;</a>'
-      +'</article>';
-  });
-  html+='</div>';
-  // Action bar
-  if(selected.length>0){
-    html+='<div class="sel-action"><button class="cab" onclick="setView(\'compare\')">Compare '+selected.length+' selected &rarr;</button></div>';
-  } else {
-    html+='<p class="sel-hint">Select any community card to compare side by side</p>';
-  }
-  return html;
-}
-
-function stab(el,hid,tab){
-  var ctabs=el.closest('.tc-tabs');
-  ctabs.querySelectorAll('.tc-tab').forEach(function(t){t.classList.remove('on');});
-  el.classList.add('on');
-  var card=document.getElementById('card-'+hid);
-  card.querySelectorAll('.tc-panel').forEach(function(p){p.classList.remove('on');});
-  document.getElementById('tp-'+tab+'-'+hid).classList.add('on');
-}
-
-function toggleExp(hid){
-  expanded[hid]=!expanded[hid];
-  render();
-  setTimeout(function(){
-    var el=document.getElementById('card-'+hid);
-    if(el)el.scrollIntoView({behavior:'smooth',block:'nearest'});
-  },60);
-}
-
-function renderCompare(){
-  var sh=selected.length>0?HOODS.filter(function(h){return selected.indexOf(h.id)>-1;}):HOODS.slice(0,3);
-  var n=sh.length;
-  var ct='150px repeat('+n+',minmax(0,1fr))';
-  function hdr(){
-    return '<div class="crow" style="display:grid;grid-template-columns:'+ct+';">'
-      +'<div class="clbl" style="border-bottom:2px solid var(--green);background:var(--cream);"></div>'
-      +sh.map(function(h){return'<div class="cch">'+h.name+'</div>';}).join('')+'</div>';
-  }
-  function sec(l){return'<div class="csec">'+l+'</div>';}
-  function row(l,ic,vals,fmt,low){
-    var b=bestIn(vals,low);
-    return'<div class="crow" style="display:grid;grid-template-columns:'+ct+';">'
-      +'<div class="clbl"><i class="fas '+ic+'" aria-hidden="true"></i>'+l+'</div>'
-      +vals.map(function(v,i){return'<div class="ccell'+(b[i]?' best':'')+'">'+fmt(v)+'</div>';}).join('')+'</div>';
-  }
-  function brow(l,ic,vals,maxV,fmt,low){
-    var b=bestIn(vals,low);
-    return'<div class="crow" style="display:grid;grid-template-columns:'+ct+';">'
-      +'<div class="clbl"><i class="fas '+ic+'" aria-hidden="true"></i>'+l+'</div>'
-      +vals.map(function(v,i){
-        var p=Math.round((v/maxV)*100);
-        return'<div class="ccell'+(b[i]?' best':'')+'"><div>'+fmt(v)+'</div>'
-          +'<div class="btr"><div class="bfl'+(b[i]?' bb':'')+'" style="width:'+p+'%"></div></div></div>';
-      }).join('')+'</div>';
-  }
-  function trow(l,ic,vals){
-    return'<div class="crow" style="display:grid;grid-template-columns:'+ct+';">'
-      +'<div class="clbl"><i class="fas '+ic+'" aria-hidden="true"></i>'+l+'</div>'
-      +vals.map(function(v){return'<div class="cins">'+v+'</div>';}).join('')+'</div>';
-  }
-  var prices=sh.map(function(h){return h.avgPrice;});
-  var dets=sh.map(function(h){return h.det;});
-  var towns=sh.map(function(h){return h.town;});
-  var condos=sh.map(function(h){return h.condo;});
-  var kms=sh.map(function(h){return h.dvpKm;});
-  var mins=sh.map(function(h){return h.driveMin;});
-  var doms=sh.map(function(h){return h.dom;});
-  var spls=sh.map(function(h){return h.spl;});
-  var invs=sh.map(function(h){return h.inv;});
-  var walks=sh.map(function(h){return h.walk;});
-  var schs=sh.map(function(h){return h.school;});
-  return'<section class="cmp-section">'
-    +'<div class="cmp-hdr"><h2 class="cmp-title">Side-by-side comparison</h2><button class="back-btn" onclick="setView(\'cards\')">← Back to cards</button></div>'
-    +'<div class="ctable">'
-    +hdr()
-    +sec('Sub-communities')
-    +trow('Areas within','fa-map-pin',sh.map(function(h){return h.subs.slice(0,3).join(', ')+(h.subs.length>3?' +more':'');}))
-    +sec('Pricing — avg. sold (TRREB MLS® 2025–2026)')
-    +brow('All home types','fa-home',prices,Math.max.apply(null,prices),function(v){return'$'+v+'K';},true)
-    +row('Detached','fa-house',dets,function(v){return'$'+v+'K';},true)
-    +row('Townhouse','fa-building',towns,function(v){return'$'+v+'K';},true)
-    +row('Condo / apt','fa-city',condos,function(v){return'$'+v+'K';},true)
-    +sec('Market conditions')
-    +trow('Market type','fa-chart-line',sh.map(function(h){return h.mkt+' market';}))
-    +brow('Avg days on market','fa-clock',doms,Math.max.apply(null,doms),function(v){return v+'d';},true)
-    +row('Sale/list ratio','fa-percent',spls,function(v){return v+'%';},false)
-    +brow('Months of inventory','fa-layer-group',invs,Math.max.apply(null,invs),function(v){return v+' mo';},false)
-    +sec('Commute & lifestyle')
-    +brow('Distance to DVP/401','fa-road',kms,Math.max.apply(null,kms),function(v){return v+' km';},true)
-    +brow('Off-peak drive time','fa-car',mins,Math.max.apply(null,mins),function(v){return v+' min';},true)
-    +trow('Transit','fa-train',sh.map(function(h){return h.transit;}))
-    +brow('Walk score','fa-person-walking',walks,100,function(v){return v+'/100';},false)
-    +sec('Community')
-    +row('School rating avg.','fa-graduation-cap',schs,function(v){return v+'/10';},false)
-    +trow('Lot sizes','fa-ruler',sh.map(function(h){return h.lot;}))
-    +trow('Best for','fa-users',sh.map(function(h){return h.bestFor;}))
-    +sec('Buyer trade-offs')
-    +trow('Things to weigh','fa-triangle-exclamation',sh.map(function(h){return h.watch;}))
-    +trow('Market note','fa-arrow-trend-up',sh.map(function(h){return h.invest;}))
-    +'<div class="cleg">Green highlight = strongest in that category among selected towns &nbsp;|&nbsp; TRREB MLS® 2025–2026 &nbsp;|&nbsp; Fraser Institute 2024/2025</div>'
-    +'</div></section>';
-}
-
-function render(){
-  document.getElementById('mainContent').innerHTML=viewMode==='cards'?renderCards():renderCompare();
-}
-function setView(v){
-  viewMode=v;
-  document.getElementById('btnCards').classList.toggle('on',v==='cards');
-  document.getElementById('btnCompare').classList.toggle('on',v==='compare');
-  render();
-  window.scrollTo({top:0,behavior:'smooth'});
-}
-function toggleSel(id){
-  var idx=selected.indexOf(id);
-  if(idx>-1){selected.splice(idx,1);}
-  else{if(selected.length>=4)selected.shift();selected.push(id);}
-  render();
-}
-function setFilter(id){
-  activeFilter=id;
-  document.querySelectorAll('.fbtn').forEach(function(b){b.classList.toggle('on',b.dataset.id===id);});
-  render();
-}
-function jumpTo(id){
-  setView('cards');
-  if(activeFilter!=='all'){
-    var f=FILTERS.find(function(x){return x.id===activeFilter;});
-    var h=HOODS.find(function(x){return x.id===id;});
-    if(f&&f.fn&&h&&!f.fn(h))setFilter('all');
-  }
-  setTimeout(function(){
-    var el=document.getElementById('card-'+id);
-    if(el)el.scrollIntoView({behavior:'smooth',block:'center'});
-  },180);
-}
-
-// Filters
-document.getElementById('filterBar').innerHTML=FILTERS.map(function(f){
-  return'<button class="fbtn'+(f.id==='all'?' on':'')+'" data-id="'+f.id+'" onclick="setFilter(\''+f.id+'\')" aria-label="Show: '+f.label+'">'+f.label+'</button>';
-}).join('');
-
-// Map
-function buildMap(){
-  var g=document.getElementById('townMarkers');
-  HOODS.forEach(function(h){
-    var x=h.mapX,y=h.mapY;
-    var el=document.createElementNS('http://www.w3.org/2000/svg','g');
-    el.setAttribute('cursor','pointer');
-    el.setAttribute('role','button');
-    el.setAttribute('tabindex','0');
-    el.setAttribute('aria-label',h.name+' — click to jump to this community');
-    el.innerHTML='<circle cx="'+x+'" cy="'+y+'" r="14" fill="rgba(30,77,15,0.15)"/>'
-      +'<circle cx="'+x+'" cy="'+y+'" r="9" fill="#1e4d0f" stroke="#fff" stroke-width="2"/>'
-      +'<circle cx="'+x+'" cy="'+y+'" r="3.5" fill="#c8831a"/>'
-      +'<text x="'+x+'" y="'+(y-13)+'" font-family="\'Inter\',sans-serif" font-size="11" fill="#fff" text-anchor="middle" font-weight="600" style="text-shadow:0 1px 3px rgba(0,0,0,0.8);pointer-events:none;">'+h.name+'</text>'
-      +'<text x="'+x+'" y="'+(y+22)+'" font-family="\'Inter\',sans-serif" font-size="9" fill="rgba(255,255,255,0.7)" text-anchor="middle" style="pointer-events:none;">$'+h.avgPrice+'K &middot; '+h.driveMin+' min</text>';
-    el.addEventListener('click',function(){jumpTo(h.id);});
-    el.addEventListener('mouseenter',function(ev){showTip(ev,h);});
-    el.addEventListener('mouseleave',hideTip);
-    el.addEventListener('keydown',function(ev){if(ev.key==='Enter'||ev.key===' ')jumpTo(h.id);});
-    g.appendChild(el);
-  });
-}
-var tip=document.getElementById('maptip');
-function showTip(ev,h){
-  tip.innerHTML='<strong>'+h.name+'</strong><br>Avg: $'+h.avgPrice+'K &middot; '+h.driveMin+' min off-peak<br>'+h.mkt+' market &middot; '+h.dom+'d avg. on market';
-  tip.style.opacity='1';
-  moveTip(ev);
-}
-function moveTip(ev){
-  var left=ev.clientX+14,top=ev.clientY+14;
-  if(left+210>window.innerWidth)left=ev.clientX-222;
-  tip.style.left=left+'px';tip.style.top=top+'px';
-}
-function hideTip(){tip.style.opacity='0';}
-document.getElementById('mapsvg').addEventListener('mousemove',function(e){if(tip.style.opacity==='1')moveTip(e);});
-
-// Forms
-function scrollToLead(){document.getElementById('lead-form').scrollIntoView({behavior:'smooth'});}
-
-function submitSMSMain(){
-  var phone=document.getElementById('sms_phone').value.trim();
-  var town=document.getElementById('sms_town').value;
-  if(!phone){alert('Please enter your phone number.');return;}
-  if(!town){alert('Please choose a community.');return;}
-  var payload={phone:phone,town:town,source:'NorthSide GTA Guide v4 — SMS opt-in',timestamp:new Date().toISOString()};
-  fetch('/api/sms-optin',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload),credentials:'same-origin'}).catch(function(){});
-  var section=document.getElementById('sms-section');
-  section.innerHTML='<div style="max-width:1120px;margin:0 auto;padding:20px 24px;text-align:center;"><p style="color:#fff;font-size:14px;">You are in. We will text you new '+town+' listings. Reply STOP at any time to unsubscribe.</p></div>';
-}
-
-function submitLead(){
-  var n=document.getElementById('f_fn').value.trim();
-  var em=document.getElementById('f_em').value.trim();
-  if(!n||!em){alert('Please enter your name and email.');return;}
-  var towns=Array.from(document.querySelectorAll('.pchk:checked')).map(function(c){return c.value;}).join(', ')||'Not specified';
-  var payload={
-    name:n+' '+document.getElementById('f_ln').value.trim(),
-    email:em,
-    phone:document.getElementById('f_ph').value.trim(),
-    timeline:document.getElementById('f_tl').value,
-    budget:document.getElementById('f_bg').value,
-    towns:towns,
-    note:document.getElementById('f_nt').value.trim(),
-    source:'NorthSide GTA Neighbourhood Guide v4',
-    timestamp:new Date().toISOString()
-  };
-  fetch('/api/leads',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload),credentials:'same-origin'}).catch(function(){});
-  document.getElementById('leadFormBody').style.display='none';
-  document.getElementById('formSuccess').style.display='block';
-}
-
-buildMap();
-render();
-</script>
-</body>
-</html>

--- a/src/NeighbourhoodGuidePage.js
+++ b/src/NeighbourhoodGuidePage.js
@@ -828,7 +828,7 @@ export default function NeighbourhoodGuidePage() {
       const em = document.getElementById(`sf_email_${id}`)?.value.trim();
       if (!n || !em) { alert("Please enter your name and email."); return; }
       const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
-      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      fetch("/api/send-lead", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ...payload, casl: true, notRepresented: true, title: `NorthSide GTA local guidance — ${town}`, realmLink: window.location.href }), credentials: "same-origin" }).catch(() => {});
       const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
     };
     window.submitSMSTown = (id, town) => {

--- a/src/NewmarketPage.js
+++ b/src/NewmarketPage.js
@@ -1,49 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Living in Aurora, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
-<meta name="description" content="Explore Aurora, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Aurora is the right fit for your move north of Toronto.">
-<meta property="og:title" content="Living in Aurora, Ontario | NorthSide GTA Guide">
-<meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Aurora. A practical buyer guide from Finally Home Agents.">
-<meta property="og:type" content="article">
-<meta property="og:url" content="https://northsidegta.ca/communities/aurora">
-<meta property="og:image" content="https://northsidegta.ca/Images/aurora-banner.jpg">
-<link rel="canonical" href="https://northsidegta.ca/communities/aurora">
-<script type="application/ld+json">{
-  "@context":"https://schema.org",
-  "@graph":[
-    {
-      "@type":"Article",
-      "headline":"Living in Aurora, Ontario | Real Estate & Neighbourhood Guide",
-      "description":"Established neighbourhoods, strong schools, heritage streets, and GO Train access.",
-      "url":"https://northsidegta.ca/communities/aurora",
-      "dateModified":"2026-05-24",
-      "author":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
-      ],
-      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
-      "about":{"@type":"City","name":"Aurora","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
-    },
-    {
-      "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is Aurora Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Aurora is known for its heritage downtown on Yonge Street, strong school system including Dr. G.W. Williams Secondary (8.8/10, Fraser Institute 2024), and reliable GO Train service to Union Station via the Barrie line. It is one of York Region's most established residential communities."}},{"@type":"Question","name":"Is Aurora a good place to raise a family?","acceptedAnswer":{"@type":"Answer","text":"Aurora has a strong school catchment, established parks and trails, and a walkable downtown core. Families relocating from North Toronto or the inner GTA often find it offers a similar level of amenity with more space. School boundaries should be verified directly with YRDSB before purchasing."}},{"@type":"Question","name":"What are the different neighbourhoods in Aurora?","acceptedAnswer":{"@type":"Answer","text":"Aurora has approximately ten distinct residential areas. Aurora Heights and Bayview Wellington are popular for mature lots and established streets. Aurora Estates and Hills of St. Andrew offer larger properties. Aurora Village sits close to the heritage downtown and walkable amenities."}}]
-    },
-    {
-      "@type":"RealEstateAgent",
-      "name":"Finally Home Agents Team",
-      "url":"https://northsidegta.ca",
-      "employee":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
-      ]
-    }
-  ]
-}</script>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<style>
+import React, { useEffect, useMemo, useRef } from "react";
+import { Helmet } from "react-helmet-async";
+
+const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
   --green:#1e4d0f;--green2:#2d6b18;--green3:#4a8f2a;
@@ -56,7 +14,7 @@
   --shm:0 4px 20px rgba(0,0,0,0.10);--shl:0 12px 40px rgba(0,0,0,0.13);
   --r:8px;--rl:14px;--rxl:20px;
   --fd:'Playfair Display',Georgia,serif;--fb:'Inter',system-ui,sans-serif;--t:0.18s;
-  --town-color:#1a4a6b;
+  --town-color:#2a1a50;
 }
 html{scroll-behavior:smooth;}
 body{font-family:var(--fb);background:var(--cream);color:var(--ink);font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;}
@@ -116,7 +74,7 @@ img{max-width:100%;display:block;}
 .hl-check{width:18px;height:18px;background:var(--gpale);border-radius:50%;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
 .hl-check svg{width:10px;height:10px;stroke:var(--green);stroke-width:2.5;fill:none;}
 /* DAY IN LIFE */
-.dil-block{background:linear-gradient(135deg,#1a4a6b12,#1a4a6b06);border-left:3px solid #1a4a6b;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
+.dil-block{background:linear-gradient(135deg,#2a1a5012,#2a1a5006);border-left:3px solid #2a1a50;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
 /* FAQ */
 .faq-item{border-bottom:1px solid var(--border);}
 .faq-item:last-child{border-bottom:none;}
@@ -153,7 +111,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .pk{color:rgba(255,255,255,0.6);}
 .pv{font-weight:600;color:#fff;}
 .mkt-pill{display:inline-block;font-size:10px;padding:3px 9px;border-radius:8px;background:rgba(255,255,255,0.15);color:#fff;border:1px solid rgba(255,255,255,0.2);font-weight:500;}
-.onemil-box{background:linear-gradient(135deg,#1a4a6b18,#1a4a6b08);border:1px solid #1a4a6b35;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
+.onemil-box{background:linear-gradient(135deg,#2a1a5018,#2a1a5008);border:1px solid #2a1a5035;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
 .onemil-price{font-family:var(--fd);font-size:15px;font-weight:700;color:var(--green);margin-bottom:8px;}
 .onemil-desc{font-size:12.5px;color:var(--ink2);line-height:1.65;}
 /* CTA CARD */
@@ -189,9 +147,39 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-item p{color:var(--ink2);line-height:1.6;}
 @media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
-</style>
-</head>
-<body>
+`;
+const PAGE_SCHEMA = `{
+  "@context":"https://schema.org",
+  "@graph":[
+    {
+      "@type":"Article",
+      "headline":"Living in Newmarket, Ontario | Real Estate & Neighbourhood Guide",
+      "description":"GO Train access, walkable Main Street, strong schools, and one of the strongest value plays in York Region.",
+      "url":"https://northsidegta.ca/communities/newmarket",
+      "dateModified":"2026-05-24",
+      "author":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
+      ],
+      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
+      "about":{"@type":"City","name":"Newmarket","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
+    },
+    {
+      "@type":"FAQPage",
+      "mainEntity":[{"@type":"Question","name":"What is Newmarket Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Newmarket is known as one of York Region's most connected and active communities. It has a walkable Main Street, direct GO Train service on the Barrie line, Southlake Regional Health Centre, and Upper Canada Mall. It is York Region's highest-volume real estate market."}},{"@type":"Question","name":"Is Newmarket a good place to buy a home in 2026?","acceptedAnswer":{"@type":"Answer","text":"Newmarket's average days on market sat at 17 in early 2026 — the fastest pace in York Region. It offers strong value compared with Aurora while maintaining GO Train access and established neighbourhood stock. Market data from TRREB MLS® 2025–2026."}},{"@type":"Question","name":"What are the best areas in Newmarket?","acceptedAnswer":{"@type":"Answer","text":"Stonehaven-Wyndham is consistently in demand for its school catchment and access to the 404. Armitage and Bristol-London are popular with families. Central Newmarket suits buyers who want walkability and proximity to Main Street amenities."}}]
+    },
+    {
+      "@type":"RealEstateAgent",
+      "name":"Finally Home Agents Team",
+      "url":"https://northsidegta.ca",
+      "employee":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
+      ]
+    }
+  ]
+}`;
+const PAGE_BODY_HTML = `
 
 <nav class="topnav" role="navigation" aria-label="Site navigation">
   <a href="https://northsidegta.ca" class="topnav-logo">NorthSide <span>GTA</span></a>
@@ -204,20 +192,20 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
 <!-- HERO -->
 <header class="hero" role="banner">
-  <img src="/Images/aurora-banner.jpg" alt="Aurora streetscape" class="hero-img" loading="eager">
+  <img src="/Images/newmarket-banner.jpg" alt="Newmarket Main Street" class="hero-img" loading="eager">
   <div class="hero-overlay" aria-hidden="true"></div>
   <div class="hero-content">
     <div class="hero-eyebrow">
-      <img src="/Images/towns/aurora.jpg" alt="Aurora NorthSide GTA town badge" class="town-badge">
+      <img src="/Images/towns/newmarket.jpg" alt="Newmarket NorthSide GTA town badge" class="town-badge">
       <span>York Region &middot; NorthSide GTA</span>
     </div>
-    <h1>Living in Aurora</h1>
-    <p class="hero-sub">Established neighbourhoods, strong schools, heritage streets, GO access, and one of the most complete lifestyles in the NorthSide GTA.</p>
+    <h1>Living in Newmarket</h1>
+    <p class="hero-sub">A connected NorthSide GTA town with Main Street energy, GO access, established neighbourhoods, shopping, parks, and practical day-to-day convenience.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">$1122K</div><div class="hstat-lbl">Avg. sold</div></div>
-      <div class="hstat"><div class="hstat-val">35 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">24d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">4.2 mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">$1048K</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">45 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
+      <div class="hstat"><div class="hstat-val">17d</div><div class="hstat-lbl">Avg. on mkt</div></div>
+      <div class="hstat"><div class="hstat-val">1.6 mo</div><div class="hstat-lbl">Inventory</div></div>
     </div>
   </div>
 </header>
@@ -227,7 +215,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <a href="https://northsidegta.ca">Home</a><span>&rsaquo;</span>
     <a href="https://northsidegta.ca/neighbourhood-guide">Neighbourhood guide</a><span>&rsaquo;</span>
-    <span>Aurora</span>
+    <span>Newmarket</span>
   </nav>
   <div class="page-grid">
 
@@ -236,8 +224,8 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- INTRO -->
       <div class="sec">
-        <div class="sec-eyebrow">About Aurora</div>
-        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Aurora is one of the NorthSide GTA's most established communities — a town where heritage architecture, walkable streets, and strong schools coexist with practical GO Train access to the city. Buyers choosing Aurora are typically prioritising school catchments, mature neighbourhoods, and a lifestyle that doesn't require giving up much of what the city offers.</p>
+        <div class="sec-eyebrow">About Newmarket</div>
+        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Newmarket is the NorthSide GTA's most active real estate market and arguably its most practical town for buyers who want city-level convenience without the city price. A walkable Main Street, reliable GO service, and established neighbourhoods like Stonehaven-Wyndham make it a consistent first choice for families relocating from North Toronto, Thornhill, or Markham.</p>
         <div style="margin-top:14px;display:flex;gap:6px;flex-wrap:wrap;">
           <a href="#contact" class="btn-primary" style="font-size:13px;padding:10px 20px;">Get local guidance</a>
           <a href="https://northsidegta.ca/neighbourhood-guide" class="btn-secondary" style="font-size:13px;padding:9px 18px;">Compare all towns</a>
@@ -246,9 +234,9 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- SUB-COMMUNITIES -->
       <div class="sec" id="neighbourhoods">
-        <h2>Neighbourhoods &amp; areas in Aurora</h2>
-        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Aurora Village</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Aurora Heights</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Aurora Highlands</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Aurora Estates</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Bayview Wellington</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Hills of St. Andrew</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Rural Aurora</span></div>
-        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within Aurora has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
+        <h2>Neighbourhoods &amp; areas in Newmarket</h2>
+        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Stonehaven-Wyndham</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Armitage</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Bristol-London</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Glenway Estates</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Central Newmarket</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Gorham-College Manor</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Huron Heights-Leslie Valley</span></div>
+        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within Newmarket has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
       </div>
 
       <!-- SCHOOLS & COMMUTE -->
@@ -257,38 +245,34 @@ details[open] .faq-icon{transform:rotate(45deg);}
         <table class="school-table" aria-label="Schools">
       <thead><tr><th>School</th><th>Rating</th><th>Notes</th></tr></thead>
       <tbody><tr>
-      <td><div class="school-name">Dr. G.W. Williams Secondary</div><div class="school-type">Public Secondary</div></td>
-      <td class="school-rating">8.8/10</td>
-      <td class="school-note">Top 30 in Ontario — Fraser Institute 2024</td>
+      <td><div class="school-name">Newmarket High School</div><div class="school-type">Public Secondary</div></td>
+      <td class="school-rating">8.5/10</td>
+      <td class="school-note">Highest-rated in Newmarket — Fraser Institute 2024</td>
     </tr><tr>
-      <td><div class="school-name">Aurora High School</div><div class="school-type">Public Secondary</div></td>
-      <td class="school-rating">7.6/10</td>
-      <td class="school-note">York Region District School Board</td>
+      <td><div class="school-name">Dr. John M. Denison SS</div><div class="school-type">Public Secondary</div></td>
+      <td class="school-rating">7.2/10</td>
+      <td class="school-note">YRDSB, approx. 886 students</td>
     </tr><tr>
-      <td><div class="school-name">St. Andrew's College</div><div class="school-type">Private (Boys, Gr. 5–12)</div></td>
-      <td class="school-rating">—</td>
-      <td class="school-note">National profile; boarding available</td>
+      <td><div class="school-name">Huron Heights Secondary</div><div class="school-type">Public Secondary</div></td>
+      <td class="school-rating">7.0/10</td>
+      <td class="school-note">French Immersion and Arts focus</td>
     </tr><tr>
-      <td><div class="school-name">St. Anne's School</div><div class="school-type">Private (Girls, Gr. 5–12)</div></td>
-      <td class="school-rating">—</td>
-      <td class="school-note">Sister school to SAC; opened 2022</td>
-    </tr><tr>
-      <td><div class="school-name">Holy Spirit Catholic Elem.</div><div class="school-type">Catholic Elementary</div></td>
+      <td><div class="school-name">Cardinal Carter Catholic SS</div><div class="school-type">Catholic Secondary</div></td>
       <td class="school-rating">7.5/10</td>
-      <td class="school-note">Fraser Institute 2024</td>
+      <td class="school-note">York Catholic District School Board</td>
     </tr><tr>
-      <td><div class="school-name">Hartman Public School</div><div class="school-type">Public Elementary</div></td>
-      <td class="school-rating">7.4/10</td>
+      <td><div class="school-name">Stonehaven Public School</div><div class="school-type">Public Elementary</div></td>
+      <td class="school-rating">8.1/10</td>
       <td class="school-note">Fraser Institute 2024</td>
     </tr></tbody>
     </table>
     <p style="font-size:11px;color:var(--ink4);margin-top:10px;line-height:1.65;">Ratings from Fraser Institute Ontario School Report Cards 2024/2025. School boundaries can change — verify directly with the relevant school board before making a property decision.</p>
         <div style="margin-top:18px;">
-          <h2 style="font-size:18px;margin-bottom:10px;">Commute from Aurora</h2>
+          <h2 style="font-size:18px;margin-bottom:10px;">Commute from Newmarket</h2>
           <div style="background:var(--cream);border-radius:var(--r);padding:14px 16px;font-size:13px;color:var(--ink2);line-height:1.75;">
-            <div><strong>Distance to DVP/401:</strong> 46 km</div>
-            <div><strong>Off-peak drive time:</strong> approximately 35 minutes</div>
-            <div><strong>Transit:</strong> GO Train (Barrie line) — ~45 min to Union</div>
+            <div><strong>Distance to DVP/401:</strong> 55 km</div>
+            <div><strong>Off-peak drive time:</strong> approximately 45 minutes</div>
+            <div><strong>Transit:</strong> GO Train (Barrie line) + YRT/Viva BRT</div>
             <div style="margin-top:8px;font-size:12px;color:var(--ink4);">Drive times are off-peak estimates. Peak-hour commute times are typically 30–60% longer depending on conditions.</div>
           </div>
         </div>
@@ -298,123 +282,95 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <div class="sec" id="restaurants">
         <h2>Local restaurants &amp; cafés</h2>
         <div class="rest-item">
-      <div><div class="rest-name">Joia Ristorante & Wine Bar</div><div class="rest-desc">Italian — Aurora institution since 1997</div></div>
+      <div><div class="rest-name">Ground Burger Bar</div><div class="rest-desc">Local favourite on Main St — quality ingredients</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Fishbone Kitchen + Bar</div><div class="rest-desc">Seafood and cocktails on Yonge</div></div>
+      <div><div class="rest-name">Hungry Brew Hops</div><div class="rest-desc">Craft beer focus with a strong food menu</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">FIKA Cafe</div><div class="rest-desc">Café with a strong patio</div></div>
+      <div><div class="rest-name">Luna Ristorante</div><div class="rest-desc">Italian — well-regarded by locals</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Beertown Public House</div><div class="rest-desc">Craft beer and pub fare</div></div>
+      <div><div class="rest-name">Flaming Stove</div><div class="rest-desc">Modern Indian and Asian-inspired menu</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Locale Aurora</div><div class="rest-desc">Modern Canadian comfort food</div></div>
+      <div><div class="rest-name">Poached Dreams Diner</div><div class="rest-desc">Weekend brunch — expect a wait</div></div>
     </div><p style="font-size:11px;color:var(--ink4);margin-top:10px;">Included for community context. Not ranked or endorsed by Finally Home Agents.</p>
       </div>
 
       <!-- TASTEHUB -->
-      <section class="th-section" aria-labelledby="th-h-aurora">
+      <section class="th-section" aria-labelledby="th-h-newmarket">
   <div class="th-header">
     <div>
       <div class="sec-eyebrow">Community-powered local food picks</div>
-      <h2 class="sec-h2" id="th-h-aurora" style="font-size:20px;">NorthSide TasteHub Local Favourites in Aurora</h2>
-      <p class="sec-sub" style="font-size:13px;margin-top:6px;">From downtown date-night spots to cafés, patios, and family-friendly restaurants, TasteHub helps buyers see where Aurora locals actually go.</p>
+      <h2 class="sec-h2" id="th-h-newmarket" style="font-size:20px;">NorthSide TasteHub Local Favourites in Newmarket</h2>
+      <p class="sec-sub" style="font-size:13px;margin-top:6px;">Main Street, cafés, casual restaurants, patios, and family favourites are part of what makes Newmarket feel complete. TasteHub brings those local picks into the guide.</p>
       <p style="font-size:11px;color:var(--ink4);margin-top:6px;">TasteHub results are community-powered and are not paid rankings or endorsements.</p>
     </div>
     <div style="display:flex;flex-direction:column;gap:8px;flex-shrink:0;">
-      <a href="/tastehub?town=aurora" class="btn-primary" style="font-size:12px;padding:9px 18px;">See Aurora favourites</a>
+      <a href="/tastehub?town=newmarket" class="btn-primary" style="font-size:12px;padding:9px 18px;">See Newmarket favourites</a>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;padding:8px 16px;">Vote on TasteHub</a>
     </div>
   </div>
-  <div id="th-polls-aurora" class="th-cards">
+  <div id="th-polls-newmarket" class="th-cards">
     <!-- TasteHub polls load here -->
     <div class="th-fallback">
-      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for Aurora are coming soon.</p>
+      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for Newmarket are coming soon.</p>
       <p style="margin-bottom:14px;">Explore live TasteHub voting across the NorthSide GTA.</p>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;">See all TasteHub polls</a>
     </div>
   </div>
 </section>
-<script>
-(function(){
-  var townName = "Aurora";
-  var containerId = "th-polls-aurora";
-  var tasteHubUrl = "/tastehub?town=" + encodeURIComponent(townName.toLowerCase().replace(/ /g,'-'));
-  fetch('/api/tastehub/polls', {credentials:'same-origin'})
-    .then(function(r){if(!r.ok)throw new Error('no polls');return r.json();})
-    .then(function(data){
-      var polls = Array.isArray(data) ? data : (data.polls || []);
-      var live = polls.filter(function(p){
-        return p.status === 'live' && p.town && p.town.toLowerCase() === townName.toLowerCase();
-      }).slice(0,3);
-      if(live.length === 0) return;
-      var container = document.getElementById(containerId);
-      container.innerHTML = live.map(function(p){
-        var href = p.slug ? '/tastehub/' + p.slug : '/tastehub';
-        var img = p.image || '/seo/tastehub-default-poll-share.jpg';
-        return '<a href="' + href + '" class="th-card" style="text-decoration:none;color:inherit;">'
-          + '<img src="' + img + '" alt="' + (p.title||'TasteHub poll') + '" class="th-card-img" loading="lazy">'
-          + '<div class="th-card-body">'
-          + '<div class="th-card-town">' + townName + '</div>'
-          + '<div class="th-card-title">' + (p.title||'Local favourite') + '</div>'
-          + '<div class="th-card-cta">Vote now &rarr;</div>'
-          + '</div></a>';
-      }).join('');
-    })
-    .catch(function(){ /* fallback already shown */ });
-})();
-</script>
+
 
       <!-- WHY PEOPLE CHOOSE -->
       <div class="sec" id="lifestyle">
-        <h2>Why people choose Aurora</h2>
-        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Heritage downtown on Yonge St</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Aurora Farmers Market (Saturdays)</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Nokiidaa Trail system</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Magna Golf Club nearby</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>10 distinct neighbourhoods</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Strong library and community facilities</span></div></div>
+        <h2>Why people choose Newmarket</h2>
+        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Main Street shops and dining</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Southlake Regional Health Centre</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Upper Canada Mall</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Highway 404 and 400 access</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Fairy Lake Park</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Weekly Farmers Market</span></div></div>
       </div>
 
       <!-- BUYER FIT -->
       <div class="sec" id="buyer-fit">
-        <h2>Is Aurora the right fit?</h2>
+        <h2>Is Newmarket the right fit?</h2>
         <div class="fit-grid">
           <div class="fit-item fit-good">
             <div class="fit-label">Well suited for</div>
-            <p>Families prioritising schools and commute, buyers moving from North Toronto, upsizers from Markham or Richmond Hill.</p>
+            <p>First-time buyers, Toronto-based families relocating north, commuters, buyers downsizing from larger GTA homes.</p>
           </div>
           <div class="fit-item fit-watch">
             <div class="fit-label">Things to weigh up</div>
-            <p>Premium pricing relative to other NorthSide GTA towns. Older homes may require capital improvements.</p>
+            <p>With average days on market at 17, well-priced listings in strong school zones move quickly. Budget preparation matters here.</p>
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
-          <strong>Market note:</strong> Aurora tends to hold value consistently across market cycles. A balanced mix of heritage stock, established neighbourhoods, and ongoing demand.
+          <strong>Market note:</strong> Newmarket consistently posts the highest transaction volume in York Region. Rental demand from GO commuters provides a practical floor for investment properties.
         </div>
       </div>
 
       <!-- DAY IN LIFE -->
       <div class="sec" id="day-in-life">
-        <h2>A day in Aurora</h2>
-        <div class="dil-block">Morning coffee near Yonge St, then a short walk to Aurora GO station. Union Station approximately 45 minutes later. After school, kids walk home from Dr. G.W. Williams while you wrap up the workday. Weekend: Aurora Farmers Market on Saturday morning, Nokiidaa Trail in the afternoon, Sunday round at Magna if you know someone.</div>
+        <h2>A day in Newmarket</h2>
+        <div class="dil-block">Walk to Newmarket GO station in about 9 minutes. Union Station roughly 55 minutes later. Kids are often independent on foot or bike — the neighbourhood has real pedestrian culture. Dinner on Main Street a few nights a week. Weekend: Fairy Lake by kayak, Sunday farmers market, hockey at Ray Twinney Arena.</div>
       </div>
 
       <!-- FAQ -->
       <div class="sec" id="faq">
         <h2>Frequently asked questions</h2>
         <details class="faq-item">
-      <summary class="faq-summary">What is Aurora Ontario known for? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Aurora is known for its heritage downtown on Yonge Street, strong school system including Dr. G.W. Williams Secondary (8.8/10, Fraser Institute 2024), and reliable GO Train service to Union Station via the Barrie line. It is one of York Region's most established residential communities.</div>
+      <summary class="faq-summary">What is Newmarket Ontario known for? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Newmarket is known as one of York Region's most connected and active communities. It has a walkable Main Street, direct GO Train service on the Barrie line, Southlake Regional Health Centre, and Upper Canada Mall. It is York Region's highest-volume real estate market.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">Is Aurora a good place to raise a family? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Aurora has a strong school catchment, established parks and trails, and a walkable downtown core. Families relocating from North Toronto or the inner GTA often find it offers a similar level of amenity with more space. School boundaries should be verified directly with YRDSB before purchasing.</div>
+      <summary class="faq-summary">Is Newmarket a good place to buy a home in 2026? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Newmarket's average days on market sat at 17 in early 2026 — the fastest pace in York Region. It offers strong value compared with Aurora while maintaining GO Train access and established neighbourhood stock. Market data from TRREB MLS® 2025–2026.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">What are the different neighbourhoods in Aurora? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Aurora has approximately ten distinct residential areas. Aurora Heights and Bayview Wellington are popular for mature lots and established streets. Aurora Estates and Hills of St. Andrew offer larger properties. Aurora Village sits close to the heritage downtown and walkable amenities.</div>
+      <summary class="faq-summary">What are the best areas in Newmarket? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Stonehaven-Wyndham is consistently in demand for its school catchment and access to the 404. Armitage and Bristol-London are popular with families. Central Newmarket suits buyers who want walkability and proximity to Main Street amenities.</div>
     </details>
       </div>
 
       <!-- OTHER COMMUNITIES -->
       <div class="sec">
         <h2>Other NorthSide GTA communities</h2>
-        <div class="towns-nav"><a href="/communities/aurora" class="town-nav-chip current">
+        <div class="towns-nav"><a href="/communities/aurora" class="town-nav-chip">
       <img src="/Images/towns/aurora.jpg" alt="Aurora NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Aurora
-    </a><a href="/communities/newmarket" class="town-nav-chip">
+    </a><a href="/communities/newmarket" class="town-nav-chip current">
       <img src="/Images/towns/newmarket.jpg" alt="Newmarket NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Newmarket
     </a><a href="/communities/stouffville" class="town-nav-chip">
@@ -444,37 +400,37 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
         <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$1122K</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$1561K</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$918K</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$720K</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">24d</span></div>
-        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">97%</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">4.2</span></div>
-        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">Buyer's market</span></span></div>
+        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$1048K</span></div>
+        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$1142K</span></div>
+        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$820K</span></div>
+        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$544K</span></div>
+        <div class="prow"><span class="pk">Days on market</span><span class="pv">17d</span></div>
+        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">98%</span></div>
+        <div class="prow"><span class="pk">Months inventory</span><span class="pv">1.6</span></div>
+        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">Balanced market</span></span></div>
         <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">TRREB MLS® 2025–2026. Not an appraisal. Confirm with a registered agent before decisions.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->
       <div class="onemil-box">
-        <div class="onemil-price">What does $1M buy in Aurora?</div>
-        <p class="onemil-desc">A well-maintained 3-bed detached on a 40-ft lot in Aurora Heights or Bayview Wellington. Likely a 1980s–90s build on a mature tree-lined street, within walking distance of schools. Expect to budget for updates.</p>
+        <div class="onemil-price">What does $1M buy in Newmarket?</div>
+        <p class="onemil-desc">A 4-bed detached in Stonehaven-Wyndham or Armitage — typically a 2000s build with a double garage, finished basement, and solid school catchment. Often includes a pool. Strong value compared with nearby options in Aurora or Richmond Hill.</p>
         <p style="font-size:10px;color:var(--ink4);margin-top:8px;">Based on active listings Q1–Q2 2026. Properties vary.</p>
       </div>
 
       <!-- CTA -->
       <div class="cta-card">
         <h3>Talk to a local real estate agent</h3>
-        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether Aurora fits your lifestyle, budget, and timing.</p>
+        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether Newmarket fits your lifestyle, budget, and timing.</p>
         <div class="agent-sm">
           <div class="asm"><div class="asm-name">Matthew Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
           <div class="asm"><div class="asm-name">Landon Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
         </div>
         <div class="cta-form">
-          <input type="text" id="sf_name_aurora" placeholder="Your name" autocomplete="name">
-          <input type="email" id="sf_email_aurora" placeholder="Email address" autocomplete="email">
-          <input type="tel" id="sf_phone_aurora" placeholder="Phone (optional)" autocomplete="tel">
-          <select id="sf_tl_aurora">
+          <input type="text" id="sf_name_newmarket" placeholder="Your name" autocomplete="name">
+          <input type="email" id="sf_email_newmarket" placeholder="Email address" autocomplete="email">
+          <input type="tel" id="sf_phone_newmarket" placeholder="Phone (optional)" autocomplete="tel">
+          <select id="sf_tl_newmarket">
             <option value="">Timeline</option>
             <option>Ready now</option>
             <option>1–3 months</option>
@@ -482,14 +438,14 @@ details[open] .faq-icon{transform:rotate(45deg);}
             <option>6–12 months</option>
             <option>Just researching</option>
           </select>
-          <button class="cta-submit" onclick="submitTownLead('aurora','Aurora')">Get local guidance &rarr;</button>
+          <button class="cta-submit" onclick="submitTownLead('newmarket','Newmarket')">Get local guidance &rarr;</button>
         </div>
         <div class="sms-box">
-          <p>Want listings for Aurora? Get quiet text alerts.</p>
+          <p>Want listings for Newmarket? Get quiet text alerts.</p>
           <p style="font-size:11px;color:rgba(255,255,255,0.5);margin-bottom:8px;">No spam. Just relevant listings and local updates.</p>
           <div class="sms-row">
-            <input type="tel" id="sms_aurora" placeholder="Your phone number">
-            <button class="sms-btn" onclick="submitSMSTown('aurora','Aurora')">Set alerts</button>
+            <input type="tel" id="sms_newmarket" placeholder="Your phone number">
+            <button class="sms-btn" onclick="submitSMSTown('newmarket','Newmarket')">Set alerts</button>
           </div>
         </div>
         <p class="reco-note">By submitting you consent to being contacted by Matthew Mulhall and Landon Mulhall, Sales Representatives, Finally Home Agents Team, HomeLife Optimum Realty, Brokerage, under TRESA, governed by RECO. For SMS: standard msg &amp; data rates may apply. Reply STOP to unsubscribe.</p>
@@ -505,41 +461,60 @@ details[open] .faq-icon{transform:rotate(45deg);}
   </div>
 </footer>
 
-<script>
-function submitTownLead(id, town) {
-  var n = document.getElementById('sf_name_' + id).value.trim();
-  var em = document.getElementById('sf_email_' + id).value.trim();
-  if (!n || !em) { alert('Please enter your name and email.'); return; }
-  var payload = {
-    name: n, email: em,
-    phone: document.getElementById('sf_phone_' + id).value,
-    timeline: document.getElementById('sf_tl_' + id).value,
-    town: town,
-    source: 'NorthSide GTA Neighbourhood Guide v4 — ' + town + ' town page',
-    timestamp: new Date().toISOString()
-  };
-  fetch('/api/leads', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var btn = document.querySelector('.cta-submit');
-  if (btn) { btn.textContent = '✓ Request sent'; btn.disabled = true; }
+
+`;
+
+export default function NewmarketPage() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const townName = "Newmarket";
+    const container = containerRef.current?.querySelector("#th-polls-newmarket");
+    if (!container) return;
+    fetch("/api/tastehub/polls", { credentials: "same-origin" })
+      .then((r) => { if (!r.ok) throw new Error("no polls"); return r.json(); })
+      .then((data) => {
+        const polls = Array.isArray(data) ? data : data.polls || [];
+        const live = polls.filter((p) => p.status === "live" && p.town && p.town.toLowerCase() === townName.toLowerCase()).slice(0, 3);
+        if (!live.length) return;
+        container.innerHTML = live.map((p) => {
+          const href = p.slug ? `/tastehub/${p.slug}` : "/tastehub";
+          const img = p.image || "/seo/tastehub-default-poll-share.jpg";
+          return `<a href="${href}" class="th-card" style="text-decoration:none;color:inherit;"><img src="${img}" alt="${p.title || "TasteHub poll"}" class="th-card-img" loading="lazy"><div class="th-card-body"><div class="th-card-town">${townName}</div><div class="th-card-title">${p.title || "Local favourite"}</div><div class="th-card-cta">Vote now &rarr;</div></div></a>`;
+        }).join("");
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    window.submitTownLead = (id, town) => {
+      const n = document.getElementById(`sf_name_${id}`)?.value.trim();
+      const em = document.getElementById(`sf_email_${id}`)?.value.trim();
+      if (!n || !em) { alert("Please enter your name and email."); return; }
+      const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
+      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
+    };
+    window.submitSMSTown = (id, town) => {
+      const phone = document.getElementById(`sms_${id}`)?.value.trim();
+      if (!phone) { alert("Please enter your phone number."); return; }
+      const payload = { phone, town, source: `NorthSide SMS opt-in — ${town}`, timestamp: new Date().toISOString() };
+      fetch("/api/sms-optin", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const smsBox = document.getElementById(`sms_${id}`)?.closest(".sms-box");
+      if (smsBox) smsBox.innerHTML = `<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ${town} listings. Reply STOP to unsubscribe.</p>`;
+    };
+    return () => { delete window.submitTownLead; delete window.submitSMSTown; };
+  }, []);
+  const schemaObject = useMemo(() => JSON.parse(PAGE_SCHEMA), []);
+  return (<><Helmet>
+      <title>Living in Newmarket, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
+      <meta name="description" content="Explore Newmarket, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Newmarket is the right fit for your move north of Toronto." />
+      <meta property="og:title" content="Living in Newmarket, Ontario | NorthSide GTA Guide" />
+      <meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Newmarket. A practical buyer guide from Finally Home Agents." />
+      <meta property="og:type" content="article" />
+      <meta property="og:url" content="https://northsidegta.ca/communities/newmarket" />
+      <meta property="og:image" content="https://northsidegta.ca/Images/newmarket-banner.jpg" />
+      <link rel="canonical" href="https://northsidegta.ca/communities/newmarket" />
+      <script type="application/ld+json">{JSON.stringify(schemaObject)}</script>
+    </Helmet><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /></>);
 }
-function submitSMSTown(id, town) {
-  var phone = document.getElementById('sms_' + id).value.trim();
-  if (!phone) { alert('Please enter your phone number.'); return; }
-  var payload = { phone: phone, town: town, source: 'NorthSide SMS opt-in — ' + town, timestamp: new Date().toISOString() };
-  fetch('/api/sms-optin', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var smsBox = document.getElementById('sms_' + id).closest('.sms-box');
-  if (smsBox) smsBox.innerHTML = '<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ' + town + ' listings. Reply STOP to unsubscribe.</p>';
-}
-</script>
-</body>
-</html>

--- a/src/NewmarketPage.js
+++ b/src/NewmarketPage.js
@@ -492,7 +492,7 @@ export default function NewmarketPage() {
       const em = document.getElementById(`sf_email_${id}`)?.value.trim();
       if (!n || !em) { alert("Please enter your name and email."); return; }
       const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
-      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      fetch("/api/send-lead", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ...payload, casl: true, notRepresented: true, title: `NorthSide GTA local guidance — ${town}`, realmLink: window.location.href }), credentials: "same-origin" }).catch(() => {});
       const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
     };
     window.submitSMSTown = (id, town) => {

--- a/src/ScugogPage.js
+++ b/src/ScugogPage.js
@@ -484,7 +484,7 @@ export default function ScugogPage() {
       const em = document.getElementById(`sf_email_${id}`)?.value.trim();
       if (!n || !em) { alert("Please enter your name and email."); return; }
       const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
-      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      fetch("/api/send-lead", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ...payload, casl: true, notRepresented: true, title: `NorthSide GTA local guidance — ${town}`, realmLink: window.location.href }), credentials: "same-origin" }).catch(() => {});
       const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
     };
     window.submitSMSTown = (id, town) => {

--- a/src/ScugogPage.js
+++ b/src/ScugogPage.js
@@ -1,49 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Living in East Gwillimbury, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
-<meta name="description" content="Explore East Gwillimbury, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether East Gwillimbury is the right fit for your move north of Toronto.">
-<meta property="og:title" content="Living in East Gwillimbury, Ontario | NorthSide GTA Guide">
-<meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in East Gwillimbury. A practical buyer guide from Finally Home Agents.">
-<meta property="og:type" content="article">
-<meta property="og:url" content="https://northsidegta.ca/communities/east-gwillimbury">
-<meta property="og:image" content="https://northsidegta.ca/Images/eastgwillimbury-banner.jpg">
-<link rel="canonical" href="https://northsidegta.ca/communities/east-gwillimbury">
-<script type="application/ld+json">{
-  "@context":"https://schema.org",
-  "@graph":[
-    {
-      "@type":"Article",
-      "headline":"Living in East Gwillimbury, Ontario | Real Estate & Neighbourhood Guide",
-      "description":"Large lots, new estate builds, fast growth, and Highway 404 access across Sharon, Queensville, and Holland Landing.",
-      "url":"https://northsidegta.ca/communities/east-gwillimbury",
-      "dateModified":"2026-05-24",
-      "author":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
-      ],
-      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
-      "about":{"@type":"City","name":"East Gwillimbury","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
-    },
-    {
-      "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is East Gwillimbury Ontario like?","acceptedAnswer":{"@type":"Answer","text":"East Gwillimbury is York Region's fastest-growing municipality, spanning Sharon, Queensville, Holland Landing, and Mount Albert. It is known for larger new-construction homes, significant infrastructure investment, and the HALP recreation centre opened in 2025."}},{"@type":"Question","name":"Is East Gwillimbury a good place to buy?","acceptedAnswer":{"@type":"Answer","text":"For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. It is currently a buyer's market with approximately 4.5 months of inventory. Daily commuting requires car travel."}},{"@type":"Question","name":"Does East Gwillimbury have GO Train service?","acceptedAnswer":{"@type":"Answer","text":"No — East Gwillimbury does not currently have a GO Train station. The closest stations are in Aurora and Newmarket. Residents primarily commute via Highway 404. The Bradford bypass is improving east-west access."}}]
-    },
-    {
-      "@type":"RealEstateAgent",
-      "name":"Finally Home Agents Team",
-      "url":"https://northsidegta.ca",
-      "employee":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
-      ]
-    }
-  ]
-}</script>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<style>
+import React, { useEffect, useMemo, useRef } from "react";
+import { Helmet } from "react-helmet-async";
+
+const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
   --green:#1e4d0f;--green2:#2d6b18;--green3:#4a8f2a;
@@ -56,7 +14,7 @@
   --shm:0 4px 20px rgba(0,0,0,0.10);--shl:0 12px 40px rgba(0,0,0,0.13);
   --r:8px;--rl:14px;--rxl:20px;
   --fd:'Playfair Display',Georgia,serif;--fb:'Inter',system-ui,sans-serif;--t:0.18s;
-  --town-color:#3a1e0a;
+  --town-color:#2a1208;
 }
 html{scroll-behavior:smooth;}
 body{font-family:var(--fb);background:var(--cream);color:var(--ink);font-size:15px;line-height:1.6;-webkit-font-smoothing:antialiased;}
@@ -116,7 +74,7 @@ img{max-width:100%;display:block;}
 .hl-check{width:18px;height:18px;background:var(--gpale);border-radius:50%;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
 .hl-check svg{width:10px;height:10px;stroke:var(--green);stroke-width:2.5;fill:none;}
 /* DAY IN LIFE */
-.dil-block{background:linear-gradient(135deg,#3a1e0a12,#3a1e0a06);border-left:3px solid #3a1e0a;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
+.dil-block{background:linear-gradient(135deg,#2a120812,#2a120806);border-left:3px solid #2a1208;padding:18px 20px;border-radius:0 var(--r) var(--r) 0;font-size:13.5px;color:var(--ink2);line-height:1.8;}
 /* FAQ */
 .faq-item{border-bottom:1px solid var(--border);}
 .faq-item:last-child{border-bottom:none;}
@@ -153,7 +111,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .pk{color:rgba(255,255,255,0.6);}
 .pv{font-weight:600;color:#fff;}
 .mkt-pill{display:inline-block;font-size:10px;padding:3px 9px;border-radius:8px;background:rgba(255,255,255,0.15);color:#fff;border:1px solid rgba(255,255,255,0.2);font-weight:500;}
-.onemil-box{background:linear-gradient(135deg,#3a1e0a18,#3a1e0a08);border:1px solid #3a1e0a35;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
+.onemil-box{background:linear-gradient(135deg,#2a120818,#2a120808);border:1px solid #2a120835;border-radius:var(--rl);padding:18px;margin-bottom:16px;}
 .onemil-price{font-family:var(--fd);font-size:15px;font-weight:700;color:var(--green);margin-bottom:8px;}
 .onemil-desc{font-size:12.5px;color:var(--ink2);line-height:1.65;}
 /* CTA CARD */
@@ -189,9 +147,39 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-item p{color:var(--ink2);line-height:1.6;}
 @media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
-</style>
-</head>
-<body>
+`;
+const PAGE_SCHEMA = `{
+  "@context":"https://schema.org",
+  "@graph":[
+    {
+      "@type":"Article",
+      "headline":"Living in Scugog, Ontario | Real Estate & Neighbourhood Guide",
+      "description":"Port Perry heritage streets, Lake Scugog waterfront, century homes, and a genuinely distinct small-town character.",
+      "url":"https://northsidegta.ca/communities/scugog",
+      "dateModified":"2026-05-24",
+      "author":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
+      ],
+      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
+      "about":{"@type":"City","name":"Scugog","containedInPlace":{"@type":"AdministrativeArea","name":"Durham Region, Ontario"}}
+    },
+    {
+      "@type":"FAQPage",
+      "mainEntity":[{"@type":"Question","name":"What is Port Perry Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Port Perry, the main centre of Scugog Township, is known for its Victorian Main Street, Lake Scugog waterfront, Heritage Festival, antique shops on Water Street, and a well-preserved small-town character. It is one of the more visually distinctive communities in Ontario."}},{"@type":"Question","name":"Is Scugog a good place to buy a home?","acceptedAnswer":{"@type":"Answer","text":"For buyers who want heritage properties, waterfront access, or a genuine small-town character — and who have flexible work arrangements — Scugog offers distinctive properties at Durham Region pricing. The commute to Toronto is the principal consideration: approximately 75 minutes off-peak, more during peak periods."}},{"@type":"Question","name":"What communities are in Scugog Township?","acceptedAnswer":{"@type":"Answer","text":"Scugog includes Port Perry (the main commercial and residential centre), Blackstock, Caesarea, Prince Albert, Nestleton, and extensive rural areas."}}]
+    },
+    {
+      "@type":"RealEstateAgent",
+      "name":"Finally Home Agents Team",
+      "url":"https://northsidegta.ca",
+      "employee":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
+      ]
+    }
+  ]
+}`;
+const PAGE_BODY_HTML = `
 
 <nav class="topnav" role="navigation" aria-label="Site navigation">
   <a href="https://northsidegta.ca" class="topnav-logo">NorthSide <span>GTA</span></a>
@@ -204,20 +192,20 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
 <!-- HERO -->
 <header class="hero" role="banner">
-  <img src="/Images/eastgwillimbury-banner.jpg" alt="Neighbourhood streetscape in East Gwillimbury" class="hero-img" loading="eager">
+  <img src="/Images/scugog-banner.jpg" alt="Port Perry waterfront in Scugog" class="hero-img" loading="eager">
   <div class="hero-overlay" aria-hidden="true"></div>
   <div class="hero-content">
     <div class="hero-eyebrow">
-      <img src="/Images/towns/east-gwillimbury.jpg" alt="East Gwillimbury NorthSide GTA town badge" class="town-badge">
-      <span>York Region &middot; NorthSide GTA</span>
+      <img src="/Images/towns/scugog.jpg" alt="Scugog NorthSide GTA town badge" class="town-badge">
+      <span>Durham Region &middot; NorthSide GTA</span>
     </div>
-    <h1>Living in East Gwillimbury</h1>
-    <p class="hero-sub">Newer communities, larger lots, family-focused growth, and quick access to Highway 404 across Sharon, Queensville, Holland Landing, and Mount Albert.</p>
+    <h1>Living in Scugog</h1>
+    <p class="hero-sub">Port Perry heritage, Lake Scugog waterfront, small-town character, and a slower pace within reach of the GTA.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">$1150K</div><div class="hstat-lbl">Avg. sold</div></div>
-      <div class="hstat"><div class="hstat-val">50 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">30d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">4.5 mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">$960K</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">75 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
+      <div class="hstat"><div class="hstat-val">36d</div><div class="hstat-lbl">Avg. on mkt</div></div>
+      <div class="hstat"><div class="hstat-val">5.5 mo</div><div class="hstat-lbl">Inventory</div></div>
     </div>
   </div>
 </header>
@@ -227,7 +215,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
   <nav class="breadcrumb" aria-label="Breadcrumb">
     <a href="https://northsidegta.ca">Home</a><span>&rsaquo;</span>
     <a href="https://northsidegta.ca/neighbourhood-guide">Neighbourhood guide</a><span>&rsaquo;</span>
-    <span>East Gwillimbury</span>
+    <span>Scugog</span>
   </nav>
   <div class="page-grid">
 
@@ -236,8 +224,8 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- INTRO -->
       <div class="sec">
-        <div class="sec-eyebrow">About East Gwillimbury</div>
-        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">East Gwillimbury is a practical choice for buyers who are prioritising home size, lot size, and newer construction over commute convenience. Communities like Sharon, Queensville, and Holland Landing are growing quickly, with meaningful infrastructure investment underway. The trade-off is clear: daily driving is required, and the local amenity base is still developing.</p>
+        <div class="sec-eyebrow">About Scugog</div>
+        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Scugog is a deliberate choice. Buyers who move here are typically not compromising — they are choosing Port Perry's character, Lake Scugog's waterfront, and a pace that the closer suburbs cannot offer. The commute trade-off is real and should be factored into any decision. The heritage property stock, particularly on and near Main Street, is irreplaceable.</p>
         <div style="margin-top:14px;display:flex;gap:6px;flex-wrap:wrap;">
           <a href="#contact" class="btn-primary" style="font-size:13px;padding:10px 20px;">Get local guidance</a>
           <a href="https://northsidegta.ca/neighbourhood-guide" class="btn-secondary" style="font-size:13px;padding:9px 18px;">Compare all towns</a>
@@ -246,9 +234,9 @@ details[open] .faq-icon{transform:rotate(45deg);}
 
       <!-- SUB-COMMUNITIES -->
       <div class="sec" id="neighbourhoods">
-        <h2>Neighbourhoods &amp; areas in East Gwillimbury</h2>
-        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Holland Landing</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Sharon</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Queensville</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Mount Albert</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Rural East Gwillimbury</span></div>
-        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within East Gwillimbury has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
+        <h2>Neighbourhoods &amp; areas in Scugog</h2>
+        <div style="margin-bottom:12px;"><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Port Perry</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Blackstock</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Caesarea</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Prince Albert</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Rural Scugog</span><span style="font-size:12px;padding:4px 11px;border-radius:8px;background:var(--gpale);border:1px solid var(--gborder);color:var(--green2);font-weight:500;display:inline-block;margin:3px 4px 3px 0;">Nestleton</span></div>
+        <p style="font-size:13px;color:var(--ink3);line-height:1.7;">Each area within Scugog has its own character, price range, and feel. Talk to Matthew or Landon about which sub-community fits your lifestyle and budget best.</p>
       </div>
 
       <!-- SCHOOLS & COMMUTE -->
@@ -257,30 +245,26 @@ details[open] .faq-icon{transform:rotate(45deg);}
         <table class="school-table" aria-label="Schools">
       <thead><tr><th>School</th><th>Rating</th><th>Notes</th></tr></thead>
       <tbody><tr>
-      <td><div class="school-name">Sharon Public School</div><div class="school-type">Public Elementary</div></td>
-      <td class="school-rating">7.8/10</td>
-      <td class="school-note">Highest-rated in EG — Fraser Institute 2024</td>
+      <td><div class="school-name">Port Perry High School</div><div class="school-type">Public Secondary</div></td>
+      <td class="school-rating">6.5/10</td>
+      <td class="school-note">Durham District School Board</td>
     </tr><tr>
-      <td><div class="school-name">Queensville Public School</div><div class="school-type">Public Elementary</div></td>
-      <td class="school-rating">7.5/10</td>
-      <td class="school-note">Newer school serving fast-growing community</td>
+      <td><div class="school-name">Scugog Central Public School</div><div class="school-type">Public Elementary</div></td>
+      <td class="school-rating">6.8/10</td>
+      <td class="school-note">Fraser Institute 2024</td>
     </tr><tr>
-      <td><div class="school-name">Dr. John M. Denison SS</div><div class="school-type">Secondary (Newmarket)</div></td>
-      <td class="school-rating">7.2/10</td>
-      <td class="school-note">Primary secondary school for EG residents</td>
-    </tr><tr>
-      <td><div class="school-name">Sacred Heart Catholic Elementary</div><div class="school-type">Catholic Elementary</div></td>
-      <td class="school-rating">7.6/10</td>
-      <td class="school-note">York Catholic District School Board</td>
+      <td><div class="school-name">St. Theresa Catholic Elementary</div><div class="school-type">Catholic Elementary</div></td>
+      <td class="school-rating">6.7/10</td>
+      <td class="school-note">Durham Catholic District School Board</td>
     </tr></tbody>
     </table>
     <p style="font-size:11px;color:var(--ink4);margin-top:10px;line-height:1.65;">Ratings from Fraser Institute Ontario School Report Cards 2024/2025. School boundaries can change — verify directly with the relevant school board before making a property decision.</p>
         <div style="margin-top:18px;">
-          <h2 style="font-size:18px;margin-bottom:10px;">Commute from East Gwillimbury</h2>
+          <h2 style="font-size:18px;margin-bottom:10px;">Commute from Scugog</h2>
           <div style="background:var(--cream);border-radius:var(--r);padding:14px 16px;font-size:13px;color:var(--ink2);line-height:1.75;">
-            <div><strong>Distance to DVP/401:</strong> 60 km</div>
-            <div><strong>Off-peak drive time:</strong> approximately 50 minutes</div>
-            <div><strong>Transit:</strong> Highway 404 and Bradford bypass — no GO Train station</div>
+            <div><strong>Distance to DVP/401:</strong> 88 km</div>
+            <div><strong>Off-peak drive time:</strong> approximately 75 minutes</div>
+            <div><strong>Transit:</strong> Car-dependent — Durham Transit only</div>
             <div style="margin-top:8px;font-size:12px;color:var(--ink4);">Drive times are off-peak estimates. Peak-hour commute times are typically 30–60% longer depending on conditions.</div>
           </div>
         </div>
@@ -290,111 +274,85 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <div class="sec" id="restaurants">
         <h2>Local restaurants &amp; cafés</h2>
         <div class="rest-item">
-      <div><div class="rest-name">Sharon village cafés</div><div class="rest-desc">Independent cafés in the heritage village core</div></div>
+      <div><div class="rest-name">Simcoe Street Grill</div><div class="rest-desc">Waterfront dining — well-regarded locally</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Holland Landing diners</div><div class="rest-desc">Small-town diner options along Yonge St</div></div>
+      <div><div class="rest-name">St. Andrew's Pub</div><div class="rest-desc">Heritage pub in a 150-year-old building</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">HALP Aquatics Café</div><div class="rest-desc">Café inside the HALP recreation centre (opened 2025)</div></div>
+      <div><div class="rest-name">Princess Street Cafe</div><div class="rest-desc">Weekend brunch — busy by 9 AM</div></div>
     </div><div class="rest-item">
-      <div><div class="rest-name">Newmarket dining — 15 min south</div><div class="rest-desc">Full restaurant and retail corridor</div></div>
+      <div><div class="rest-name">Fiesta Gardens</div><div class="rest-desc">Coffee and gelato on the main strip</div></div>
+    </div><div class="rest-item">
+      <div><div class="rest-name">Inn at Port Perry (dining)</div><div class="rest-desc">Sit-down dining in a historic inn</div></div>
     </div><p style="font-size:11px;color:var(--ink4);margin-top:10px;">Included for community context. Not ranked or endorsed by Finally Home Agents.</p>
       </div>
 
       <!-- TASTEHUB -->
-      <section class="th-section" aria-labelledby="th-h-east-gwillimbury">
+      <section class="th-section" aria-labelledby="th-h-scugog">
   <div class="th-header">
     <div>
       <div class="sec-eyebrow">Community-powered local food picks</div>
-      <h2 class="sec-h2" id="th-h-east-gwillimbury" style="font-size:20px;">NorthSide TasteHub Local Favourites in East Gwillimbury</h2>
-      <p class="sec-sub" style="font-size:13px;margin-top:6px;">From Sharon to Queensville, Holland Landing, and Mount Albert, TasteHub helps buyers discover local cafés, takeout spots, and community favourites.</p>
+      <h2 class="sec-h2" id="th-h-scugog" style="font-size:20px;">NorthSide TasteHub Local Favourites in Scugog</h2>
+      <p class="sec-sub" style="font-size:13px;margin-top:6px;">Port Perry's restaurants, cafés, bakeries, patios, and lake-town favourites are a major part of Scugog's lifestyle. TasteHub shows what locals are voting for.</p>
       <p style="font-size:11px;color:var(--ink4);margin-top:6px;">TasteHub results are community-powered and are not paid rankings or endorsements.</p>
     </div>
     <div style="display:flex;flex-direction:column;gap:8px;flex-shrink:0;">
-      <a href="/tastehub?town=east-gwillimbury" class="btn-primary" style="font-size:12px;padding:9px 18px;">See East Gwillimbury favourites</a>
+      <a href="/tastehub?town=scugog" class="btn-primary" style="font-size:12px;padding:9px 18px;">See Scugog favourites</a>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;padding:8px 16px;">Vote on TasteHub</a>
     </div>
   </div>
-  <div id="th-polls-east-gwillimbury" class="th-cards">
+  <div id="th-polls-scugog" class="th-cards">
     <!-- TasteHub polls load here -->
     <div class="th-fallback">
-      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for East Gwillimbury are coming soon.</p>
+      <p style="margin-bottom:8px;font-weight:500;">TasteHub polls for Scugog are coming soon.</p>
       <p style="margin-bottom:14px;">Explore live TasteHub voting across the NorthSide GTA.</p>
       <a href="/tastehub" class="btn-secondary" style="font-size:12px;">See all TasteHub polls</a>
     </div>
   </div>
 </section>
-<script>
-(function(){
-  var townName = "East Gwillimbury";
-  var containerId = "th-polls-east-gwillimbury";
-  var tasteHubUrl = "/tastehub?town=" + encodeURIComponent(townName.toLowerCase().replace(/ /g,'-'));
-  fetch('/api/tastehub/polls', {credentials:'same-origin'})
-    .then(function(r){if(!r.ok)throw new Error('no polls');return r.json();})
-    .then(function(data){
-      var polls = Array.isArray(data) ? data : (data.polls || []);
-      var live = polls.filter(function(p){
-        return p.status === 'live' && p.town && p.town.toLowerCase() === townName.toLowerCase();
-      }).slice(0,3);
-      if(live.length === 0) return;
-      var container = document.getElementById(containerId);
-      container.innerHTML = live.map(function(p){
-        var href = p.slug ? '/tastehub/' + p.slug : '/tastehub';
-        var img = p.image || '/seo/tastehub-default-poll-share.jpg';
-        return '<a href="' + href + '" class="th-card" style="text-decoration:none;color:inherit;">'
-          + '<img src="' + img + '" alt="' + (p.title||'TasteHub poll') + '" class="th-card-img" loading="lazy">'
-          + '<div class="th-card-body">'
-          + '<div class="th-card-town">' + townName + '</div>'
-          + '<div class="th-card-title">' + (p.title||'Local favourite') + '</div>'
-          + '<div class="th-card-cta">Vote now &rarr;</div>'
-          + '</div></a>';
-      }).join('');
-    })
-    .catch(function(){ /* fallback already shown */ });
-})();
-</script>
+
 
       <!-- WHY PEOPLE CHOOSE -->
       <div class="sec" id="lifestyle">
-        <h2>Why people choose East Gwillimbury</h2>
-        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>HALP Aquatic and Recreation Centre (opened 2025)</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Sharon heritage village</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Bradford bypass road improvements</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Estate subdivisions in Sharon</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Fastest-growing municipality in York Region</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Holland Landing Conservation Area</span></div></div>
+        <h2>Why people choose Scugog</h2>
+        <div class="highlight-grid"><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Port Perry Victorian Main Street</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Lake Scugog waterfront</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Heritage Festival (annual summer event)</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Boutique shops and galleries on Water St</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Antiques on Water Street</span></div><div class="hl-item"><div class="hl-check"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></div><span>Fireworks on the lake, July 1st</span></div></div>
       </div>
 
       <!-- BUYER FIT -->
       <div class="sec" id="buyer-fit">
-        <h2>Is East Gwillimbury the right fit?</h2>
+        <h2>Is Scugog the right fit?</h2>
         <div class="fit-grid">
           <div class="fit-item fit-good">
             <div class="fit-label">Well suited for</div>
-            <p>Buyers prioritising space, newer construction, and home size. Families with flexible or remote work arrangements. Upsizers from Newmarket, Aurora, or Barrie.</p>
+            <p>Heritage home buyers, waterfront property seekers, buyers with remote work flexibility, buyers approaching or in retirement.</p>
           </div>
           <div class="fit-item fit-watch">
             <div class="fit-label">Things to weigh up</div>
-            <p>East Gwillimbury is car-dependent. There is no GO Train station. Daily commuting requires highway driving, typically 45 to 60 minutes off-peak to central Toronto.</p>
+            <p>Scugog has the longest commute of the seven NorthSide GTA communities — approximately 75 minutes off-peak to central Toronto, and considerably longer during peak hours. Remote or hybrid work is a practical prerequisite for most buyers.</p>
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
-          <strong>Market note:</strong> Significant municipal infrastructure investment underway. The HALP recreation centre opened in 2025. Long-term value picture is positive as the area matures, though the current market offers buyer-side leverage.
+          <strong>Market note:</strong> Waterfront and heritage properties have historically held value relative to the broader local market. Non-waterfront inventory is soft, with 5.5 months available and buyers holding meaningful negotiating room.
         </div>
       </div>
 
       <!-- DAY IN LIFE -->
       <div class="sec" id="day-in-life">
-        <h2>A day in East Gwillimbury</h2>
-        <div class="dil-block">Morning school drop-off is around the corner — the subdivision layout makes it quick. The 404 south takes 45 to 60 minutes off-peak depending on where you're headed in the city. Pull into the three-car garage in the evening. After dinner: HALP Aquatics with the kids, or a walk in the new trails behind the Sharon expansion. The home is larger and newer than most of what's available further south at this price.</div>
+        <h2>A day in Scugog</h2>
+        <div class="dil-block">Morning walk along Water Street — Port Perry's Main Street is genuinely one of the most well-preserved Victorian streetscapes in Ontario. Work from home, or commit to the long drive. Evenings on the dock in summer. Weekend: Port Perry Farmers Market, kayaking on the lake, antique browsing on Water Street. The Heritage Festival in late summer brings the whole region in.</div>
       </div>
 
       <!-- FAQ -->
       <div class="sec" id="faq">
         <h2>Frequently asked questions</h2>
         <details class="faq-item">
-      <summary class="faq-summary">What is East Gwillimbury Ontario like? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">East Gwillimbury is York Region's fastest-growing municipality, spanning Sharon, Queensville, Holland Landing, and Mount Albert. It is known for larger new-construction homes, significant infrastructure investment, and the HALP recreation centre opened in 2025.</div>
+      <summary class="faq-summary">What is Port Perry Ontario known for? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Port Perry, the main centre of Scugog Township, is known for its Victorian Main Street, Lake Scugog waterfront, Heritage Festival, antique shops on Water Street, and a well-preserved small-town character. It is one of the more visually distinctive communities in Ontario.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">Is East Gwillimbury a good place to buy? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. It is currently a buyer's market with approximately 4.5 months of inventory. Daily commuting requires car travel.</div>
+      <summary class="faq-summary">Is Scugog a good place to buy a home? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">For buyers who want heritage properties, waterfront access, or a genuine small-town character — and who have flexible work arrangements — Scugog offers distinctive properties at Durham Region pricing. The commute to Toronto is the principal consideration: approximately 75 minutes off-peak, more during peak periods.</div>
     </details><details class="faq-item">
-      <summary class="faq-summary">Does East Gwillimbury have GO Train service? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">No — East Gwillimbury does not currently have a GO Train station. The closest stations are in Aurora and Newmarket. Residents primarily commute via Highway 404. The Bradford bypass is improving east-west access.</div>
+      <summary class="faq-summary">What communities are in Scugog Township? <span class="faq-icon">+</span></summary>
+      <div class="faq-answer">Scugog includes Port Perry (the main commercial and residential centre), Blackstock, Caesarea, Prince Albert, Nestleton, and extensive rural areas.</div>
     </details>
       </div>
 
@@ -410,7 +368,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
     </a><a href="/communities/stouffville" class="town-nav-chip">
       <img src="/Images/towns/stouffville.jpg" alt="Stouffville NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Stouffville
-    </a><a href="/communities/east-gwillimbury" class="town-nav-chip current">
+    </a><a href="/communities/east-gwillimbury" class="town-nav-chip">
       <img src="/Images/towns/east-gwillimbury.jpg" alt="East Gwillimbury NorthSide GTA town badge" width="20" height="20" loading="lazy">
       East Gwillimbury
     </a><a href="/communities/georgina" class="town-nav-chip">
@@ -419,7 +377,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
     </a><a href="/communities/uxbridge" class="town-nav-chip">
       <img src="/Images/towns/uxbridge.jpg" alt="Uxbridge NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Uxbridge
-    </a><a href="/communities/scugog" class="town-nav-chip">
+    </a><a href="/communities/scugog" class="town-nav-chip current">
       <img src="/Images/towns/scugog.jpg" alt="Scugog NorthSide GTA town badge" width="20" height="20" loading="lazy">
       Scugog
     </a></div>
@@ -434,37 +392,37 @@ details[open] .faq-icon{transform:rotate(45deg);}
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
         <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$1150K</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$1550K</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$890K</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$680K</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">30d</span></div>
+        <div class="prow"><span class="pk">All types avg.</span><span class="pv">$960K</span></div>
+        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">$1099K</span></div>
+        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">$762K</span></div>
+        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">$800K</span></div>
+        <div class="prow"><span class="pk">Days on market</span><span class="pv">36d</span></div>
         <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">98%</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">4.5</span></div>
+        <div class="prow"><span class="pk">Months inventory</span><span class="pv">5.5</span></div>
         <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">Buyer's market</span></span></div>
         <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">TRREB MLS® 2025–2026. Not an appraisal. Confirm with a registered agent before decisions.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->
       <div class="onemil-box">
-        <div class="onemil-price">What does $1M buy in East Gwillimbury?</div>
-        <p class="onemil-desc">A 4 to 5 bed estate detached on a 50 to 60 ft lot in Queensville or Sharon — typically 2,600 to 3,200 sq ft, three-car garage, large backyard, built within the last five years. More home per dollar than most of York Region.</p>
+        <div class="onemil-price">What does $1M buy in Scugog?</div>
+        <p class="onemil-desc">A well-preserved Victorian century home on a double lot steps from Port Perry's Main Street and the waterfront, or a contemporary 4-bed on Lake Scugog with dock access. Heritage properties of this character are rare and not replicable at this price elsewhere in the GTA orbit.</p>
         <p style="font-size:10px;color:var(--ink4);margin-top:8px;">Based on active listings Q1–Q2 2026. Properties vary.</p>
       </div>
 
       <!-- CTA -->
       <div class="cta-card">
         <h3>Talk to a local real estate agent</h3>
-        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether East Gwillimbury fits your lifestyle, budget, and timing.</p>
+        <p>We can help you compare neighbourhoods, understand current pricing, and decide whether Scugog fits your lifestyle, budget, and timing.</p>
         <div class="agent-sm">
           <div class="asm"><div class="asm-name">Matthew Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
           <div class="asm"><div class="asm-name">Landon Mulhall</div><div class="asm-role">Sales Representative</div><div class="asm-brok">HomeLife Optimum Realty</div></div>
         </div>
         <div class="cta-form">
-          <input type="text" id="sf_name_east-gwillimbury" placeholder="Your name" autocomplete="name">
-          <input type="email" id="sf_email_east-gwillimbury" placeholder="Email address" autocomplete="email">
-          <input type="tel" id="sf_phone_east-gwillimbury" placeholder="Phone (optional)" autocomplete="tel">
-          <select id="sf_tl_east-gwillimbury">
+          <input type="text" id="sf_name_scugog" placeholder="Your name" autocomplete="name">
+          <input type="email" id="sf_email_scugog" placeholder="Email address" autocomplete="email">
+          <input type="tel" id="sf_phone_scugog" placeholder="Phone (optional)" autocomplete="tel">
+          <select id="sf_tl_scugog">
             <option value="">Timeline</option>
             <option>Ready now</option>
             <option>1–3 months</option>
@@ -472,14 +430,14 @@ details[open] .faq-icon{transform:rotate(45deg);}
             <option>6–12 months</option>
             <option>Just researching</option>
           </select>
-          <button class="cta-submit" onclick="submitTownLead('east-gwillimbury','East Gwillimbury')">Get local guidance &rarr;</button>
+          <button class="cta-submit" onclick="submitTownLead('scugog','Scugog')">Get local guidance &rarr;</button>
         </div>
         <div class="sms-box">
-          <p>Want listings for East Gwillimbury? Get quiet text alerts.</p>
+          <p>Want listings for Scugog? Get quiet text alerts.</p>
           <p style="font-size:11px;color:rgba(255,255,255,0.5);margin-bottom:8px;">No spam. Just relevant listings and local updates.</p>
           <div class="sms-row">
-            <input type="tel" id="sms_east-gwillimbury" placeholder="Your phone number">
-            <button class="sms-btn" onclick="submitSMSTown('east-gwillimbury','East Gwillimbury')">Set alerts</button>
+            <input type="tel" id="sms_scugog" placeholder="Your phone number">
+            <button class="sms-btn" onclick="submitSMSTown('scugog','Scugog')">Set alerts</button>
           </div>
         </div>
         <p class="reco-note">By submitting you consent to being contacted by Matthew Mulhall and Landon Mulhall, Sales Representatives, Finally Home Agents Team, HomeLife Optimum Realty, Brokerage, under TRESA, governed by RECO. For SMS: standard msg &amp; data rates may apply. Reply STOP to unsubscribe.</p>
@@ -495,41 +453,60 @@ details[open] .faq-icon{transform:rotate(45deg);}
   </div>
 </footer>
 
-<script>
-function submitTownLead(id, town) {
-  var n = document.getElementById('sf_name_' + id).value.trim();
-  var em = document.getElementById('sf_email_' + id).value.trim();
-  if (!n || !em) { alert('Please enter your name and email.'); return; }
-  var payload = {
-    name: n, email: em,
-    phone: document.getElementById('sf_phone_' + id).value,
-    timeline: document.getElementById('sf_tl_' + id).value,
-    town: town,
-    source: 'NorthSide GTA Neighbourhood Guide v4 — ' + town + ' town page',
-    timestamp: new Date().toISOString()
-  };
-  fetch('/api/leads', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var btn = document.querySelector('.cta-submit');
-  if (btn) { btn.textContent = '✓ Request sent'; btn.disabled = true; }
+
+`;
+
+export default function ScugogPage() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const townName = "Scugog";
+    const container = containerRef.current?.querySelector("#th-polls-scugog");
+    if (!container) return;
+    fetch("/api/tastehub/polls", { credentials: "same-origin" })
+      .then((r) => { if (!r.ok) throw new Error("no polls"); return r.json(); })
+      .then((data) => {
+        const polls = Array.isArray(data) ? data : data.polls || [];
+        const live = polls.filter((p) => p.status === "live" && p.town && p.town.toLowerCase() === townName.toLowerCase()).slice(0, 3);
+        if (!live.length) return;
+        container.innerHTML = live.map((p) => {
+          const href = p.slug ? `/tastehub/${p.slug}` : "/tastehub";
+          const img = p.image || "/seo/tastehub-default-poll-share.jpg";
+          return `<a href="${href}" class="th-card" style="text-decoration:none;color:inherit;"><img src="${img}" alt="${p.title || "TasteHub poll"}" class="th-card-img" loading="lazy"><div class="th-card-body"><div class="th-card-town">${townName}</div><div class="th-card-title">${p.title || "Local favourite"}</div><div class="th-card-cta">Vote now &rarr;</div></div></a>`;
+        }).join("");
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    window.submitTownLead = (id, town) => {
+      const n = document.getElementById(`sf_name_${id}`)?.value.trim();
+      const em = document.getElementById(`sf_email_${id}`)?.value.trim();
+      if (!n || !em) { alert("Please enter your name and email."); return; }
+      const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
+      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
+    };
+    window.submitSMSTown = (id, town) => {
+      const phone = document.getElementById(`sms_${id}`)?.value.trim();
+      if (!phone) { alert("Please enter your phone number."); return; }
+      const payload = { phone, town, source: `NorthSide SMS opt-in — ${town}`, timestamp: new Date().toISOString() };
+      fetch("/api/sms-optin", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const smsBox = document.getElementById(`sms_${id}`)?.closest(".sms-box");
+      if (smsBox) smsBox.innerHTML = `<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ${town} listings. Reply STOP to unsubscribe.</p>`;
+    };
+    return () => { delete window.submitTownLead; delete window.submitSMSTown; };
+  }, []);
+  const schemaObject = useMemo(() => JSON.parse(PAGE_SCHEMA), []);
+  return (<><Helmet>
+      <title>Living in Scugog, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
+      <meta name="description" content="Explore Scugog, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Scugog is the right fit for your move north of Toronto." />
+      <meta property="og:title" content="Living in Scugog, Ontario | NorthSide GTA Guide" />
+      <meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Scugog. A practical buyer guide from Finally Home Agents." />
+      <meta property="og:type" content="article" />
+      <meta property="og:url" content="https://northsidegta.ca/communities/scugog" />
+      <meta property="og:image" content="https://northsidegta.ca/Images/scugog-banner.jpg" />
+      <link rel="canonical" href="https://northsidegta.ca/communities/scugog" />
+      <script type="application/ld+json">{JSON.stringify(schemaObject)}</script>
+    </Helmet><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /></>);
 }
-function submitSMSTown(id, town) {
-  var phone = document.getElementById('sms_' + id).value.trim();
-  if (!phone) { alert('Please enter your phone number.'); return; }
-  var payload = { phone: phone, town: town, source: 'NorthSide SMS opt-in — ' + town, timestamp: new Date().toISOString() };
-  fetch('/api/sms-optin', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var smsBox = document.getElementById('sms_' + id).closest('.sms-box');
-  if (smsBox) smsBox.innerHTML = '<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ' + town + ' listings. Reply STOP to unsubscribe.</p>';
-}
-</script>
-</body>
-</html>

--- a/src/StouffvillePage.js
+++ b/src/StouffvillePage.js
@@ -492,7 +492,7 @@ export default function StouffvillePage() {
       const em = document.getElementById(`sf_email_${id}`)?.value.trim();
       if (!n || !em) { alert("Please enter your name and email."); return; }
       const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
-      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      fetch("/api/send-lead", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ...payload, casl: true, notRepresented: true, title: `NorthSide GTA local guidance — ${town}`, realmLink: window.location.href }), credentials: "same-origin" }).catch(() => {});
       const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
     };
     window.submitSMSTown = (id, town) => {

--- a/src/StouffvillePage.js
+++ b/src/StouffvillePage.js
@@ -1,49 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Living in Stouffville, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
-<meta name="description" content="Explore Stouffville, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Stouffville is the right fit for your move north of Toronto.">
-<meta property="og:title" content="Living in Stouffville, Ontario | NorthSide GTA Guide">
-<meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Stouffville. A practical buyer guide from Finally Home Agents.">
-<meta property="og:type" content="article">
-<meta property="og:url" content="https://northsidegta.ca/communities/stouffville">
-<meta property="og:image" content="https://northsidegta.ca/Images/stouffville-banner.jpg">
-<link rel="canonical" href="https://northsidegta.ca/communities/stouffville">
-<script type="application/ld+json">{
-  "@context":"https://schema.org",
-  "@graph":[
-    {
-      "@type":"Article",
-      "headline":"Living in Stouffville, Ontario | Real Estate & Neighbourhood Guide",
-      "description":"GO Train access, newer builds on larger lots, strong schools, and a heritage Main Street.",
-      "url":"https://northsidegta.ca/communities/stouffville",
-      "dateModified":"2026-05-24",
-      "author":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
-      ],
-      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
-      "about":{"@type":"City","name":"Stouffville","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
-    },
-    {
-      "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"Is Stouffville a good place to live?","acceptedAnswer":{"@type":"Answer","text":"Stouffville combines newer homes, strong schools, GO Train access, and a heritage Main Street in a way that works well for families relocating from the inner GTA. It is one of York Region's fastest-growing communities."}},{"@type":"Question","name":"What is Stouffville Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Stouffville is known for its rapid residential growth, new construction developments, heritage Main Street, Ballantrae Golf & Country Club, and a strong community character. It is a popular destination for families moving from Toronto, Markham, or Richmond Hill."}},{"@type":"Question","name":"What is the housing market like in Stouffville?","acceptedAnswer":{"@type":"Answer","text":"As of early 2026, Stouffville has approximately 6 months of inventory — a buyer's market. Average sold price across all property types is approximately $1,114,000. Detached homes average around $1,280,000. Data from TRREB MLS® 2025–2026."}}]
-    },
-    {
-      "@type":"RealEstateAgent",
-      "name":"Finally Home Agents Team",
-      "url":"https://northsidegta.ca",
-      "employee":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
-      ]
-    }
-  ]
-}</script>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<style>
+import React, { useEffect, useMemo, useRef } from "react";
+import { Helmet } from "react-helmet-async";
+
+const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
   --green:#1e4d0f;--green2:#2d6b18;--green3:#4a8f2a;
@@ -189,9 +147,39 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-item p{color:var(--ink2);line-height:1.6;}
 @media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
-</style>
-</head>
-<body>
+`;
+const PAGE_SCHEMA = `{
+  "@context":"https://schema.org",
+  "@graph":[
+    {
+      "@type":"Article",
+      "headline":"Living in Stouffville, Ontario | Real Estate & Neighbourhood Guide",
+      "description":"GO Train access, newer builds on larger lots, strong schools, and a heritage Main Street.",
+      "url":"https://northsidegta.ca/communities/stouffville",
+      "dateModified":"2026-05-24",
+      "author":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
+      ],
+      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
+      "about":{"@type":"City","name":"Stouffville","containedInPlace":{"@type":"AdministrativeArea","name":"York Region, Ontario"}}
+    },
+    {
+      "@type":"FAQPage",
+      "mainEntity":[{"@type":"Question","name":"Is Stouffville a good place to live?","acceptedAnswer":{"@type":"Answer","text":"Stouffville combines newer homes, strong schools, GO Train access, and a heritage Main Street in a way that works well for families relocating from the inner GTA. It is one of York Region's fastest-growing communities."}},{"@type":"Question","name":"What is Stouffville Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Stouffville is known for its rapid residential growth, new construction developments, heritage Main Street, Ballantrae Golf & Country Club, and a strong community character. It is a popular destination for families moving from Toronto, Markham, or Richmond Hill."}},{"@type":"Question","name":"What is the housing market like in Stouffville?","acceptedAnswer":{"@type":"Answer","text":"As of early 2026, Stouffville has approximately 6 months of inventory — a buyer's market. Average sold price across all property types is approximately $1,114,000. Detached homes average around $1,280,000. Data from TRREB MLS® 2025–2026."}}]
+    },
+    {
+      "@type":"RealEstateAgent",
+      "name":"Finally Home Agents Team",
+      "url":"https://northsidegta.ca",
+      "employee":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
+      ]
+    }
+  ]
+}`;
+const PAGE_BODY_HTML = `
 
 <nav class="topnav" role="navigation" aria-label="Site navigation">
   <a href="https://northsidegta.ca" class="topnav-logo">NorthSide <span>GTA</span></a>
@@ -329,35 +317,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
     </div>
   </div>
 </section>
-<script>
-(function(){
-  var townName = "Stouffville";
-  var containerId = "th-polls-stouffville";
-  var tasteHubUrl = "/tastehub?town=" + encodeURIComponent(townName.toLowerCase().replace(/ /g,'-'));
-  fetch('/api/tastehub/polls', {credentials:'same-origin'})
-    .then(function(r){if(!r.ok)throw new Error('no polls');return r.json();})
-    .then(function(data){
-      var polls = Array.isArray(data) ? data : (data.polls || []);
-      var live = polls.filter(function(p){
-        return p.status === 'live' && p.town && p.town.toLowerCase() === townName.toLowerCase();
-      }).slice(0,3);
-      if(live.length === 0) return;
-      var container = document.getElementById(containerId);
-      container.innerHTML = live.map(function(p){
-        var href = p.slug ? '/tastehub/' + p.slug : '/tastehub';
-        var img = p.image || '/seo/tastehub-default-poll-share.jpg';
-        return '<a href="' + href + '" class="th-card" style="text-decoration:none;color:inherit;">'
-          + '<img src="' + img + '" alt="' + (p.title||'TasteHub poll') + '" class="th-card-img" loading="lazy">'
-          + '<div class="th-card-body">'
-          + '<div class="th-card-town">' + townName + '</div>'
-          + '<div class="th-card-title">' + (p.title||'Local favourite') + '</div>'
-          + '<div class="th-card-cta">Vote now &rarr;</div>'
-          + '</div></a>';
-      }).join('');
-    })
-    .catch(function(){ /* fallback already shown */ });
-})();
-</script>
+
 
       <!-- WHY PEOPLE CHOOSE -->
       <div class="sec" id="lifestyle">
@@ -501,41 +461,60 @@ details[open] .faq-icon{transform:rotate(45deg);}
   </div>
 </footer>
 
-<script>
-function submitTownLead(id, town) {
-  var n = document.getElementById('sf_name_' + id).value.trim();
-  var em = document.getElementById('sf_email_' + id).value.trim();
-  if (!n || !em) { alert('Please enter your name and email.'); return; }
-  var payload = {
-    name: n, email: em,
-    phone: document.getElementById('sf_phone_' + id).value,
-    timeline: document.getElementById('sf_tl_' + id).value,
-    town: town,
-    source: 'NorthSide GTA Neighbourhood Guide v4 — ' + town + ' town page',
-    timestamp: new Date().toISOString()
-  };
-  fetch('/api/leads', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var btn = document.querySelector('.cta-submit');
-  if (btn) { btn.textContent = '✓ Request sent'; btn.disabled = true; }
+
+`;
+
+export default function StouffvillePage() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const townName = "Stouffville";
+    const container = containerRef.current?.querySelector("#th-polls-stouffville");
+    if (!container) return;
+    fetch("/api/tastehub/polls", { credentials: "same-origin" })
+      .then((r) => { if (!r.ok) throw new Error("no polls"); return r.json(); })
+      .then((data) => {
+        const polls = Array.isArray(data) ? data : data.polls || [];
+        const live = polls.filter((p) => p.status === "live" && p.town && p.town.toLowerCase() === townName.toLowerCase()).slice(0, 3);
+        if (!live.length) return;
+        container.innerHTML = live.map((p) => {
+          const href = p.slug ? `/tastehub/${p.slug}` : "/tastehub";
+          const img = p.image || "/seo/tastehub-default-poll-share.jpg";
+          return `<a href="${href}" class="th-card" style="text-decoration:none;color:inherit;"><img src="${img}" alt="${p.title || "TasteHub poll"}" class="th-card-img" loading="lazy"><div class="th-card-body"><div class="th-card-town">${townName}</div><div class="th-card-title">${p.title || "Local favourite"}</div><div class="th-card-cta">Vote now &rarr;</div></div></a>`;
+        }).join("");
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    window.submitTownLead = (id, town) => {
+      const n = document.getElementById(`sf_name_${id}`)?.value.trim();
+      const em = document.getElementById(`sf_email_${id}`)?.value.trim();
+      if (!n || !em) { alert("Please enter your name and email."); return; }
+      const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
+      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
+    };
+    window.submitSMSTown = (id, town) => {
+      const phone = document.getElementById(`sms_${id}`)?.value.trim();
+      if (!phone) { alert("Please enter your phone number."); return; }
+      const payload = { phone, town, source: `NorthSide SMS opt-in — ${town}`, timestamp: new Date().toISOString() };
+      fetch("/api/sms-optin", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const smsBox = document.getElementById(`sms_${id}`)?.closest(".sms-box");
+      if (smsBox) smsBox.innerHTML = `<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ${town} listings. Reply STOP to unsubscribe.</p>`;
+    };
+    return () => { delete window.submitTownLead; delete window.submitSMSTown; };
+  }, []);
+  const schemaObject = useMemo(() => JSON.parse(PAGE_SCHEMA), []);
+  return (<><Helmet>
+      <title>Living in Stouffville, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
+      <meta name="description" content="Explore Stouffville, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Stouffville is the right fit for your move north of Toronto." />
+      <meta property="og:title" content="Living in Stouffville, Ontario | NorthSide GTA Guide" />
+      <meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Stouffville. A practical buyer guide from Finally Home Agents." />
+      <meta property="og:type" content="article" />
+      <meta property="og:url" content="https://northsidegta.ca/communities/stouffville" />
+      <meta property="og:image" content="https://northsidegta.ca/Images/stouffville-banner.jpg" />
+      <link rel="canonical" href="https://northsidegta.ca/communities/stouffville" />
+      <script type="application/ld+json">{JSON.stringify(schemaObject)}</script>
+    </Helmet><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /></>);
 }
-function submitSMSTown(id, town) {
-  var phone = document.getElementById('sms_' + id).value.trim();
-  if (!phone) { alert('Please enter your phone number.'); return; }
-  var payload = { phone: phone, town: town, source: 'NorthSide SMS opt-in — ' + town, timestamp: new Date().toISOString() };
-  fetch('/api/sms-optin', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var smsBox = document.getElementById('sms_' + id).closest('.sms-box');
-  if (smsBox) smsBox.innerHTML = '<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ' + town + ' listings. Reply STOP to unsubscribe.</p>';
-}
-</script>
-</body>
-</html>

--- a/src/UxbridgePage.js
+++ b/src/UxbridgePage.js
@@ -484,7 +484,7 @@ export default function UxbridgePage() {
       const em = document.getElementById(`sf_email_${id}`)?.value.trim();
       if (!n || !em) { alert("Please enter your name and email."); return; }
       const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
-      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      fetch("/api/send-lead", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ...payload, casl: true, notRepresented: true, title: `NorthSide GTA local guidance — ${town}`, realmLink: window.location.href }), credentials: "same-origin" }).catch(() => {});
       const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
     };
     window.submitSMSTown = (id, town) => {

--- a/src/UxbridgePage.js
+++ b/src/UxbridgePage.js
@@ -1,49 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Living in Uxbridge, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
-<meta name="description" content="Explore Uxbridge, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Uxbridge is the right fit for your move north of Toronto.">
-<meta property="og:title" content="Living in Uxbridge, Ontario | NorthSide GTA Guide">
-<meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Uxbridge. A practical buyer guide from Finally Home Agents.">
-<meta property="og:type" content="article">
-<meta property="og:url" content="https://northsidegta.ca/communities/uxbridge">
-<meta property="og:image" content="https://northsidegta.ca/Images/uxbridge-banner.jpg">
-<link rel="canonical" href="https://northsidegta.ca/communities/uxbridge">
-<script type="application/ld+json">{
-  "@context":"https://schema.org",
-  "@graph":[
-    {
-      "@type":"Article",
-      "headline":"Living in Uxbridge, Ontario | Real Estate & Neighbourhood Guide",
-      "description":"Canada's Trail Capital — 300+ km of trails, heritage streets, a local arts scene, and Durham Region pricing.",
-      "url":"https://northsidegta.ca/communities/uxbridge",
-      "dateModified":"2026-05-24",
-      "author":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
-      ],
-      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
-      "about":{"@type":"City","name":"Uxbridge","containedInPlace":{"@type":"AdministrativeArea","name":"Durham Region, Ontario"}}
-    },
-    {
-      "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is Uxbridge Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge holds the official designation of Canada's Trail Capital, with more than 300 km of trails on the Oak Ridges Moraine including the Trans Canada Trail and Durham Forest. The town is also known for its equestrian community, active arts scene, and Theatre Uxbridge."}},{"@type":"Question","name":"Is Uxbridge a good place to live?","acceptedAnswer":{"@type":"Answer","text":"For buyers with remote work flexibility, equestrian interests, or a preference for a quieter lifestyle within reach of the GTA, Uxbridge is a strong option. The main trade-offs are car-dependence and a longer commute. The market is balanced with approximately 4 months of inventory."}},{"@type":"Question","name":"What trails are in Uxbridge?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge has more than 300 km of multi-use trails supporting hiking, mountain biking, equestrian use, cross-country skiing, and snowshoeing. Key routes include Durham Forest, Glen Major Forest, the Trans Canada Trail, and the Oak Ridges Moraine Trail."}}]
-    },
-    {
-      "@type":"RealEstateAgent",
-      "name":"Finally Home Agents Team",
-      "url":"https://northsidegta.ca",
-      "employee":[
-        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
-        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
-      ]
-    }
-  ]
-}</script>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<style>
+import React, { useEffect, useMemo, useRef } from "react";
+import { Helmet } from "react-helmet-async";
+
+const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
   --green:#1e4d0f;--green2:#2d6b18;--green3:#4a8f2a;
@@ -189,9 +147,39 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-item p{color:var(--ink2);line-height:1.6;}
 @media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
-</style>
-</head>
-<body>
+`;
+const PAGE_SCHEMA = `{
+  "@context":"https://schema.org",
+  "@graph":[
+    {
+      "@type":"Article",
+      "headline":"Living in Uxbridge, Ontario | Real Estate & Neighbourhood Guide",
+      "description":"Canada's Trail Capital — 300+ km of trails, heritage streets, a local arts scene, and Durham Region pricing.",
+      "url":"https://northsidegta.ca/communities/uxbridge",
+      "dateModified":"2026-05-24",
+      "author":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative","worksFor":{"@type":"Organization","name":"HomeLife Optimum Realty"}}
+      ],
+      "publisher":{"@type":"Organization","name":"Finally Home Agents Team","url":"https://northsidegta.ca"},
+      "about":{"@type":"City","name":"Uxbridge","containedInPlace":{"@type":"AdministrativeArea","name":"Durham Region, Ontario"}}
+    },
+    {
+      "@type":"FAQPage",
+      "mainEntity":[{"@type":"Question","name":"What is Uxbridge Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge holds the official designation of Canada's Trail Capital, with more than 300 km of trails on the Oak Ridges Moraine including the Trans Canada Trail and Durham Forest. The town is also known for its equestrian community, active arts scene, and Theatre Uxbridge."}},{"@type":"Question","name":"Is Uxbridge a good place to live?","acceptedAnswer":{"@type":"Answer","text":"For buyers with remote work flexibility, equestrian interests, or a preference for a quieter lifestyle within reach of the GTA, Uxbridge is a strong option. The main trade-offs are car-dependence and a longer commute. The market is balanced with approximately 4 months of inventory."}},{"@type":"Question","name":"What trails are in Uxbridge?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge has more than 300 km of multi-use trails supporting hiking, mountain biking, equestrian use, cross-country skiing, and snowshoeing. Key routes include Durham Forest, Glen Major Forest, the Trans Canada Trail, and the Oak Ridges Moraine Trail."}}]
+    },
+    {
+      "@type":"RealEstateAgent",
+      "name":"Finally Home Agents Team",
+      "url":"https://northsidegta.ca",
+      "employee":[
+        {"@type":"Person","name":"Matthew Mulhall","jobTitle":"Sales Representative"},
+        {"@type":"Person","name":"Landon Mulhall","jobTitle":"Sales Representative"}
+      ]
+    }
+  ]
+}`;
+const PAGE_BODY_HTML = `
 
 <nav class="topnav" role="navigation" aria-label="Site navigation">
   <a href="https://northsidegta.ca" class="topnav-logo">NorthSide <span>GTA</span></a>
@@ -321,35 +309,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
     </div>
   </div>
 </section>
-<script>
-(function(){
-  var townName = "Uxbridge";
-  var containerId = "th-polls-uxbridge";
-  var tasteHubUrl = "/tastehub?town=" + encodeURIComponent(townName.toLowerCase().replace(/ /g,'-'));
-  fetch('/api/tastehub/polls', {credentials:'same-origin'})
-    .then(function(r){if(!r.ok)throw new Error('no polls');return r.json();})
-    .then(function(data){
-      var polls = Array.isArray(data) ? data : (data.polls || []);
-      var live = polls.filter(function(p){
-        return p.status === 'live' && p.town && p.town.toLowerCase() === townName.toLowerCase();
-      }).slice(0,3);
-      if(live.length === 0) return;
-      var container = document.getElementById(containerId);
-      container.innerHTML = live.map(function(p){
-        var href = p.slug ? '/tastehub/' + p.slug : '/tastehub';
-        var img = p.image || '/seo/tastehub-default-poll-share.jpg';
-        return '<a href="' + href + '" class="th-card" style="text-decoration:none;color:inherit;">'
-          + '<img src="' + img + '" alt="' + (p.title||'TasteHub poll') + '" class="th-card-img" loading="lazy">'
-          + '<div class="th-card-body">'
-          + '<div class="th-card-town">' + townName + '</div>'
-          + '<div class="th-card-title">' + (p.title||'Local favourite') + '</div>'
-          + '<div class="th-card-cta">Vote now &rarr;</div>'
-          + '</div></a>';
-      }).join('');
-    })
-    .catch(function(){ /* fallback already shown */ });
-})();
-</script>
+
 
       <!-- WHY PEOPLE CHOOSE -->
       <div class="sec" id="lifestyle">
@@ -493,41 +453,60 @@ details[open] .faq-icon{transform:rotate(45deg);}
   </div>
 </footer>
 
-<script>
-function submitTownLead(id, town) {
-  var n = document.getElementById('sf_name_' + id).value.trim();
-  var em = document.getElementById('sf_email_' + id).value.trim();
-  if (!n || !em) { alert('Please enter your name and email.'); return; }
-  var payload = {
-    name: n, email: em,
-    phone: document.getElementById('sf_phone_' + id).value,
-    timeline: document.getElementById('sf_tl_' + id).value,
-    town: town,
-    source: 'NorthSide GTA Neighbourhood Guide v4 — ' + town + ' town page',
-    timestamp: new Date().toISOString()
-  };
-  fetch('/api/leads', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var btn = document.querySelector('.cta-submit');
-  if (btn) { btn.textContent = '✓ Request sent'; btn.disabled = true; }
+
+`;
+
+export default function UxbridgePage() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const townName = "Uxbridge";
+    const container = containerRef.current?.querySelector("#th-polls-uxbridge");
+    if (!container) return;
+    fetch("/api/tastehub/polls", { credentials: "same-origin" })
+      .then((r) => { if (!r.ok) throw new Error("no polls"); return r.json(); })
+      .then((data) => {
+        const polls = Array.isArray(data) ? data : data.polls || [];
+        const live = polls.filter((p) => p.status === "live" && p.town && p.town.toLowerCase() === townName.toLowerCase()).slice(0, 3);
+        if (!live.length) return;
+        container.innerHTML = live.map((p) => {
+          const href = p.slug ? `/tastehub/${p.slug}` : "/tastehub";
+          const img = p.image || "/seo/tastehub-default-poll-share.jpg";
+          return `<a href="${href}" class="th-card" style="text-decoration:none;color:inherit;"><img src="${img}" alt="${p.title || "TasteHub poll"}" class="th-card-img" loading="lazy"><div class="th-card-body"><div class="th-card-town">${townName}</div><div class="th-card-title">${p.title || "Local favourite"}</div><div class="th-card-cta">Vote now &rarr;</div></div></a>`;
+        }).join("");
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    window.submitTownLead = (id, town) => {
+      const n = document.getElementById(`sf_name_${id}`)?.value.trim();
+      const em = document.getElementById(`sf_email_${id}`)?.value.trim();
+      if (!n || !em) { alert("Please enter your name and email."); return; }
+      const payload = { name: n, email: em, phone: document.getElementById(`sf_phone_${id}`)?.value, timeline: document.getElementById(`sf_tl_${id}`)?.value, town, source: `NorthSide GTA Neighbourhood Guide v4 — ${town} town page`, timestamp: new Date().toISOString() };
+      fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const btn = document.querySelector(".cta-submit"); if (btn) { btn.textContent = "✓ Request sent"; btn.disabled = true; }
+    };
+    window.submitSMSTown = (id, town) => {
+      const phone = document.getElementById(`sms_${id}`)?.value.trim();
+      if (!phone) { alert("Please enter your phone number."); return; }
+      const payload = { phone, town, source: `NorthSide SMS opt-in — ${town}`, timestamp: new Date().toISOString() };
+      fetch("/api/sms-optin", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload), credentials: "same-origin" }).catch(() => {});
+      const smsBox = document.getElementById(`sms_${id}`)?.closest(".sms-box");
+      if (smsBox) smsBox.innerHTML = `<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ${town} listings. Reply STOP to unsubscribe.</p>`;
+    };
+    return () => { delete window.submitTownLead; delete window.submitSMSTown; };
+  }, []);
+  const schemaObject = useMemo(() => JSON.parse(PAGE_SCHEMA), []);
+  return (<><Helmet>
+      <title>Living in Uxbridge, Ontario | Real Estate &amp; Neighbourhood Guide | Finally Home Agents</title>
+      <meta name="description" content="Explore Uxbridge, Ontario with Finally Home Agents. Compare neighbourhoods, home prices, commute, schools, parks, local favourites, and whether Uxbridge is the right fit for your move north of Toronto." />
+      <meta property="og:title" content="Living in Uxbridge, Ontario | NorthSide GTA Guide" />
+      <meta property="og:description" content="Compare lifestyle, commute, home prices, schools, neighbourhoods, and local favourites in Uxbridge. A practical buyer guide from Finally Home Agents." />
+      <meta property="og:type" content="article" />
+      <meta property="og:url" content="https://northsidegta.ca/communities/uxbridge" />
+      <meta property="og:image" content="https://northsidegta.ca/Images/uxbridge-banner.jpg" />
+      <link rel="canonical" href="https://northsidegta.ca/communities/uxbridge" />
+      <script type="application/ld+json">{JSON.stringify(schemaObject)}</script>
+    </Helmet><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /></>);
 }
-function submitSMSTown(id, town) {
-  var phone = document.getElementById('sms_' + id).value.trim();
-  if (!phone) { alert('Please enter your phone number.'); return; }
-  var payload = { phone: phone, town: town, source: 'NorthSide SMS opt-in — ' + town, timestamp: new Date().toISOString() };
-  fetch('/api/sms-optin', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify(payload),
-    credentials: 'same-origin'
-  }).catch(function() {});
-  var smsBox = document.getElementById('sms_' + id).closest('.sms-box');
-  if (smsBox) smsBox.innerHTML = '<p style="color:rgba(255,255,255,0.8);font-size:13px;">&#10003; You're in. We'll text you new ' + town + ' listings. Reply STOP to unsubscribe.</p>';
-}
-</script>
-</body>
-</html>


### PR DESCRIPTION
### Motivation

- Migrate several static neighbourhood HTML pages into the React app so they can be rendered, SEO-managed, and re-used within the SPA architecture.
- Surface community pages via explicit routes and short URLs for better routing and integration with existing components.
- Replace inline DOM scripts with React-friendly effects and centralized `Helmet` metadata for consistent SSR/SEO behavior.

### Description

- Converted multiple static HTML files into React components under `src/` including `AuroraPage`, `NewmarketPage`, `StouffvillePage`, `EastGwillimburyPage`, `GeorginaPage`, `UxbridgePage`, `ScugogPage`, and `NeighbourhoodGuidePage`, moving content into `PAGE_STYLE`, `PAGE_SCHEMA`, and `PAGE_BODY_HTML` constants and rendering via `dangerouslySetInnerHTML` with React `useEffect` hooks for dynamic behavior.
- Replaced inline scripts for TasteHub polls and form handlers with `useEffect` implementations that fetch `/api/tastehub/polls` and expose `window.submitTownLead` / `window.submitSMSTown` while cleaning up on unmount.
- Added `Helmet` metadata injection (`title`, meta, canonical, JSON-LD) and `useMemo` parsing of page schema for each converted page.
- Updated `src/App.js` to import the new pages and add routes: `'/neighbourhood-guide'` and community routes such as `'/communities/aurora'`, `'/communities/newmarket'`, `'/communities/stouffville'`, `'/communities/east-gwillimbury'`, `'/communities/georgina'`, `'/communities/uxbridge'`, `'/communities/scugog'`, while retaining the generic `'/communities/:slug'` and short-town routes generated from `towns.json`.

### Testing

- Built the application using `npm run build` locally to verify compilation of the new components and route wiring, and the build completed successfully.
- Ran the test suite with `npm test` and observed passing tests for affected modules and no new test failures.
- Performed a local dev run (`npm start`) and spot-checked rendered pages for the new routes to confirm metadata injection and TasteHub poll fetching logic executed without console errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14acbeca54832496578ec280b69ed0)