### PR TITLE
Buyers page: canonicalize social image URLs to non‑www, add author/publisher, and strengthen JSON‑LD

### DIFF
--- a/public/data/seo/buyers.json
+++ b/public/data/seo/buyers.json
@@ -2,5 +2,5 @@
   "route": "/buyers",
   "seo_title": "Buying a Home North of Toronto | Buyers Guide | Finally Home Agents | NorthSide GTA",
   "seo_description": "Buying a home north of Toronto? Finally Home Agents guides buyers across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog. Local expertise, town-by-town guidance, and a free strategy call.",
-  "seo_image": "/uploads/buyers-page-seo.jpg"
+  "seo_image": "https://northsidegta.ca/uploads/buyers-page-seo.jpg"
 }

--- a/scripts/generate-static-route-html.js
+++ b/scripts/generate-static-route-html.js
@@ -88,6 +88,11 @@ function buildHeadFragments(baseHtml, doctype, baseTags, routeMeta) {
   const fragments = combinedTags.map(stringifyTag).filter(Boolean);
   fragments.forEach((fragment) => appendHeadTag(head, fragment));
 
+  const schemaFragment = stringifyJsonLdScript(routeMeta.schema);
+  if (schemaFragment) {
+    appendHeadTag(head, schemaFragment);
+  }
+
   return finalizeHtml(doc, doctype);
 }
 
@@ -156,6 +161,13 @@ function stringifyTag(tag) {
     return attrText ? `<link ${attrText} />` : "";
   }
   return "";
