### PR TITLE
Use production team photo in homepage “We live here. We work here.” section

### DIFF
--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -747,8 +747,8 @@ main { padding-top: 100px; }
 @media (min-width: 640px) { .agent-intro { padding-block: var(--section-py-lg); } }
 .agent-intro__grid { display: grid; gap: 40px; align-items: center; }
 @media (min-width: 1024px) { .agent-intro__grid { grid-template-columns: 1fr 1fr; } }
-.agent-intro__photo { overflow: hidden; border-radius: var(--radius-card-lg); border: 1px solid var(--ns-border); box-shadow: 0 16px 40px rgba(35,71,10,0.1); }
-.agent-intro__img { width: 100%; height: 100%; object-fit: cover; }
+.agent-intro__photo { overflow: hidden; border-radius: var(--radius-card-lg); border: 1px solid var(--ns-border); background: linear-gradient(135deg, rgba(23,63,8,0.96), rgba(35,92,13,0.82)); box-shadow: 0 16px 40px rgba(35,71,10,0.1); }
+.agent-intro__img { display: block; width: 100%; height: 100%; object-fit: cover; }
 .agent-intro__copy .section-heading { margin-top: 12px; }
 .agent-intro__body { margin-top: 20px; font-size: 16px; line-height: 1.7; color: #475569; }
 @media (min-width: 640px) { .agent-intro__body { font-size: 18px; } }
@@ -1006,54 +1006,24 @@ main { padding-top: 100px; }
 .mobile-drawer__footer { margin-top: auto; }
 .mobile-drawer-open { overflow: hidden; }
 
-.agent-intro__photo-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  height: 100%;
-  min-height: 420px;
-}
-.agent-intro__portrait {
-  position: relative;
+.agent-intro__team-card {
   overflow: hidden;
   margin: 0;
-  border-radius: 24px;
+  aspect-ratio: 1484 / 1060;
+  border-radius: calc(var(--radius-card-lg) - 1px);
   background: linear-gradient(135deg, rgba(23,63,8,0.9), rgba(35,92,13,0.72));
   box-shadow: inset 0 0 0 1px rgba(255,255,255,0.18);
 }
-.agent-intro__portrait .agent-intro__img {
-  width: 100%;
-  height: 100%;
-  min-height: 420px;
-  object-fit: cover;
-  object-position: center top;
+.agent-intro__team-card .agent-intro__img {
+  object-position: center center;
   filter: saturate(1.02) contrast(1.03);
 }
-.agent-intro__portrait figcaption {
-  position: absolute;
-  inset-inline: 12px;
-  bottom: 12px;
-  border: 1px solid rgba(244,239,229,0.22);
-  border-radius: 999px;
-  background: rgba(23,63,8,0.78);
-  color: var(--ns-cream);
-  padding: 8px 12px;
-  text-align: center;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  backdrop-filter: blur(8px);
-}
 @media (max-width: 520px) {
-  .agent-intro__photo-grid {
-    grid-template-columns: 1fr;
-    min-height: 0;
-  }
-  .agent-intro__portrait .agent-intro__img {
+  .agent-intro__team-card {
     min-height: 320px;
   }
 }
+
 
 .hero__map-frame svg.northside-map--inline {
   display: block;

--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -855,29 +855,16 @@ export const HOMEPAGE_MARKUP = String.raw`
   <section class="agent-intro" aria-labelledby="agent-heading">
     <div class="section-inner section-inner--narrow">
       <div class="agent-intro__grid">
-        <div class="agent-intro__photo" role="img" aria-label="Matthew Mulhall and Landon Mulhall of Finally Home Agents — NorthSide GTA real estate">
-          <div class="agent-intro__photo-grid">
-            <figure class="agent-intro__portrait">
-              <img
-                src="/Images/matthew.jpg"
-                alt=""
-                width="400" height="600"
-                loading="lazy"
-                class="agent-intro__img"
-              >
-              <figcaption>Matthew Mulhall</figcaption>
-            </figure>
-            <figure class="agent-intro__portrait">
-              <img
-                src="/Images/landon.jpg"
-                alt=""
-                width="400" height="600"
-                loading="lazy"
-                class="agent-intro__img"
-              >
-              <figcaption>Landon Mulhall</figcaption>
-            </figure>
-          </div>
+        <div class="agent-intro__photo">
+          <figure class="agent-intro__team-card">
+            <img
+              src="/assets/homepage/matthew-landon-northside-gta.jpg"
+              alt="Matthew Mulhall and Landon Mulhall of Finally Home Agents — NorthSide GTA real estate"
+              width="1484" height="1060"
+              loading="lazy"
+              class="agent-intro__img"
+            >
+          </figure>
         </div>
         <div class="agent-intro__copy">
           <p class="section-eyebrow">The team behind NorthSide GTA</p>


### PR DESCRIPTION
### Motivation
- Replace temporary/individual portrait placeholders with the single approved production team image and ensure it uses the correct production asset path, alt text, and responsive sizing without redesigning the section.

### Description
- Replaced the two separate portrait figures with a single team image in `src/homepageMarkup.js` using the production path `/assets/homepage/matthew-landon-northside-gta.jpg`, the requested alt text, `width="1484"` and `height="1060"`, and `loading="lazy"` (left image/card area preserved). 
- Updated `src/HomePage.css` to preserve the rounded card, premium dark-green/cream treatment and enforce `object-fit: cover` and responsive behavior via `.agent-intro__photo`, `.agent-intro__img`, and a new `.agent-intro__team-card` with an aspect-ratio to avoid layout shift. 
- Kept the existing right-side copy and CTAs untouched and did not redesign layout or replace other assets.

### Testing
- Ran `npm run build` and the production build completed successfully (warnings from third-party source-maps only). 
- Ran `npm run lint --if-present` (no failing lint output; no project lint script configured). 
- Started the dev server and verified the image is served (`curl -I` returned `HTTP/1.1 200 OK` for `/assets/homepage/matthew-landon-northside-gta.jpg`).
- Automated verification using Playwright against the local dev server confirmed the desktop image loaded, had the expected natural dimensions, `object-fit: cover`, and the width/height attributes; mobile verification required extra waiting due to intermittent environment network/proxy console errors but screenshots were captured showing the responsive layout (`/tmp/northside-agent-intro-desktop.png` and `/tmp/northside-agent-intro-mobile.png`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a219f4187408324b44528aa01856588)