### PR TITLE
Add Communities landing page, styles, navigation link, and SEO metadata

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import AboutPage        from "./AboutPage";
 import BuyersPage       from "./BuyersPage";
 import SellersPage      from "./SellersPage";
 import CommunityPage    from "./CommunityPage";
+import CommunitiesPage  from "./CommunitiesPage";
 import ContactPage      from "./ContactPage";
 import VipPage          from "./vip";
 import SignWithUsPage   from "./SignWithUsPage";
@@ -105,6 +106,7 @@ function App() {
           <Route path="/buyers"       element={<BuyersPage />} />
           <Route path="/sellers"      element={<SellersPage />} />
           <Route path="/community"    element={<CommunityPage />} />
+          <Route path="/communities"  element={<CommunitiesPage />} />
           <Route path="/tastehub"     element={<TasteHubPage />} />
           <Route path="/tastehub/request-tabletop-sign" element={<TasteHubRequestTabletopSignPage />} />
           <Route path="/tastehub/:slug" element={<TasteHubPage />} />

--- a/src/CommunitiesPage.css
+++ b/src/CommunitiesPage.css
@@ -148,11 +148,20 @@
   background: #f4f1e8;
   box-shadow: 0 26px 70px rgba(35,71,10,0.12);
 }
-.communities-map-card__object {
+.communities-map-card__inline,
+.communities-map-card__fallback {
   display: block;
   width: 100%;
   aspect-ratio: 16 / 9;
-  border: 0;
+}
+.communities-map-card__inline svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.communities-map-card__fallback {
+  height: auto;
+  object-fit: contain;
 }
 .communities-map-card .map-legend { padding: 0 1rem 1rem; justify-content: center; }
 

--- a/src/CommunitiesPage.css
+++ b/src/CommunitiesPage.css
@@ -1,0 +1,296 @@
+.communities-page {
+  background: #fffaf1;
+  color: var(--ns-text);
+  overflow-x: clip;
+}
+
+.communities-hero {
+  background:
+    radial-gradient(circle at 80% 20%, rgba(201, 164, 101, 0.22), transparent 34rem),
+    linear-gradient(135deg, #102d08 0%, #173f08 48%, #0f2508 100%);
+  color: #fff;
+  padding: clamp(4rem, 8vw, 7rem) 0 4rem;
+}
+
+.communities-hero__grid,
+.communities-north__grid,
+.communities-lead__grid,
+.communities-agents__grid {
+  display: grid;
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: center;
+}
+
+@media (min-width: 900px) {
+  .communities-hero__grid,
+  .communities-lead__grid,
+  .communities-agents__grid { grid-template-columns: minmax(0, 1.04fr) minmax(320px, 0.76fr); }
+  .communities-north__grid { grid-template-columns: minmax(280px, 0.7fr) minmax(0, 1fr); }
+}
+
+.communities-hero .section-eyebrow,
+.communities-lead .section-eyebrow,
+.communities-final-cta .section-eyebrow { color: #d9bd82; }
+
+.communities-hero h1 {
+  margin-top: 0.85rem;
+  max-width: 760px;
+  font-family: var(--font-serif);
+  font-size: clamp(2.4rem, 6vw, 5.8rem);
+  font-weight: 500;
+  line-height: 0.95;
+  letter-spacing: -0.045em;
+  color: #fbf6e8;
+}
+
+.communities-hero__lead {
+  margin-top: 1.35rem;
+  max-width: 680px;
+  font-size: clamp(1.05rem, 2vw, 1.35rem);
+  line-height: 1.55;
+  color: rgba(255,255,255,0.88);
+}
+
+.communities-hero__body,
+.communities-lead p,
+.communities-agents p,
+.communities-final-cta p {
+  margin-top: 1rem;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: rgba(255,255,255,0.78);
+}
+
+.communities-hero__actions,
+.communities-agent-actions,
+.communities-final-cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.5rem;
+}
+
+.communities-hero__card,
+.communities-agents__photo {
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.18);
+  border-radius: 2rem;
+  background: rgba(255,255,255,0.08);
+  box-shadow: 0 28px 70px rgba(0,0,0,0.34);
+}
+
+.communities-hero__card img,
+.communities-agents__photo img {
+  width: 100%;
+  aspect-ratio: 1.4 / 1;
+  object-fit: cover;
+}
+
+.communities-hero__card > div { padding: 1.35rem; }
+.communities-hero__card-kicker { font-size: 0.72rem; letter-spacing: 0.22em; text-transform: uppercase; color: #d9bd82; font-weight: 700; }
+.communities-hero__card-title { margin-top: 0.4rem; font-family: var(--font-serif); font-size: 1.7rem; color: #fff8e8; }
+.communities-hero__card-copy { margin-top: 0.35rem; color: rgba(255,255,255,0.74); line-height: 1.55; }
+
+.communities-proof {
+  background: #fff;
+  border-bottom: 1px solid var(--ns-border);
+}
+
+.communities-proof__grid {
+  display: grid;
+  gap: 1px;
+  background: var(--ns-border);
+}
+@media (min-width: 760px) { .communities-proof__grid { grid-template-columns: repeat(4, 1fr); } }
+.communities-proof__grid span {
+  min-height: 74px;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: #fff;
+  color: var(--ns-green-dark);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.communities-north,
+.communities-map-section,
+.communities-compare,
+.communities-matrix,
+.communities-reviews,
+.communities-faq { padding: var(--section-py-lg) 0; }
+
+.communities-north { background: var(--ns-paper-warm); }
+.communities-north__cards { display: grid; gap: 1rem; }
+@media (min-width: 640px) { .communities-north__cards { grid-template-columns: repeat(3, 1fr); } }
+.communities-mini-card,
+.communities-town-card,
+.communities-review-grid blockquote {
+  border: 1px solid var(--ns-border);
+  border-radius: var(--radius-card);
+  background: #fff;
+  box-shadow: 0 18px 45px rgba(35,71,10,0.07);
+}
+.communities-mini-card { padding: 1.35rem; }
+.communities-mini-card h3,
+.communities-town-card h3 { font-family: var(--font-serif); font-size: 1.45rem; color: var(--ns-emerald-900); }
+.communities-mini-card p,
+.communities-town-card p { margin-top: 0.65rem; color: var(--ns-slate); line-height: 1.65; }
+
+.communities-map-section { background: #fffaf1; }
+.communities-map-card {
+  overflow: hidden;
+  border: 1px solid rgba(200,167,90,0.36);
+  border-radius: 2rem;
+  background: #f4f1e8;
+  box-shadow: 0 26px 70px rgba(35,71,10,0.12);
+}
+.communities-map-card__object {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 0;
+}
+.communities-map-card .map-legend { padding: 0 1rem 1rem; justify-content: center; }
+
+.communities-logo-rail {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin-top: 1.5rem;
+}
+@media (min-width: 700px) { .communities-logo-rail { grid-template-columns: repeat(7, minmax(0, 1fr)); } }
+.communities-logo-rail__tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 96px;
+  padding: 1rem;
+  border: 1px solid var(--ns-border);
+  border-radius: 1.25rem;
+  background: #fff;
+  text-decoration: none;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+.communities-logo-rail__tile:hover { transform: translateY(-2px); box-shadow: 0 14px 32px rgba(35,71,10,0.1); }
+.communities-logo-rail__tile img,
+.communities-town-card__logo-wrap img {
+  width: 100%;
+  height: 72px;
+  object-fit: contain;
+}
+
+.communities-compare { background: #fff; }
+.communities-town-grid {
+  display: grid;
+  gap: 1rem;
+}
+@media (min-width: 720px) { .communities-town-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (min-width: 1080px) { .communities-town-grid { grid-template-columns: repeat(3, 1fr); } }
+.communities-town-card { overflow: hidden; display: flex; flex-direction: column; }
+.communities-town-card__logo-wrap {
+  display: grid;
+  place-items: center;
+  min-height: 150px;
+  padding: 1.4rem;
+  background: linear-gradient(135deg, #f8f4ea, #fffdf8);
+  border-bottom: 1px solid var(--ns-border);
+}
+.communities-town-card__body { display: flex; flex: 1; flex-direction: column; padding: 1.35rem; }
+.communities-town-card .pill-list { margin-top: 1rem; }
+.communities-town-card__link {
+  margin-top: auto;
+  padding-top: 1.25rem;
+  color: var(--ns-green-dark);
+  font-weight: 700;
+  text-decoration: none;
+}
+.communities-town-card__link:hover { text-decoration: underline; }
+
+.communities-matrix { background: var(--ns-paper-warm); }
+.communities-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--ns-border);
+  border-radius: var(--radius-card);
+  background: #fff;
+  box-shadow: 0 18px 45px rgba(35,71,10,0.06);
+}
+.communities-table { width: 100%; min-width: 760px; border-collapse: collapse; }
+.communities-table th,
+.communities-table td { padding: 1rem; border-bottom: 1px solid #eee8dc; text-align: left; vertical-align: top; line-height: 1.55; }
+.communities-table thead th { background: #173f08; color: #fff8e8; font-size: 0.8rem; letter-spacing: 0.14em; text-transform: uppercase; }
+.communities-table tbody th { color: var(--ns-green-dark); font-weight: 800; }
+.communities-table a { color: inherit; text-decoration: none; }
+.communities-table a:hover { text-decoration: underline; }
+
+.communities-lead {
+  padding: var(--section-py-lg) 0;
+  background: linear-gradient(135deg, #173f08, #0f2508);
+  color: #fff;
+}
+.communities-check-list {
+  display: grid;
+  gap: 0.65rem;
+  margin: 1.35rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+.communities-check-list li {
+  position: relative;
+  padding-left: 1.65rem;
+  color: rgba(255,255,255,0.82);
+  line-height: 1.6;
+}
+.communities-check-list li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: #d9bd82;
+  font-weight: 800;
+}
+
+.communities-agents { padding: var(--section-py-lg) 0; background: #fff; }
+.communities-agents p { color: var(--ns-slate); }
+.communities-agents__photo { border-color: var(--ns-border); background: var(--ns-paper-warm); }
+
+.communities-reviews { background: var(--ns-paper-warm); }
+.communities-review-grid { display: grid; gap: 1rem; }
+@media (min-width: 760px) { .communities-review-grid { grid-template-columns: repeat(2, 1fr); } }
+.communities-review-grid blockquote { padding: 1.5rem; }
+.communities-review-grid div { color: #d98b2b; letter-spacing: 0.16em; }
+.communities-review-grid p { margin-top: 0.85rem; color: var(--ns-slate); line-height: 1.7; }
+.communities-review-grid cite { display: block; margin-top: 1rem; color: var(--ns-green-dark); font-weight: 700; font-style: normal; }
+
+.communities-faq { background: #fff; }
+
+.communities-final-cta {
+  padding: var(--section-py-lg) 0;
+  background:
+    radial-gradient(circle at 20% 10%, rgba(201,164,101,0.22), transparent 24rem),
+    linear-gradient(135deg, #0f2508, #173f08);
+  color: #fff;
+}
+.communities-final-cta__inner {
+  text-align: center;
+  max-width: 760px;
+}
+.communities-final-cta h2 {
+  margin-top: 0.75rem;
+  font-family: var(--font-serif);
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  font-weight: 500;
+  line-height: 1;
+  color: #fff8e8;
+}
+.communities-final-cta__actions { justify-content: center; }
+
+@media (max-width: 560px) {
+  .communities-hero__actions .btn,
+  .communities-agent-actions .btn,
+  .communities-final-cta__actions .btn { width: 100%; }
+  .communities-logo-rail__tile { min-height: 84px; }
+  .communities-map-card { border-radius: 1.25rem; }
+}

--- a/src/CommunitiesPage.js
+++ b/src/CommunitiesPage.js
@@ -145,6 +145,50 @@ const structuredData = {
   ],
 };
 
+
+function InlineNorthsideMap() {
+  const [svgMarkup, setSvgMarkup] = React.useState("");
+
+  React.useEffect(() => {
+    let isMounted = true;
+
+    fetch("/assets/homepage/northside-map.svg")
+      .then((response) => (response.ok ? response.text() : ""))
+      .then((markup) => {
+        if (!isMounted || !markup) return;
+        setSvgMarkup(markup.replaceAll('<a href="/communities/', '<a target="_top" href="/communities/'));
+      })
+      .catch(() => {
+        if (isMounted) setSvgMarkup("");
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  if (!svgMarkup) {
+    return (
+      <img
+        className="communities-map-card__fallback"
+        src="/assets/homepage/northside-map.svg"
+        alt="NorthSide GTA map showing Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog"
+        width="1600"
+        height="900"
+        loading="lazy"
+      />
+    );
+  }
+
+  return (
+    <div
+      className="communities-map-card__inline"
+      aria-label="Interactive NorthSide GTA map with focus communities and nearby guided areas"
+      dangerouslySetInnerHTML={{ __html: svgMarkup }}
+    />
+  );
+}
+
 function TownLogoRail() {
   return (
     <nav className="communities-logo-rail" aria-label="Official town logos for NorthSide GTA communities">
@@ -250,14 +294,7 @@ function CommunitiesPage() {
               <p className="section-sub">Focus communities link to their town pages. Nearby guided areas are shown as contextual service areas only.</p>
             </div>
             <div className="communities-map-card">
-              <object
-                className="communities-map-card__object"
-                data="/assets/homepage/northside-map.svg"
-                type="image/svg+xml"
-                aria-label="Interactive NorthSide GTA map with focus communities and nearby guided areas"
-              >
-                <img src="/assets/homepage/northside-map.svg" alt="NorthSide GTA map showing Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog" width="1600" height="900" loading="lazy" />
-              </object>
+              <InlineNorthsideMap />
               <div className="map-legend" aria-label="Map legend">
                 <span className="map-legend__item"><span className="map-legend__dot map-legend__dot--focus" aria-hidden="true"></span>NorthSide GTA focus area</span>
                 <span className="map-legend__item"><span className="map-legend__dot map-legend__dot--served" aria-hidden="true"></span>Guidance also available nearby</span>

--- a/src/CommunitiesPage.js
+++ b/src/CommunitiesPage.js
@@ -1,0 +1,426 @@
+import React from "react";
+import DynamicMetaTags from "./components/seo/DynamicMetaTags";
+import Navigation from "./Navigation";
+import Footer from "./Footer";
+import LeadForm from "./components/LeadForm";
+import "./HomePage.css";
+import "./CommunitiesPage.css";
+
+const PAGE_URL = "https://northsidegta.ca/communities";
+const PAGE_TITLE = "NorthSide GTA Communities | Compare Towns North of Toronto";
+const PAGE_DESCRIPTION =
+  "Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog with Matthew and Landon Mulhall of Finally Home Agents.";
+const OG_IMAGE = "https://northsidegta.ca/assets/homepage/northside-map.svg";
+const TEAM_IMAGE = "/assets/homepage/matthew-landon-northside-gta.jpg";
+const TEAM_IMAGE_ALT =
+  "Matthew Mulhall and Landon Mulhall of Finally Home Agents — NorthSide GTA real estate";
+
+const towns = [
+  {
+    name: "Georgina",
+    slug: "georgina",
+    logo: "/assets/town-logos/georgina.webp",
+    alt: "Georgina official municipal logo",
+    fit: "Lake Simcoe lifestyle, value, cottages, family neighbourhoods, and room to breathe.",
+    bestFor: "Buyers who want waterfront access, more space, and a community feel without leaving the GTA orbit.",
+    watch: "Commute patterns vary by village, so Keswick, Sutton, Jackson's Point, and Pefferlaw should be compared carefully.",
+    highlights: ["Lake Simcoe", "More space", "Value"],
+  },
+  {
+    name: "East Gwillimbury",
+    slug: "east-gwillimbury",
+    logo: "/assets/town-logos/east-gwillimbury.webp",
+    alt: "East Gwillimbury official municipal logo",
+    fit: "A growing north-of-Newmarket option with newer subdivisions, family demand, and GO/404 connectivity.",
+    bestFor: "Move-up buyers who want newer homes, schools, parks, and a quieter pace near York Region employment routes.",
+    watch: "New development pockets can feel very different from established Holland Landing, Sharon, and Mount Albert streets.",
+    highlights: ["Newer homes", "Family growth", "GO access"],
+  },
+  {
+    name: "Newmarket",
+    slug: "newmarket",
+    logo: "/assets/town-logos/newmarket.webp",
+    alt: "Newmarket official municipal logo",
+    fit: "The central NorthSide hub for walkability, healthcare, shopping, schools, trails, and commuter convenience.",
+    bestFor: "Buyers who want a strong town centre, established neighbourhoods, and convenient access to the 404 and GO Transit.",
+    watch: "Neighbourhood micro-markets matter; Bristol-London, Stonehaven, Armitage, and Old Newmarket can price differently.",
+    highlights: ["Central hub", "Trails", "GO + 404"],
+  },
+  {
+    name: "Aurora",
+    slug: "aurora",
+    logo: "/assets/town-logos/aurora.webp",
+    alt: "Aurora official municipal logo",
+    fit: "A premium York Region community with heritage streets, strong schools, ravines, golf, and executive homes.",
+    bestFor: "Buyers seeking a polished community feel, long-term resale confidence, and an upscale north GTA lifestyle.",
+    watch: "Entry price is often higher than neighbouring towns, so the lifestyle value needs to match the budget.",
+    highlights: ["Premium", "Schools", "Ravines"],
+  },
+  {
+    name: "Stouffville",
+    slug: "stouffville",
+    logo: "/assets/town-logos/stouffville.webp",
+    alt: "Whitchurch-Stouffville official municipal logo",
+    fit: "Main Street charm, family subdivisions, trails, and easy Markham/York Region access with a small-town edge.",
+    bestFor: "Buyers moving north from Markham, Scarborough, or Toronto who still want strong everyday convenience.",
+    watch: "Compare village, subdivision, and rural Whitchurch-Stouffville options because lifestyle and maintenance differ.",
+    highlights: ["Main Street", "Trails", "Markham access"],
+  },
+  {
+    name: "Uxbridge",
+    slug: "uxbridge",
+    logo: "/assets/town-logos/uxbridge.webp",
+    alt: "Uxbridge official municipal logo",
+    fit: "Trail capital energy, century homes, rural estates, golf, and a highly local community rhythm.",
+    bestFor: "Lifestyle-led buyers who value trails, space, character, and a quieter daily pace north of the city.",
+    watch: "Commute, snow routes, rural services, and property maintenance should be part of the buying plan.",
+    highlights: ["Trails", "Character", "Rural options"],
+  },
+  {
+    name: "Scugog",
+    slug: "scugog",
+    logo: "/assets/town-logos/scugog.webp",
+    alt: "Scugog official municipal logo",
+    fit: "Port Perry waterfront, Lake Scugog, heritage charm, rural properties, and a relaxed east-side NorthSide option.",
+    bestFor: "Buyers who want lake-town lifestyle, small-town charm, and more space while staying connected to Durham Region.",
+    watch: "Port Perry, waterfront, and rural pockets each carry different pricing, servicing, and lifestyle considerations.",
+    highlights: ["Port Perry", "Waterfront", "Heritage"],
+  },
+];
+
+const faqs = [
+  {
+    question: "Which NorthSide GTA community is best for moving north from Toronto?",
+    answer:
+      "There is no single best town. Newmarket and Aurora often appeal to buyers prioritizing established York Region convenience, East Gwillimbury and Georgina can offer more space, Stouffville balances small-town feel with Markham access, while Uxbridge and Scugog lean more lifestyle, trails, and lake-town living.",
+  },
+  {
+    question: "Can Matthew and Landon help us compare towns before we start showings?",
+    answer:
+      "Yes. Matthew and Landon Mulhall help buyers compare commute, schools, trails, lake access, neighbourhood feel, home style, and market conditions before narrowing the search to specific listings.",
+  },
+  {
+    question: "Are these communities still connected to the GTA?",
+    answer:
+      "Yes. The NorthSide GTA is positioned for buyers who want more space and community while staying connected through routes such as Highway 404, regional roads, GO Transit, and York or Durham employment corridors.",
+  },
+  {
+    question: "Do you only work with buyers?",
+    answer:
+      "No. Finally Home Agents supports both buyers and sellers across Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog with local pricing, preparation, marketing, negotiation, and relocation guidance.",
+  },
+  {
+    question: "What happens after I request my NorthSide Town Match?",
+    answer:
+      "You will be contacted by Finally Home Agents to review your budget, timing, lifestyle priorities, commute needs, and must-haves so the recommended towns feel useful rather than generic.",
+  },
+];
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": `${PAGE_URL}#webpage`,
+      url: PAGE_URL,
+      name: PAGE_TITLE,
+      description: PAGE_DESCRIPTION,
+      about: {
+        "@type": "RealEstateAgent",
+        name: "Finally Home Agents — NorthSide GTA",
+      },
+    },
+    {
+      "@type": "FAQPage",
+      "@id": `${PAGE_URL}#faq`,
+      mainEntity: faqs.map((faq) => ({
+        "@type": "Question",
+        name: faq.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: faq.answer,
+        },
+      })),
+    },
+  ],
+};
+
+function TownLogoRail() {
+  return (
+    <nav className="communities-logo-rail" aria-label="Official town logos for NorthSide GTA communities">
+      {towns.map((town) => (
+        <a key={town.slug} href={`/communities/${town.slug}`} className="communities-logo-rail__tile">
+          <img src={town.logo} alt={town.alt} width="720" height="300" loading="lazy" decoding="async" />
+        </a>
+      ))}
+    </nav>
+  );
+}
+
+function CommunitiesPage() {
+  return (
+    <>
+      <DynamicMetaTags
+        route="/communities"
+        documentTitle={PAGE_TITLE}
+        title={PAGE_TITLE}
+        description={PAGE_DESCRIPTION}
+        canonicalUrl={PAGE_URL}
+        ogType="website"
+        ogImage={OG_IMAGE}
+        ogImageAlt="NorthSide GTA community comparison map"
+        twitterCard="summary_large_image"
+        twitterImage={OG_IMAGE}
+        twitterImageAlt="NorthSide GTA community comparison map"
+        siteName="NorthSide GTA"
+        additionalMeta={[
+          { name: "robots", content: "index, follow" },
+          { property: "og:locale", content: "en_CA" },
+          { name: "geo.region", content: "CA-ON" },
+          { name: "geo.placename", content: "NorthSide GTA, Ontario, Canada" },
+        ]}
+      >
+        <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
+      </DynamicMetaTags>
+
+      <Navigation />
+      <main className="communities-page">
+        <section className="communities-hero" aria-labelledby="communities-hero-heading">
+          <div className="section-inner communities-hero__grid">
+            <div className="communities-hero__copy">
+              <p className="section-eyebrow">NorthSide GTA community guide</p>
+              <h1 id="communities-hero-heading">Find the NorthSide town that fits your next chapter.</h1>
+              <p className="communities-hero__lead">
+                Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog with clear local guidance from Matthew and Landon Mulhall of Finally Home Agents.
+              </p>
+              <p className="communities-hero__body">
+                If you are moving north from Toronto or the inner GTA, this guide helps you weigh more space, more community, trails, lakes, schools, commute, and market fit — without making the move feel disconnected from the GTA.
+              </p>
+              <div className="communities-hero__actions">
+                <a className="btn btn--green" href="#town-match">Get Your NorthSide Town Match</a>
+                <a className="btn btn--ghost-on-dark" href="#compare-communities">Compare the Communities</a>
+              </div>
+            </div>
+            <aside className="communities-hero__card" aria-label="Finally Home Agents local guidance">
+              <img src={TEAM_IMAGE} alt={TEAM_IMAGE_ALT} width="1484" height="1060" loading="eager" decoding="async" />
+              <div>
+                <p className="communities-hero__card-kicker">Finally Home Agents</p>
+                <p className="communities-hero__card-title">Matthew &amp; Landon Mulhall</p>
+                <p className="communities-hero__card-copy">Local buyer and seller guidance across the seven focus NorthSide GTA communities.</p>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section className="communities-proof" aria-label="NorthSide GTA proof points">
+          <div className="section-inner communities-proof__grid">
+            <span>Seven focus communities</span>
+            <span>Buyer comparison guidance</span>
+            <span>Seller market strategy</span>
+            <span>Toronto-connected lifestyle moves</span>
+          </div>
+        </section>
+
+        <section className="communities-north" aria-labelledby="moving-north-heading">
+          <div className="section-inner communities-north__grid">
+            <div>
+              <p className="section-eyebrow">Why buyers move north</p>
+              <h2 className="section-heading" id="moving-north-heading">More space, more community, and a better lifestyle fit — still connected to the GTA.</h2>
+            </div>
+            <div className="communities-north__cards">
+              {[
+                ["Space to grow", "Detached homes, bigger lots, trails, and lake-country options can change daily life without cutting ties to the city."],
+                ["Community rhythm", "Main streets, local schools, sports, golf, waterfronts, farmers markets, and neighbourhood pride make each town feel distinct."],
+                ["Guided trade-offs", "The right town depends on commute, budget, home style, schools, servicing, resale, and the lifestyle you want after the move."],
+              ].map(([title, copy]) => (
+                <article className="communities-mini-card" key={title}>
+                  <h3>{title}</h3>
+                  <p>{copy}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="communities-map-section" aria-labelledby="map-heading">
+          <div className="section-inner">
+            <div className="section-header section-header--center">
+              <p className="section-eyebrow">Explore the region</p>
+              <h2 className="section-heading" id="map-heading">Start with the map, then narrow by lifestyle.</h2>
+              <p className="section-sub">Focus communities link to their town pages. Nearby guided areas are shown as contextual service areas only.</p>
+            </div>
+            <div className="communities-map-card">
+              <object
+                className="communities-map-card__object"
+                data="/assets/homepage/northside-map.svg"
+                type="image/svg+xml"
+                aria-label="Interactive NorthSide GTA map with focus communities and nearby guided areas"
+              >
+                <img src="/assets/homepage/northside-map.svg" alt="NorthSide GTA map showing Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog" width="1600" height="900" loading="lazy" />
+              </object>
+              <div className="map-legend" aria-label="Map legend">
+                <span className="map-legend__item"><span className="map-legend__dot map-legend__dot--focus" aria-hidden="true"></span>NorthSide GTA focus area</span>
+                <span className="map-legend__item"><span className="map-legend__dot map-legend__dot--served" aria-hidden="true"></span>Guidance also available nearby</span>
+              </div>
+            </div>
+            <TownLogoRail />
+          </div>
+        </section>
+
+        <section className="communities-compare" id="compare-communities" aria-labelledby="compare-heading">
+          <div className="section-inner">
+            <div className="section-header section-header--center">
+              <p className="section-eyebrow">Town comparison cards</p>
+              <h2 className="section-heading" id="compare-heading">Compare the seven NorthSide GTA focus communities.</h2>
+            </div>
+            <div className="communities-town-grid">
+              {towns.map((town) => (
+                <article className="communities-town-card" key={town.slug}>
+                  <div className="communities-town-card__logo-wrap">
+                    <img src={town.logo} alt={town.alt} width="720" height="300" loading="lazy" decoding="async" />
+                  </div>
+                  <div className="communities-town-card__body">
+                    <h3>{town.name}</h3>
+                    <p>{town.fit}</p>
+                    <ul className="pill-list" aria-label={`${town.name} highlights`}>
+                      {town.highlights.map((item) => <li className="pill" key={item}>{item}</li>)}
+                    </ul>
+                    <a href={`/communities/${town.slug}`} className="communities-town-card__link">Explore {town.name} →</a>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="communities-matrix" aria-labelledby="matrix-heading">
+          <div className="section-inner">
+            <div className="section-header">
+              <p className="section-eyebrow">Decision matrix</p>
+              <h2 className="section-heading" id="matrix-heading">Use the town-by-town trade-offs before you chase listings.</h2>
+            </div>
+            <div className="communities-table-wrap">
+              <table className="communities-table">
+                <thead>
+                  <tr>
+                    <th>Community</th>
+                    <th>Often fits</th>
+                    <th>What to review with Matthew and Landon</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {towns.map((town) => (
+                    <tr key={town.slug}>
+                      <th scope="row"><a href={`/communities/${town.slug}`}>{town.name}</a></th>
+                      <td>{town.bestFor}</td>
+                      <td>{town.watch}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section className="communities-lead" id="town-match" aria-labelledby="town-match-heading">
+          <div className="section-inner communities-lead__grid">
+            <div>
+              <p className="section-eyebrow">Lead with fit, not guesswork</p>
+              <h2 className="section-heading" id="town-match-heading">Get Your NorthSide Town Match.</h2>
+              <p>
+                Tell us what matters most — budget, commute, schools, trails, lake access, home style, timing, and what you are leaving behind. Matthew and Landon will help you narrow the communities that actually fit.
+              </p>
+              <ul className="communities-check-list">
+                <li>Town shortlist based on lifestyle and market reality.</li>
+                <li>Guidance on commute, schools, trails, lakes, and neighbourhood feel.</li>
+                <li>Buyer or seller next steps from Finally Home Agents.</li>
+              </ul>
+            </div>
+            <LeadForm
+              slug="northside-town-match"
+              title="NorthSide GTA Town Match"
+              realmLink="https://northsidegta.ca/communities"
+              ctaText="Get Your NorthSide Town Match"
+              formHeader="Find your best-fit NorthSide GTA town"
+              formSubheader="A simple, valuable next step for buyers comparing communities north of Toronto."
+              trustLine="No generic drip campaign — just practical town guidance from Matthew and Landon."
+              helperText="We will use your details to follow up about your NorthSide GTA community fit request."
+            />
+          </div>
+        </section>
+
+        <section className="communities-agents" aria-labelledby="agents-heading">
+          <div className="section-inner section-inner--narrow communities-agents__grid">
+            <figure className="communities-agents__photo">
+              <img src={TEAM_IMAGE} alt={TEAM_IMAGE_ALT} width="1484" height="1060" loading="lazy" decoding="async" />
+            </figure>
+            <div>
+              <p className="section-eyebrow">The team behind NorthSide GTA</p>
+              <h2 className="section-heading" id="agents-heading">Finally Home Agents makes the move north feel clear.</h2>
+              <p>
+                Matthew and Landon connect the big-picture lifestyle decision to the details that matter in real estate: pricing, neighbourhoods, commute, schools, property type, preparation, negotiation, and long-term fit.
+              </p>
+              <div className="communities-agent-actions">
+                <a href="https://wa.me/16476684646" className="btn btn--whatsapp">Talk With Finally Home Agents</a>
+                <a href="tel:+16476684646" className="btn btn--outline-green">Matthew · 647-668-4646</a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="communities-reviews" aria-labelledby="reviews-heading">
+          <div className="section-inner">
+            <div className="section-header section-header--center">
+              <p className="section-eyebrow">Proof from clients</p>
+              <h2 className="section-heading" id="reviews-heading">Guidance that helps people move with confidence.</h2>
+            </div>
+            <div className="communities-review-grid">
+              <blockquote>
+                <div aria-label="5 stars">★★★★★</div>
+                <p>“Matt understood our priorities as a family and ensured that these priorities were held in high regard throughout the whole process.”</p>
+                <cite>Larissa Halko · Buyer &amp; Seller</cite>
+              </blockquote>
+              <blockquote>
+                <div aria-label="5 stars">★★★★★</div>
+                <p>“Thanks to Matt we sold our home for much more than the market rate — higher than any comparable in the neighbourhood.”</p>
+                <cite>Arron Breen · Buyer &amp; Seller</cite>
+              </blockquote>
+            </div>
+          </div>
+        </section>
+
+        <section className="communities-faq" aria-labelledby="faq-heading">
+          <div className="section-inner section-inner--faq">
+            <div className="section-header section-header--center">
+              <p className="section-eyebrow">Common questions</p>
+              <h2 className="section-heading" id="faq-heading">NorthSide GTA communities FAQ</h2>
+            </div>
+            <dl className="faq__list">
+              {faqs.map((faq) => (
+                <div className="faq__item" key={faq.question}>
+                  <dt className="faq__question">{faq.question}</dt>
+                  <dd className="faq__answer">{faq.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+
+        <section className="communities-final-cta" aria-labelledby="final-cta-heading">
+          <div className="section-inner communities-final-cta__inner">
+            <p className="section-eyebrow">Ready to compare towns?</p>
+            <h2 id="final-cta-heading">Make your move north with a clearer plan.</h2>
+            <p>Start with your NorthSide Town Match, then explore the community pages that fit your lifestyle, commute, and budget.</p>
+            <div className="communities-final-cta__actions">
+              <a className="btn btn--white-on-dark" href="#town-match">Get Your NorthSide Town Match</a>
+              <a className="btn btn--ghost-on-dark" href="/contact">Talk With Finally Home Agents</a>
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+export default CommunitiesPage;

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -32,6 +32,7 @@ export default function Navigation() {
   ];
 
   const communitiesItems = [
+    { to: "/communities", label: "Compare Communities" },
     { to: "/tastehub", label: "NorthSide TasteHub™", badge: "NEW" },
     { to: "/community", label: "NorthSide Events Guide" },
     { divider: true },

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -143,6 +143,30 @@ const STATIC_ROUTE_META_CONFIGS = [
     },
   },
   {
+    route: "/communities",
+    meta: {
+      route: "/communities",
+      documentTitle: "NorthSide GTA Communities | Compare Towns North of Toronto",
+      title: "NorthSide GTA Communities | Compare Towns North of Toronto",
+      description:
+        "Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog with Matthew and Landon Mulhall of Finally Home Agents.",
+      canonicalUrl: "https://northsidegta.ca/communities",
+      ogType: "website",
+      ogImage: "https://northsidegta.ca/assets/homepage/northside-map.svg",
+      ogImageAlt: "NorthSide GTA community comparison map",
+      twitterCard: "summary_large_image",
+      twitterImage: "https://northsidegta.ca/assets/homepage/northside-map.svg",
+      twitterImageAlt: "NorthSide GTA community comparison map",
+      siteName: "NorthSide GTA",
+      additionalMeta: [
+        { name: "robots", content: "index, follow" },
+        { property: "og:locale", content: "en_CA" },
+        { name: "geo.region", content: "CA-ON" },
+        { name: "geo.placename", content: "NorthSide GTA, Ontario, Canada" },
+      ],
+    },
+  },
+  {
     route: "/community",
     meta: {
       route: "/community",


### PR DESCRIPTION
### Motivation
- Introduce a dedicated NorthSide GTA Communities landing page to help buyers compare nearby towns and capture leads. 
- Surface community comparison content in the primary site navigation and route hierarchy. 
- Provide SEO/structured data for the new page so search engines can index and surface community guidance and FAQs. 

### Description
- Added a new React page component at `src/CommunitiesPage.js` that renders map, town cards, comparison matrix, FAQs, lead form, and structured data. 
- Added styles for the page in `src/CommunitiesPage.css` and imported it into the component. 
- Registered the page route and import in `src/App.js` by adding `import CommunitiesPage from "./CommunitiesPage"` and a `Route` for `/communities`. 
- Added a top-level navigation entry in `src/Navigation.js` for `"/communities"` and updated the communities menu items. 
- Added static SEO metadata and Open Graph/twitter config for the route in `src/components/seo/staticRouteMetaConfigs.mjs`. 

### Testing
- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a231d2996a883248c9c5f83fbbf9866)