+}
+
+function stringifyJsonLdScript(schema) {
+  if (!schema) return "";
+  const json = typeof schema === "string" ? schema : JSON.stringify(schema);
+  if (!json) return "";
+  return `<script type="application/ld+json">${json.replace(/</g, "\\u003c")}</script>`;
 }
 
 function escapeHtml(value) {

--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import Footer from "./Footer";
 import { getFormEndpoint } from "./components/contact/contactConfig";
+import { BUYERS_SCHEMA } from "./components/seo/buyersSchema.mjs";
 
 const COMMUNITIES = [
   "Aurora",
@@ -185,76 +186,6 @@ const REVIEWS = [
   ["Larissa Halko", "Buyer & Seller", "What really stood out was that Matt understood our priorities as a family and ensured these were held in high regard throughout the whole process."],
   ["Susan Booth", "Seller · Holland Landing", "Their professionalism and personal attention set them apart. Throughout the entire process these Finally Home Agents exceeded our expectations."],
 ];
-
-const SCHEMA = {
-  "@context": "https://schema.org",
-  "@graph": [
-    {
-      "@type": "WebPage",
-      "@id": "https://northsidegta.ca/buyers",
-      url: "https://northsidegta.ca/buyers",
-      name: "Buying a Home North of Toronto | Finally Home Agents | NorthSide GTA",
-      description:
-        "Buying a home north of Toronto? Finally Home Agents guides buyers across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog.",
-      inLanguage: "en-CA",
-      isPartOf: { "@id": "https://northsidegta.ca/#website" },
-      breadcrumb: {
-        "@type": "BreadcrumbList",
-        itemListElement: [
-          { "@type": "ListItem", position: 1, name: "NorthSide GTA", item: "https://northsidegta.ca" },
-          { "@type": "ListItem", position: 2, name: "Buyers", item: "https://northsidegta.ca/buyers" },
-        ],
-      },
-    },
-    {
-      "@type": "RealEstateAgent",
-      name: "Finally Home Agents",
-      url: "https://northsidegta.ca",
-      telephone: "+16476684646",
-      areaServed: [
-        "Aurora, Ontario",
-        "Newmarket, Ontario",
-        "Whitchurch-Stouffville, Ontario",
-        "Uxbridge, Ontario",
-        "Georgina, Ontario",
-        "East Gwillimbury, Ontario",
-        "Scugog, Ontario",
-      ],
-      description:
-        "Finally Home Agents — Matthew and Landon Mulhall — provide buyer representation across the NorthSide GTA, operating under HomeLife Optimum Realty, Brokerage.",
-      aggregateRating: { "@type": "AggregateRating", ratingValue: "5.0", reviewCount: "12", bestRating: "5" },
-    },
-    {
-      "@type": "FAQPage",
-      mainEntity: [
-        {
-          "@type": "Question",
-          name: "Which communities do Finally Home Agents serve for buyers?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Finally Home Agents serves buyers across Aurora, Newmarket, Whitchurch-Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog — with guidance also available in King, Bradford, Vaughan, Richmond Hill, Markham, Pickering, Ajax, Whitby, and Oshawa.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "What does the buyer process look like with Finally Home Agents?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Finally Home Agents starts with a town strategy call to match buyers to the right community, then builds curated showing days, provides offer strategy and negotiation support, and stays involved through to closing and beyond.",
-          },
-        },
-        {
-          "@type": "Question",
-          name: "Is there a tool to help me decide which NorthSide GTA town to buy in?",
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: "Yes. The Town Match quiz on this page asks three questions about your lifestyle, pace of life, and commute needs, then recommends a primary community plus two alternatives.",
-          },
-        },
-      ],
-    },
-  ],
-};
 
 function scrollToSection(id) {
   document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -552,16 +483,14 @@ export default function BuyersPage() {
           name="description"
           content="Buying a home north of Toronto? Finally Home Agents guides buyers across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog. Local expertise, town-by-town guidance, and a free strategy call."
         />
-        <meta
-          name="keywords"
-          content="buy a home north of Toronto, NorthSide GTA buyers agent, Aurora homes for sale, Newmarket homes for sale, Stouffville real estate, Uxbridge homes, Georgina real estate, East Gwillimbury homes, Scugog real estate, town match quiz, Finally Home Agents buyers"
-        />
+        <meta name="author" content="Finally Home Agents" />
+        <meta name="publisher" content="Finally Home Agents" />
         <link rel="canonical" href="https://northsidegta.ca/buyers" />
         <meta property="og:title" content="Buying a Home North of Toronto | Finally Home Agents | NorthSide GTA" />
         <meta property="og:description" content="Find the right community north of Toronto. Town-by-town buyer guidance from Finally Home Agents across the NorthSide GTA." />
         <meta property="og:url" content="https://northsidegta.ca/buyers" />
         <meta property="og:type" content="website" />
-        <meta property="og:image" content="https://www.northsidegta.ca/uploads/buyers-page-seo.jpg" />
+        <meta property="og:image" content="https://northsidegta.ca/uploads/buyers-page-seo.jpg" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <meta property="og:locale" content="en_CA" />
@@ -569,9 +498,9 @@ export default function BuyersPage() {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content="Buying a Home North of Toronto | Finally Home Agents | NorthSide GTA" />
         <meta name="twitter:description" content="Find the right community north of Toronto. Town-by-town buyer guidance from Finally Home Agents across the NorthSide GTA." />
-        <meta name="twitter:image" content="https://www.northsidegta.ca/uploads/buyers-page-seo.jpg" />
+        <meta name="twitter:image" content="https://northsidegta.ca/uploads/buyers-page-seo.jpg" />
         <meta name="twitter:site" content="@northsidegta" />
-        <script type="application/ld+json">{JSON.stringify(SCHEMA)}</script>
+        <script type="application/ld+json">{JSON.stringify(BUYERS_SCHEMA)}</script>
       </Helmet>
 
       <style>{BUYERS_STYLES}</style>

--- a/src/components/seo/__generatedSiteSeo.json
+++ b/src/components/seo/__generatedSiteSeo.json
@@ -12,7 +12,7 @@
   "/buyers": {
     "seo_title": "Buying a Home North of Toronto | Buyers Guide | Finally Home Agents | NorthSide GTA",
     "seo_description": "Buying a home north of Toronto? Finally Home Agents guides buyers across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog. Local expertise, town-by-town guidance, and a free strategy call.",
-    "seo_image": "/uploads/buyers-page-seo.jpg"
+    "seo_image": "https://northsidegta.ca/uploads/buyers-page-seo.jpg"
   },
   "/choose-your-path": {
     "seo_title": "Find the Right Buyer Agent | Finally Home Agents – NorthSide GTA",

--- a/src/components/seo/buyersSchema.mjs
+++ b/src/components/seo/buyersSchema.mjs
@@ -1,0 +1,85 @@
+const BUYERS_SEO_IMAGE = "https://northsidegta.ca/uploads/buyers-page-seo.jpg";
+const SITE_URL = "https://northsidegta.ca";
+const BUYERS_URL = `${SITE_URL}/buyers`;
+
+const PRIMARY_SERVICE_AREAS = [
+  "Aurora, Ontario",
+  "Newmarket, Ontario",
+  "Stouffville, Ontario",
+  "Uxbridge, Ontario",
+  "Georgina, Ontario",
+  "East Gwillimbury, Ontario",
+  "Scugog, Ontario",
+];
+
+const areaServed = PRIMARY_SERVICE_AREAS.map((name) => ({
+  "@type": "Place",
+  name,
+}));
+
+export const BUYERS_SCHEMA = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "RealEstateAgent",
+      "@id": `${SITE_URL}/#realestateagent`,
+      name: "Finally Home Agents",
+      url: SITE_URL,
+      image: BUYERS_SEO_IMAGE,
+      telephone: "+16476684646",
+      brand: {
+        "@type": "Brand",
+        "@id": `${SITE_URL}/#brand`,
+        name: "NorthSide GTA",
+        url: SITE_URL,
+      },
+      parentOrganization: {
+        "@type": "Organization",
+        name: "HomeLife Optimum Realty, Brokerage",
+      },
+      employee: [
+        { "@type": "Person", name: "Matthew Mulhall" },
+        { "@type": "Person", name: "Landon Mulhall" },
+      ],
+      areaServed,
+      description:
+        "Finally Home Agents — Matthew and Landon Mulhall — provide buyer representation across the NorthSide GTA, operating under HomeLife Optimum Realty, Brokerage.",
+    },
+    {
+      "@type": "WebPage",
+      "@id": `${BUYERS_URL}#webpage`,
+      url: BUYERS_URL,
+      name: "Buying a Home North of Toronto | Finally Home Agents | NorthSide GTA",
+      description:
+        "Buying a home north of Toronto? Finally Home Agents guides buyers across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog.",
+      inLanguage: "en-CA",
+      image: BUYERS_SEO_IMAGE,
+      about: { "@id": `${SITE_URL}/#realestateagent` },
+      provider: { "@id": `${SITE_URL}/#realestateagent` },
+      mainEntity: { "@id": `${BUYERS_URL}#service` },
+      breadcrumb: { "@id": `${BUYERS_URL}#breadcrumb` },
+    },
+    {
+      "@type": "Service",
+      "@id": `${BUYERS_URL}#service`,
+      name: "Home buyer representation north of Toronto",
+      serviceType: "Buyer representation",
+      url: BUYERS_URL,
+      provider: { "@id": `${SITE_URL}/#realestateagent` },
+      brand: { "@id": `${SITE_URL}/#brand` },
+      areaServed,
+      description:
+        "Buyer representation and town-by-town home search guidance across the NorthSide GTA communities north of Toronto.",
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": `${BUYERS_URL}#breadcrumb`,
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "NorthSide GTA", item: SITE_URL },
+        { "@type": "ListItem", position: 2, name: "Buyers", item: BUYERS_URL },
+      ],
+    },
+  ],
+};
+
+export default BUYERS_SCHEMA;

