### PR TITLE
Update homepage agent intro paragraph

### DIFF
--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -1031,7 +1031,7 @@ export const HOMEPAGE_MARKUP = String.raw`
         <div class="agent-intro__copy">
           <p class="section-eyebrow">The team behind NorthSide GTA</p>
           <h2 class="section-heading" id="agent-heading">We live here. We work here.</h2>
-          <p class="agent-intro__body">Matthew and Landon are the Finally Home Agents behind NorthSide GTA. They know which streets flood in spring, where the best trails are, and what it actually feels like to live in each of these communities. When you're making one of the biggest decisions of your life, that kind of local knowledge matters.</p>
+          <p class="agent-intro__body">For brothers Matthew and Landon, NorthSide GTA is personal.<br><br>It’s where they <span class="text-brand-green font-bold">live</span>, <span class="text-brand-green font-bold">work</span>, <span class="text-brand-green font-bold">raise their families</span>, <span class="text-brand-green font-bold">golf</span>, and spend their time. That perspective shapes how they guide clients — helping people look beyond homes and prices to understand the <span class="text-brand-green font-bold">communities</span>, lifestyle, and <span class="text-brand-green font-bold">long-term fit</span> behind each move.</p>
           <div class="agent-intro__contacts">
             <a href="https://wa.me/16476684646" class="btn btn--whatsapp">WhatsApp us</a>
             <a href="tel:+16476684646" class="btn btn--outline-green">Matthew · 647-668-4646</a>


### PR DESCRIPTION
### Motivation
- Refresh the small team paragraph under the unchanged “We live here. We work here.” heading to the new Matthew/Landon copy and apply restrained brand-green highlights to specific phrases while leaving layout, images, SEO, schema, and other sections untouched.

### Description
- Replaced the single paragraph in `src/homepageMarkup.js` (inside the `We live here. We work here.` section) with the supplied copy and wrapped the requested phrases in `<span class="text-brand-green font-bold">…</span>` so the site’s existing brand utilities provide a restrained, non-link highlight.

### Testing
- Ran `npm run build` which completed successfully (build finished with unrelated dependency/source-map warnings). 
- Ran `npm run lint --if-present` which exited successfully (no lint script defined in this repo). 
- Verified no `git diff --check` issues and captured an automated dev-server screenshot to confirm the updated paragraph renders as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21bba9e50483248917fb0dc60f7de1)