### PR TITLE
Adjust homepage town logo display sizing

### DIFF
--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -528,24 +528,13 @@ main { padding-top: 100px; }
 .focus-community-rail__tile img,
 .focus-community-rail__logo {
   display: block;
-  width: 96%;
-  max-width: 116px;
-  height: 82px;
+  width: auto;
+  height: auto;
+  max-width: 90%;
+  max-height: 78%;
   margin: auto;
   object-fit: contain;
   object-position: center;
-}
-.focus-community-rail__logo--georgina,
-.focus-community-rail__logo--east-gwillimbury,
-.focus-community-rail__logo--scugog {
-  width: 98%;
-  max-width: 118px;
-}
-.focus-community-rail__logo--aurora,
-.focus-community-rail__logo--newmarket,
-.focus-community-rail__logo--stouffville,
-.focus-community-rail__logo--uxbridge {
-  width: 94%;
 }
 .focus-community-rail__tile span {
   max-width: 100%;
@@ -574,15 +563,10 @@ main { padding-top: 100px; }
   }
   .focus-community-rail__tile img,
   .focus-community-rail__logo {
-    width: 92%;
-    max-width: 98px;
-    height: 76px;
-  }
-  .focus-community-rail__logo--georgina,
-  .focus-community-rail__logo--east-gwillimbury,
-  .focus-community-rail__logo--scugog {
-    width: 94%;
-    max-width: 100px;
+    width: auto;
+    height: auto;
+    max-width: 90%;
+    max-height: 78%;
   }
 }
 @media (min-width: 1280px) {
@@ -691,23 +675,16 @@ main { padding-top: 100px; }
 }
 .community-card__img {
   display: block;
-  width: 100%;
-  height: 100%;
-  max-width: 78%;
-  max-height: 70%;
+  width: auto;
+  height: auto;
+  max-width: 82%;
+  max-height: 76%;
   margin: auto;
   object-fit: contain;
   object-position: center;
   transition: transform 0.3s ease, filter 0.3s ease;
 }
 .community-card:hover .community-card__img { transform: scale(1.02); filter: saturate(1.03); }
-.community-card__logo--georgina,
-.community-card__logo--east-gwillimbury,
-.community-card__logo--scugog { max-width: 82%; }
-.community-card__logo--aurora,
-.community-card__logo--newmarket,
-.community-card__logo--stouffville,
-.community-card__logo--uxbridge { max-width: 76%; }
 
 .community-card__body { display: flex; flex-direction: column; flex: 1; padding: 20px; }
 .community-card__name { font-family: var(--font-serif); font-size: 20px; font-weight: 500; color: var(--ns-emerald-900); }


### PR DESCRIPTION
### Motivation
- Make the visible coloured town logo artwork larger and more intentional in the homepage hero focus-community rail and the “Explore NorthSide GTA Communities” card media areas without modifying any image assets. 
- Achieve this solely with CSS/markup so logos remain uncropped, undistorted, centred, and preserve the existing responsive layout and interactions.

### Description
- Update `src/HomePage.css` to change the focus-community rail logo rules so logos use `width: auto`, `height: auto`, `object-fit: contain`, and increased `max-width`/`max-height` to allow the visible artwork to fill more of the tile. 
- Remove per-town width overrides and apply consistent contain-based sizing across the rail (including the small-screen breakpoint) so the rail layout and centering are preserved. 
- Update community card media rules in `src/HomePage.css` to use `width: auto`, `height: auto`, `object-fit: contain`, and larger `max-width`/`max-height` so logos fill roughly 70–80% of the image area while maintaining aspect ratio.

### Testing
- Ran `npm run build` which completed successfully (build completed with unrelated warnings about Browserslist and source maps). 
- Ran `npm run lint --if-present` which completed without errors. 
- Ran `git diff --check` and `git diff --name-only -- public/assets/town-logos` to confirm no image/binary changes and no issues in the diff. 
- Performed a headless visual/layout check (desktop and mobile) that confirmed town logos load, `object-fit: contain` is applied, logos are noticeably larger in the rail and cards, no logos are stretched or cropped, there are no broken images, and there is no horizontal overflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22e59630988324ba03b42cf51f08c3)