--- a/src/components/seo/metaTagUtils.js
+++ b/src/components/seo/metaTagUtils.js
@@ -154,10 +154,7 @@ function normalizeImageCandidate(candidate) {
 
   if (isAbsoluteUrl(value)) {
     try {
-      const url = new URL(value);
-      const combined = `${url.pathname}${url.search}${url.hash}`.replace(/[#?]$/, "");
-      const path = combined || url.pathname || "";
-      return ensureLeadingSlash(path);
+      return new URL(value).toString();
     } catch (error) {
       return "";
     }

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -1,3 +1,5 @@
+import { BUYERS_SCHEMA } from "./buyersSchema.mjs";
+
 const DEFAULT_GLOBAL_META_CONFIG = {
   route: "/",
   documentTitle: "NorthSide GTA Real Estate | Buy & Sell North of Toronto | Finally Home Agents",
@@ -72,18 +74,16 @@ const STATIC_ROUTE_META_CONFIGS = [
         "Buying a home north of Toronto? Finally Home Agents guides buyers across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog. Local expertise, town-by-town guidance, and a free strategy call.",
       canonicalUrl: "https://northsidegta.ca/buyers",
       ogType: "website",
-      ogImage: "https://www.northsidegta.ca/uploads/buyers-page-seo.jpg",
+      ogImage: "https://northsidegta.ca/uploads/buyers-page-seo.jpg",
       twitterCard: "summary_large_image",
-      twitterImage: "https://www.northsidegta.ca/uploads/buyers-page-seo.jpg",
+      twitterImage: "https://northsidegta.ca/uploads/buyers-page-seo.jpg",
       siteName: "NorthSide GTA",
       additionalMeta: [
         { name: "robots", content: "index,follow" },
-        {
-          name: "keywords",
-          content:
-            "buy a home north of Toronto, NorthSide GTA buyers agent, Aurora homes for sale, Newmarket homes for sale, Stouffville real estate, Uxbridge homes, Georgina real estate, East Gwillimbury homes, Scugog real estate, town match quiz, Finally Home Agents buyers",
-        },
+        { name: "author", content: "Finally Home Agents" },
+        { name: "publisher", content: "Finally Home Agents" },
       ],
+      schema: BUYERS_SCHEMA,
     },
   },
   {


### PR DESCRIPTION
### Motivation
- Normalize all /buyers SEO links to the canonical non‑www origin (https://northsidegta.ca) to remove mixed‑domain inconsistencies for sharing and indexing.
- Add basic author/publisher metadata and remove legacy meta keywords to align with modern SEO best practices.
- Ensure the /buyers page exposes robust, syntactically valid JSON‑LD that covers RealEstateAgent, WebPage, Service, and BreadcrumbList entities without inventing reviews or aggregate ratings.

### Description
- Updated in‑page Helmet metadata on the Buyers page to use non‑www social image URLs for `og:image` and `twitter:image`, preserved the canonical `https://northsidegta.ca/buyers`, removed the `<meta name="keywords">` tag, and added `<meta name="author">` and `<meta name="publisher">` (file: `src/BuyersPage.js`).
- Created a dedicated buyers JSON‑LD module (`src/components/seo/buyersSchema.mjs`) and replaced the inline schema with an `@graph` containing `RealEstateAgent`, `WebPage`, `Service`, and `BreadcrumbList`, using canonical non‑www URLs and the requested primary service areas (Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, Scugog).
- Updated static SEO configuration and generated site SEO bundle to reference the canonical non‑www buyers image URL (files: `src/components/seo/staticRouteMetaConfigs.mjs`, `public/data/seo/buyers.json`, `src/components/seo/__generatedSiteSeo.json`).
- Ensured static route HTML generation emits JSON‑LD from route metadata by adding JSON‑LD injection and preserving explicit absolute image URLs (files: `scripts/generate-static-route-html.js`, `src/components/seo/metaTagUtils.js`).
- Small utility change to preserve explicit absolute image URLs when normalizing image candidates so absolute non‑www URLs remain intact (file: `src/components/seo/metaTagUtils.js`).
- No visible copy, layout, CTA text, headings, or Google review content were changed; this is a technical SEO‑only change.

### Testing
- Ran the full unit/test suite with `npm test` and all tests passed (65/65).
- Built a production bundle with `npm run build` which completed successfully (build warnings unrelated to these changes were observed from a dependency and do not affect output).
- Performed automated post‑build validations against `build/buyers/index.html` which all passed: canonical is `https://northsidegta.ca/buyers`, `og:url` is non‑www, `og:image` and `twitter:image` use `https://northsidegta.ca/uploads/buyers-page-seo.jpg`, `author` and `publisher` meta tags present, `<meta name="keywords">` removed, page title and meta description unchanged, and `application/ld+json` is present and parses correctly.
- Verified JSON‑LD contains `RealEstateAgent`, `WebPage`, `Service`, and `BreadcrumbList` and does not include `aggregateRating` or review schema.
- Ran repository checks and grep searches to confirm no remaining `www` buyers SEO image references or keywords meta remnants.

Files changed (high level): `src/BuyersPage.js`, `src/components/seo/buyersSchema.mjs`, `src/components/seo/staticRouteMetaConfigs.mjs`, `src/components/seo/metaTagUtils.js`, `src/components/seo/__generatedSiteSeo.json`, `public/data/seo/buyers.json`, `scripts/generate-static-route-html.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9ee4dfe0832497a98928843fdfda)