### PR TITLE
Add restrained focus-community logo rail above homepage map

### DIFF
--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -314,6 +314,7 @@ main { padding-top: 100px; }
 }
 
 .hero__copy {
+  min-width: 0;
   position: relative;
   overflow: hidden;
   background: linear-gradient(145deg, #0a1a0b, #11240d, #1e3d08);
@@ -393,6 +394,7 @@ main { padding-top: 100px; }
 .google-reviews-strip__text span { font-size: 12px; color: rgba(209,250,229,0.7); }
 
 .hero__map-panel {
+  min-width: 0;
   display: flex;
   flex-direction: column;
   background: #edeae0;
@@ -467,6 +469,100 @@ main { padding-top: 100px; }
     padding: 6px 8px;
   }
   .map-legend__item { font-size: 9px; }
+}
+
+.focus-community-rail {
+  border-top: 1px solid rgba(123, 113, 95, 0.14);
+  background: linear-gradient(180deg, #f2eee4 0%, #ebe6d9 100%);
+  padding: 10px 16px 12px;
+}
+.focus-community-rail__label {
+  margin: 0 0 8px;
+  text-align: center;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  color: #51613b;
+}
+.focus-community-rail__track {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: 7px;
+  max-width: 100%;
+}
+.focus-community-rail__tile {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  border: 1px solid rgba(123, 113, 95, 0.16);
+  border-radius: 12px;
+  background: rgba(255, 252, 244, 0.78);
+  padding: 7px 6px 6px;
+  text-decoration: none;
+  color: #405232;
+  box-shadow: 0 8px 18px rgba(35, 71, 10, 0.045);
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+.focus-community-rail__tile:hover,
+.focus-community-rail__tile:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(35, 92, 13, 0.25);
+  background: rgba(255, 255, 250, 0.96);
+  box-shadow: 0 12px 22px rgba(35, 71, 10, 0.08);
+}
+.focus-community-rail__tile:focus-visible {
+  outline: 2px solid rgba(35, 92, 13, 0.42);
+  outline-offset: 2px;
+}
+.focus-community-rail__tile img {
+  display: block;
+  width: 100%;
+  max-width: 74px;
+  height: 28px;
+  object-fit: contain;
+}
+.focus-community-rail__tile span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+@media (max-width: 767px) {
+  .focus-community-rail {
+    padding-inline: 12px;
+  }
+  .focus-community-rail__label {
+    text-align: left;
+  }
+  .focus-community-rail__track {
+    justify-content: flex-start;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: thin;
+    padding: 1px 2px 4px;
+  }
+  .focus-community-rail__tile {
+    flex: 0 0 104px;
+  }
+}
+@media (min-width: 1024px) and (max-width: 1180px) {
+  .focus-community-rail__tile img {
+    max-width: 64px;
+    height: 25px;
+  }
+  .focus-community-rail__tile span {
+    font-size: 8px;
+  }
 }
 
 .hero__map-footer {

--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -474,10 +474,10 @@ main { padding-top: 100px; }
 .focus-community-rail {
   border-top: 1px solid rgba(123, 113, 95, 0.14);
   background: linear-gradient(180deg, #f2eee4 0%, #ebe6d9 100%);
-  padding: 12px 16px 14px;
+  padding: 12px 14px 14px;
 }
 .focus-community-rail__label {
-  margin: 0 0 10px;
+  margin: 0 0 8px;
   text-align: center;
   font-size: 9px;
   font-weight: 800;
@@ -498,17 +498,17 @@ main { padding-top: 100px; }
   padding: 1px 2px 4px;
 }
 .focus-community-rail__tile {
-  flex: 0 0 clamp(96px, 13%, 112px);
-  min-height: 90px;
+  flex: 0 0 clamp(104px, 13.5%, 120px);
+  min-height: 98px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 5px;
+  gap: 3px;
   border: 1px solid rgba(123, 113, 95, 0.14);
   border-radius: 14px;
-  background: rgba(255, 252, 244, 0.8);
-  padding: 8px 7px 7px;
+  background: rgba(255, 252, 244, 0.82);
+  padding: 2px 2px 4px;
   text-decoration: none;
   color: #405232;
   box-shadow: 0 8px 18px rgba(35, 71, 10, 0.045);
@@ -525,20 +525,34 @@ main { padding-top: 100px; }
   outline: 2px solid rgba(35, 92, 13, 0.42);
   outline-offset: 2px;
 }
-.focus-community-rail__tile img {
+.focus-community-rail__tile img,
+.focus-community-rail__logo {
   display: block;
-  width: 100%;
-  max-width: 96px;
-  height: 62px;
+  width: 96%;
+  max-width: 116px;
+  height: 82px;
+  margin: auto;
   object-fit: contain;
   object-position: center;
+}
+.focus-community-rail__logo--georgina,
+.focus-community-rail__logo--east-gwillimbury,
+.focus-community-rail__logo--scugog {
+  width: 98%;
+  max-width: 118px;
+}
+.focus-community-rail__logo--aurora,
+.focus-community-rail__logo--newmarket,
+.focus-community-rail__logo--stouffville,
+.focus-community-rail__logo--uxbridge {
+  width: 94%;
 }
 .focus-community-rail__tile span {
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 9px;
+  font-size: 8px;
   font-weight: 700;
   line-height: 1.2;
 }
@@ -554,13 +568,21 @@ main { padding-top: 100px; }
     gap: 7px;
   }
   .focus-community-rail__tile {
-    flex-basis: 98px;
-    min-height: 84px;
-    padding: 7px 6px 6px;
+    flex-basis: 104px;
+    min-height: 90px;
+    padding: 2px 2px 4px;
   }
-  .focus-community-rail__tile img {
-    max-width: 88px;
-    height: 58px;
+  .focus-community-rail__tile img,
+  .focus-community-rail__logo {
+    width: 92%;
+    max-width: 98px;
+    height: 76px;
+  }
+  .focus-community-rail__logo--georgina,
+  .focus-community-rail__logo--east-gwillimbury,
+  .focus-community-rail__logo--scugog {
+    width: 94%;
+    max-width: 100px;
   }
 }
 @media (min-width: 1280px) {

--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -680,9 +680,34 @@ main { padding-top: 100px; }
 .community-card:hover { transform: translateY(-2px); box-shadow: 0 16px 40px rgba(35,71,10,0.1); }
 .community-card__link { display: flex; flex-direction: column; flex: 1; text-decoration: none; color: inherit; }
 
-.community-card__img-wrap { aspect-ratio: 16/10; overflow: hidden; background: #dcfce7; }
-.community-card__img { width: 100%; height: 100%; object-fit: cover; transition: transform 0.3s; }
-.community-card:hover .community-card__img { transform: scale(1.04); }
+.community-card__img-wrap {
+  aspect-ratio: 16/10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: linear-gradient(145deg, #f6f1e8 0%, #ebe4d5 100%);
+  padding: clamp(28px, 7%, 40px);
+}
+.community-card__img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  max-width: 78%;
+  max-height: 70%;
+  margin: auto;
+  object-fit: contain;
+  object-position: center;
+  transition: transform 0.3s ease, filter 0.3s ease;
+}
+.community-card:hover .community-card__img { transform: scale(1.02); filter: saturate(1.03); }
+.community-card__logo--georgina,
+.community-card__logo--east-gwillimbury,
+.community-card__logo--scugog { max-width: 82%; }
+.community-card__logo--aurora,
+.community-card__logo--newmarket,
+.community-card__logo--stouffville,
+.community-card__logo--uxbridge { max-width: 76%; }
 
 .community-card__body { display: flex; flex-direction: column; flex: 1; padding: 20px; }
 .community-card__name { font-family: var(--font-serif); font-size: 20px; font-weight: 500; color: var(--ns-emerald-900); }

--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -474,10 +474,10 @@ main { padding-top: 100px; }
 .focus-community-rail {
   border-top: 1px solid rgba(123, 113, 95, 0.14);
   background: linear-gradient(180deg, #f2eee4 0%, #ebe6d9 100%);
-  padding: 10px 16px 12px;
+  padding: 12px 16px 14px;
 }
 .focus-community-rail__label {
-  margin: 0 0 8px;
+  margin: 0 0 10px;
   text-align: center;
   font-size: 9px;
   font-weight: 800;
@@ -490,21 +490,25 @@ main { padding-top: 100px; }
   display: flex;
   align-items: stretch;
   justify-content: center;
-  gap: 7px;
+  gap: 8px;
   max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+  padding: 1px 2px 4px;
 }
 .focus-community-rail__tile {
-  flex: 1 1 0;
-  min-width: 0;
+  flex: 0 0 clamp(96px, 13%, 112px);
+  min-height: 90px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  border: 1px solid rgba(123, 113, 95, 0.16);
-  border-radius: 12px;
-  background: rgba(255, 252, 244, 0.78);
-  padding: 7px 6px 6px;
+  gap: 5px;
+  border: 1px solid rgba(123, 113, 95, 0.14);
+  border-radius: 14px;
+  background: rgba(255, 252, 244, 0.8);
+  padding: 8px 7px 7px;
   text-decoration: none;
   color: #405232;
   box-shadow: 0 8px 18px rgba(35, 71, 10, 0.045);
@@ -524,9 +528,10 @@ main { padding-top: 100px; }
 .focus-community-rail__tile img {
   display: block;
   width: 100%;
-  max-width: 74px;
-  height: 28px;
+  max-width: 96px;
+  height: 62px;
   object-fit: contain;
+  object-position: center;
 }
 .focus-community-rail__tile span {
   max-width: 100%;
@@ -539,29 +544,28 @@ main { padding-top: 100px; }
 }
 @media (max-width: 767px) {
   .focus-community-rail {
-    padding-inline: 12px;
+    padding: 11px 12px 13px;
   }
   .focus-community-rail__label {
     text-align: left;
   }
   .focus-community-rail__track {
     justify-content: flex-start;
-    overflow-x: auto;
-    overscroll-behavior-x: contain;
-    scrollbar-width: thin;
-    padding: 1px 2px 4px;
+    gap: 7px;
   }
   .focus-community-rail__tile {
-    flex: 0 0 104px;
+    flex-basis: 98px;
+    min-height: 84px;
+    padding: 7px 6px 6px;
+  }
+  .focus-community-rail__tile img {
+    max-width: 88px;
+    height: 58px;
   }
 }
-@media (min-width: 1024px) and (max-width: 1180px) {
-  .focus-community-rail__tile img {
-    max-width: 64px;
-    height: 25px;
-  }
-  .focus-community-rail__tile span {
-    font-size: 8px;
+@media (min-width: 1280px) {
+  .focus-community-rail__track {
+    overflow-x: visible;
   }
 }
 

--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -549,6 +549,40 @@ export const HOMEPAGE_MARKUP = String.raw`
           </div>
         </div>
 
+        <nav class="focus-community-rail" aria-label="NorthSide GTA focus communities">
+          <p class="focus-community-rail__label">NorthSide GTA focus communities</p>
+          <div class="focus-community-rail__track">
+            <a class="focus-community-rail__tile" href="/communities/georgina" aria-label="Explore Georgina Real Estate">
+              <img src="/assets/town-logos/georgina.webp" alt="Georgina" width="720" height="300" loading="eager" decoding="async">
+              <span>Georgina</span>
+            </a>
+            <a class="focus-community-rail__tile" href="/communities/east-gwillimbury" aria-label="Explore East Gwillimbury Real Estate">
+              <img src="/assets/town-logos/east-gwillimbury.webp" alt="East Gwillimbury" width="720" height="300" loading="eager" decoding="async">
+              <span>East Gwillimbury</span>
+            </a>
+            <a class="focus-community-rail__tile" href="/communities/newmarket" aria-label="Explore Newmarket Real Estate">
+              <img src="/assets/town-logos/newmarket.webp" alt="Newmarket" width="720" height="300" loading="eager" decoding="async">
+              <span>Newmarket</span>
+            </a>
+            <a class="focus-community-rail__tile" href="/communities/aurora" aria-label="Explore Aurora Real Estate">
+              <img src="/assets/town-logos/aurora.webp" alt="Aurora" width="720" height="300" loading="eager" decoding="async">
+              <span>Aurora</span>
+            </a>
+            <a class="focus-community-rail__tile" href="/communities/stouffville" aria-label="Explore Stouffville Real Estate">
+              <img src="/assets/town-logos/stouffville.webp" alt="Whitchurch-Stouffville" width="720" height="300" loading="eager" decoding="async">
+              <span>Stouffville</span>
+            </a>
+            <a class="focus-community-rail__tile" href="/communities/uxbridge" aria-label="Explore Uxbridge Real Estate">
+              <img src="/assets/town-logos/uxbridge.webp" alt="Uxbridge" width="720" height="300" loading="eager" decoding="async">
+              <span>Uxbridge</span>
+            </a>
+            <a class="focus-community-rail__tile" href="/communities/scugog" aria-label="Explore Scugog Real Estate">
+              <img src="/assets/town-logos/scugog.webp" alt="Scugog" width="720" height="300" loading="eager" decoding="async">
+              <span>Scugog</span>
+            </a>
+          </div>
+        </nav>
+
         <div class="hero__map-footer" id="map-caption" aria-live="polite">
           NorthSide GTA focus communities · guidance also available in King, Bradford, Vaughan, Richmond Hill, Markham, Pickering, Ajax, Whitby, and Oshawa
         </div>

--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -659,7 +659,7 @@ export const HOMEPAGE_MARKUP = String.raw`
         <li class="community-card">
           <a href="/communities/georgina" class="community-card__link">
             <div class="community-card__img-wrap">
-              <img src="/Images/towns/georgina.jpg" alt="Lake Simcoe lifestyle in Georgina — NorthSide GTA real estate north of Toronto" width="480" height="300" loading="lazy" class="community-card__img">
+              <img src="/assets/town-logos/georgina.webp" alt="Georgina official municipal logo" width="720" height="300" loading="lazy" class="community-card__img community-card__logo community-card__logo--georgina">
             </div>
             <div class="community-card__body">
               <h3 class="community-card__name">Georgina</h3>
@@ -681,7 +681,7 @@ export const HOMEPAGE_MARKUP = String.raw`
         <li class="community-card">
           <a href="/communities/east-gwillimbury" class="community-card__link">
             <div class="community-card__img-wrap">
-              <img src="/Images/towns/east-gwillimbury.jpg" alt="East Gwillimbury homes and growing communities in the NorthSide GTA" width="480" height="300" loading="lazy" class="community-card__img">
+              <img src="/assets/town-logos/east-gwillimbury.webp" alt="East Gwillimbury official municipal logo" width="720" height="300" loading="lazy" class="community-card__img community-card__logo community-card__logo--east-gwillimbury">
             </div>
             <div class="community-card__body">
               <h3 class="community-card__name">East Gwillimbury</h3>
@@ -703,7 +703,7 @@ export const HOMEPAGE_MARKUP = String.raw`
         <li class="community-card">
           <a href="/communities/newmarket" class="community-card__link">
             <div class="community-card__img-wrap">
-              <img src="/Images/towns/newmarket.jpg" alt="Newmarket neighbourhoods and real estate north of Toronto" width="480" height="300" loading="lazy" class="community-card__img">
+              <img src="/assets/town-logos/newmarket.webp" alt="Newmarket official municipal logo" width="720" height="300" loading="lazy" class="community-card__img community-card__logo community-card__logo--newmarket">
             </div>
             <div class="community-card__body">
               <h3 class="community-card__name">Newmarket</h3>
@@ -725,7 +725,7 @@ export const HOMEPAGE_MARKUP = String.raw`
         <li class="community-card">
           <a href="/communities/aurora" class="community-card__link">
             <div class="community-card__img-wrap">
-              <img src="/Images/towns/aurora.jpg" alt="Aurora neighbourhoods and parks in the NorthSide GTA" width="480" height="300" loading="lazy" class="community-card__img">
+              <img src="/assets/town-logos/aurora.webp" alt="Aurora official municipal logo" width="720" height="300" loading="lazy" class="community-card__img community-card__logo community-card__logo--aurora">
             </div>
             <div class="community-card__body">
               <h3 class="community-card__name">Aurora</h3>
@@ -747,7 +747,7 @@ export const HOMEPAGE_MARKUP = String.raw`
         <li class="community-card">
           <a href="/communities/stouffville" class="community-card__link">
             <div class="community-card__img-wrap">
-              <img src="/Images/towns/stouffville.jpg" alt="Stouffville community and real estate north of Toronto" width="480" height="300" loading="lazy" class="community-card__img">
+              <img src="/assets/town-logos/stouffville.webp" alt="Whitchurch-Stouffville official municipal logo" width="720" height="300" loading="lazy" class="community-card__img community-card__logo community-card__logo--stouffville">
             </div>
             <div class="community-card__body">
               <h3 class="community-card__name">Whitchurch-Stouffville</h3>
@@ -769,7 +769,7 @@ export const HOMEPAGE_MARKUP = String.raw`
         <li class="community-card">
           <a href="/communities/uxbridge" class="community-card__link">
             <div class="community-card__img-wrap">
-              <img src="/Images/towns/uxbridge.jpg" alt="Uxbridge trails and green space in the NorthSide GTA" width="480" height="300" loading="lazy" class="community-card__img">
+              <img src="/assets/town-logos/uxbridge.webp" alt="Uxbridge official municipal logo" width="720" height="300" loading="lazy" class="community-card__img community-card__logo community-card__logo--uxbridge">
             </div>
             <div class="community-card__body">
               <h3 class="community-card__name">Uxbridge</h3>
@@ -791,7 +791,7 @@ export const HOMEPAGE_MARKUP = String.raw`
         <li class="community-card">
           <a href="/communities/scugog" class="community-card__link">
             <div class="community-card__img-wrap">
-              <img src="/Images/towns/scugog.jpg" alt="Scugog and Port Perry lakeside lifestyle in the NorthSide GTA" width="480" height="300" loading="lazy" class="community-card__img">
+              <img src="/assets/town-logos/scugog.webp" alt="Scugog official municipal logo" width="720" height="300" loading="lazy" class="community-card__img community-card__logo community-card__logo--scugog">
             </div>
             <div class="community-card__body">
               <h3 class="community-card__name">Scugog</h3>

--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -553,31 +553,31 @@ export const HOMEPAGE_MARKUP = String.raw`
           <p class="focus-community-rail__label">NorthSide GTA focus communities</p>
           <div class="focus-community-rail__track">
             <a class="focus-community-rail__tile" href="/communities/georgina" aria-label="Explore Georgina Real Estate">
-              <img src="/assets/town-logos/georgina.webp" alt="Georgina" width="720" height="300" loading="eager" decoding="async">
+              <img class="focus-community-rail__logo focus-community-rail__logo--georgina" src="/assets/town-logos/georgina.webp" alt="Georgina" width="720" height="300" loading="eager" decoding="async">
               <span>Georgina</span>
             </a>
             <a class="focus-community-rail__tile" href="/communities/east-gwillimbury" aria-label="Explore East Gwillimbury Real Estate">
-              <img src="/assets/town-logos/east-gwillimbury.webp" alt="East Gwillimbury" width="720" height="300" loading="eager" decoding="async">
+              <img class="focus-community-rail__logo focus-community-rail__logo--east-gwillimbury" src="/assets/town-logos/east-gwillimbury.webp" alt="East Gwillimbury" width="720" height="300" loading="eager" decoding="async">
               <span>East Gwillimbury</span>
             </a>
             <a class="focus-community-rail__tile" href="/communities/newmarket" aria-label="Explore Newmarket Real Estate">
-              <img src="/assets/town-logos/newmarket.webp" alt="Newmarket" width="720" height="300" loading="eager" decoding="async">
+              <img class="focus-community-rail__logo focus-community-rail__logo--newmarket" src="/assets/town-logos/newmarket.webp" alt="Newmarket" width="720" height="300" loading="eager" decoding="async">
               <span>Newmarket</span>
             </a>
             <a class="focus-community-rail__tile" href="/communities/aurora" aria-label="Explore Aurora Real Estate">
-              <img src="/assets/town-logos/aurora.webp" alt="Aurora" width="720" height="300" loading="eager" decoding="async">
+              <img class="focus-community-rail__logo focus-community-rail__logo--aurora" src="/assets/town-logos/aurora.webp" alt="Aurora" width="720" height="300" loading="eager" decoding="async">
               <span>Aurora</span>
             </a>
             <a class="focus-community-rail__tile" href="/communities/stouffville" aria-label="Explore Stouffville Real Estate">
-              <img src="/assets/town-logos/stouffville.webp" alt="Whitchurch-Stouffville" width="720" height="300" loading="eager" decoding="async">
+              <img class="focus-community-rail__logo focus-community-rail__logo--stouffville" src="/assets/town-logos/stouffville.webp" alt="Whitchurch-Stouffville" width="720" height="300" loading="eager" decoding="async">
               <span>Stouffville</span>
             </a>
             <a class="focus-community-rail__tile" href="/communities/uxbridge" aria-label="Explore Uxbridge Real Estate">
-              <img src="/assets/town-logos/uxbridge.webp" alt="Uxbridge" width="720" height="300" loading="eager" decoding="async">
+              <img class="focus-community-rail__logo focus-community-rail__logo--uxbridge" src="/assets/town-logos/uxbridge.webp" alt="Uxbridge" width="720" height="300" loading="eager" decoding="async">
               <span>Uxbridge</span>
             </a>
             <a class="focus-community-rail__tile" href="/communities/scugog" aria-label="Explore Scugog Real Estate">
-              <img src="/assets/town-logos/scugog.webp" alt="Scugog" width="720" height="300" loading="eager" decoding="async">
+              <img class="focus-community-rail__logo focus-community-rail__logo--scugog" src="/assets/town-logos/scugog.webp" alt="Scugog" width="720" height="300" loading="eager" decoding="async">
               <span>Scugog</span>
             </a>
           </div>


### PR DESCRIPTION
### Motivation
- Surface the seven NorthSide GTA focus communities with an understated, brand-aligned logo rail using the official town marks while keeping the approved map as the primary visual. 
- Use the supplied WebP assets to reduce load and avoid changing the interactive map SVG, SEO, or hero copy.

### Description
- Inserted a `nav.focus-community-rail` directly after the map frame and before the existing map caption in `src/homepageMarkup.js`, containing 7 linked tiles that use the WebP assets at `/assets/town-logos/*.webp` and include `width`/`height`, `alt`, and `aria-label` attributes. 
- Added restrained styling to `src/HomePage.css` for the rail (cream/taupe background, consistent card sizes, `object-fit: contain`, subtle hover/focus lift, and mobile horizontal scrolling). 
- Added `min-width: 0` to `.hero__copy` and `.hero__map-panel` to prevent mobile overflow and keep the hero layout intact. 
- Confirmations: official WebP assets are used; all logo links point to `/communities/[town]` routes; logos were not placed inside the map SVG; existing map links, nearby-served hover-only behavior, legend, helper text, and map interactions were preserved; the approved H1 and SEO/copy were not changed.

### Testing
- Ran `npm run build`, which completed successfully (build produced known warnings about stale Browserslist data and missing `rrule` source maps but the build succeeded). 
- Ran `npm run lint --if-present` which passed and `git diff --check` which reported no issues. 
- Automated visual/behavior checks (headless browser script) confirmed: the rail is above the fold on desktop, the rail sits within the hero panel on desktop, mobile layout has no horizontal page overflow, all 7 WebP logos load with non-zero natural dimensions and no town-logo 404s, each tile links to the correct `/communities/[town]` route, map town links remain unchanged, nearby-served areas remain hoverable but not clickable, and the single approved H1 remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22c2b81ef48324b8d5769ecb69a884)