### PR TITLE
Add Buyer FAQ section and FAQPage JSON-LD to /buyers

### DIFF
--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import Footer from "./Footer";
 import { getFormEndpoint } from "./components/contact/contactConfig";
-import { BUYERS_SCHEMA } from "./components/seo/buyersSchema.mjs";
+import { BUYER_FAQS, BUYERS_SCHEMA } from "./components/seo/buyersSchema.mjs";
 
 const COMMUNITIES = [
   "Aurora",
@@ -187,6 +187,37 @@ const REVIEWS = [
   ["Susan Booth", "Seller · Holland Landing", "Their professionalism and personal attention set them apart. Throughout the entire process these Finally Home Agents exceeded our expectations."],
 ];
 
+const FAQ_TOWN_LINKS = {
+  Aurora: "/communities/aurora",
+  Newmarket: "/communities/newmarket",
+  Stouffville: "/communities/stouffville",
+  Uxbridge: "/communities/uxbridge",
+  Georgina: "/communities/georgina",
+  "East Gwillimbury": "/communities/east-gwillimbury",
+  Scugog: "/communities/scugog",
+};
+
+const LINKED_TOWNS_PATTERN = new RegExp(
+  `\\b(${Object.keys(FAQ_TOWN_LINKS).sort((a, b) => b.length - a.length).join("|")})\\b`,
+  "g"
+);
+
+function renderFaqAnswer(answer, linkedTowns) {
+  return answer.split(LINKED_TOWNS_PATTERN).map((part, index) => {
+    const href = FAQ_TOWN_LINKS[part];
+    if (!href || linkedTowns.has(part)) {
+      return part;
+    }
+
+    linkedTowns.add(part);
+    return (
+      <a href={href} key={`${part}-${index}`}>
+        {part}
+      </a>
+    );
+  });
+}
+
 function scrollToSection(id) {
   document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
 }
@@ -199,6 +230,30 @@ function SectionHeader({ eyebrow, title, lead, dark = false, compact = false, ch
       {lead && <p className={`buyers-lead${dark ? " buyers-lead-dark" : ""}`}>{lead}</p>}
       {children}
     </div>
+  );
+}
+
+function BuyersFaqSection() {
+  const linkedTowns = new Set();
+
+  return (
+    <section className="buyers-section tinted-section buyers-faq-section">
+      <div className="buyers-container">
+        <SectionHeader
+          eyebrow="06 / Buyer FAQ"
+          title="Buyer Questions We Hear Most Often"
+          lead="Buying north of Toronto is not just about finding a house. It is about choosing the right town, commute, lifestyle, and long-term fit before you make a move."
+        />
+        <div className="buyers-faq-list">
+          {BUYER_FAQS.map(({ question, answer }, index) => (
+            <details className="buyers-faq-item" key={question} open={index === 0}>
+              <summary>{question}</summary>
+              <p>{renderFaqAnswer(answer, linkedTowns)}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -627,10 +682,12 @@ export default function BuyersPage() {
         </div>
       </section>
 
+      <BuyersFaqSection />
+
       <section className="buyers-section dark-section" id="cta-section">
         <div className="buyers-container cta-grid">
           <SectionHeader
-            eyebrow="06 / Start the Conversation"
+            eyebrow="07 / Start the Conversation"
             title="Want a town shortlist built around your actual move?"
             lead="Tell us where you’re coming from, what matters most, and when you’re thinking of moving. We’ll help you narrow the right NorthSide GTA towns before you waste time on the wrong homes."
             dark
@@ -766,6 +823,18 @@ const BUYERS_STYLES = `
   .review-card h3 { margin: 0; color: var(--primary); font-size: 13px; font-weight: 700; }
   .review-card p { margin: 4px 0 0; color: var(--muted); font-size: 12px; }
 
+  .buyers-faq-section { border-top: 1px solid var(--border); }
+  .buyers-faq-list { display: grid; gap: 10px; max-width: 920px; }
+  .buyers-faq-item { border: 1px solid var(--border); border-radius: 6px; background: #fff; box-shadow: 0 16px 45px rgba(26,26,26,0.045); overflow: hidden; }
+  .buyers-faq-item summary { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 18px 20px; color: var(--primary); font-family: "Playfair Display", Georgia, serif; font-size: 19px; line-height: 1.22; font-weight: 600; cursor: pointer; list-style: none; }
+  .buyers-faq-item summary::-webkit-details-marker { display: none; }
+  .buyers-faq-item summary::after { content: "+"; flex: 0 0 auto; width: 28px; height: 28px; border: 1px solid #d8d2c6; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; color: var(--accent); font-family: Inter, system-ui, sans-serif; font-size: 18px; line-height: 1; transition: transform 160ms ease, background 160ms ease, color 160ms ease; }
+  .buyers-faq-item[open] summary { border-bottom: 1px solid #eee8df; }
+  .buyers-faq-item[open] summary::after { content: "−"; background: var(--primary); border-color: var(--primary); color: #fff; }
+  .buyers-faq-item p { margin: 0; padding: 16px 20px 20px; color: var(--muted); font-size: 14px; line-height: 1.78; }
+  .buyers-faq-item a { color: var(--primary); font-weight: 700; text-decoration: none; border-bottom: 1px solid rgba(35,71,10,0.25); }
+  .buyers-faq-item a:hover { border-bottom-color: var(--primary); }
+
   .cta-grid { display: grid; grid-template-columns: minmax(0, 0.92fr) minmax(340px, 540px); gap: 36px; align-items: start; }
   .consultation-wrap { max-width: 540px; }
   .team-photo-block { margin-bottom: 16px; }
@@ -815,6 +884,8 @@ const BUYERS_STYLES = `
     .buyers-section-header h2 { font-size: 29px; }
     .trust-strip, .photo-grid, .market-grid, .process-grid, .reviews-grid, .also-grid, .form-two-col { grid-template-columns: 1fr; }
     .quiz-card, .consultation-card { padding: 22px; }
+    .buyers-faq-item summary { align-items: flex-start; padding: 16px; font-size: 17px; }
+    .buyers-faq-item p { padding: 14px 16px 17px; font-size: 13.5px; }
     .photo-card { min-height: 154px; }
     .market-followup { align-items: flex-start; flex-direction: column; }
     .team-photo-block img { height: 150px; object-position: center 30%; }

--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -202,6 +202,15 @@ const LINKED_TOWNS_PATTERN = new RegExp(
   "g"
 );
 
+function applyInitialFaqOpen(node, index) {
+  if (!node || index !== 0 || node.dataset.initialOpenApplied === "true") {
+    return;
+  }
+
+  node.open = true;
+  node.dataset.initialOpenApplied = "true";
+}
+
 function renderFaqAnswer(answer, linkedTowns) {
   return answer.split(LINKED_TOWNS_PATTERN).map((part, index) => {
     const href = FAQ_TOWN_LINKS[part];
@@ -246,7 +255,12 @@ function BuyersFaqSection() {
         />
         <div className="buyers-faq-list">
           {BUYER_FAQS.map(({ question, answer }, index) => (
-            <details className="buyers-faq-item" key={question} open={index === 0}>
+            <details
+              className="buyers-faq-item"
+              key={question}
+              defaultOpen={index === 0}
+              ref={(node) => applyInitialFaqOpen(node, index)}
+            >
               <summary>{question}</summary>
               <p>{renderFaqAnswer(answer, linkedTowns)}</p>
             </details>

--- a/src/components/seo/buyersSchema.mjs
+++ b/src/components/seo/buyersSchema.mjs
@@ -17,6 +17,75 @@ const areaServed = PRIMARY_SERVICE_AREAS.map((name) => ({
   name,
 }));
 
+export const BUYER_FAQS = [
+  {
+    question: "What are the best towns to buy in north of Toronto?",
+    answer:
+      "The best town depends on your budget, commute, lifestyle, and the type of home you want. Aurora and Newmarket are strong fits for buyers who want established amenities, schools, and GO Transit access. Stouffville and East Gwillimbury work well for buyers who want family neighbourhoods with York Region convenience. Uxbridge, Georgina, and Scugog are often better fits for buyers who want more space, trails, lakes, golf, and a quieter pace while still staying connected to the GTA.",
+  },
+  {
+    question: "Is moving north of Toronto a good option for Toronto buyers?",
+    answer:
+      "For many buyers, yes. Moving north of Toronto can offer more space, quieter streets, larger lots, stronger community feel, and better lifestyle value than many similarly priced options in the city. The tradeoff is that commute, transit access, schools, local amenities, and town fit matter much more. That is why choosing the right community first is often more important than chasing individual listings.",
+  },
+  {
+    question: "Which NorthSide GTA towns are best for commuting to Toronto?",
+    answer:
+      "Aurora, Newmarket, East Gwillimbury, and Stouffville are often strong options for commuters because of GO Transit access and major road connections. The best choice depends on where you work, how often you commute, and whether you prefer train access, Highway 404 access, or a quieter setting with more space.",
+  },
+  {
+    question: "Should I choose the town first or the house first?",
+    answer:
+      "Most buyers should narrow the town first. A great house in the wrong community can still become the wrong move. We help buyers compare towns based on budget, commute, schools, lifestyle, lot size, amenities, resale considerations, and long-term fit before building a focused home search.",
+  },
+  {
+    question: "How much house can I get north of Toronto compared with the city?",
+    answer:
+      "In many cases, buyers moving north can access more detached homes, larger properties, quieter streets, or newer family neighbourhoods compared with similar budgets in Toronto. The exact difference depends on the town, property type, condition, lot size, and proximity to transit or amenities. We help buyers compare those tradeoffs town by town so the search stays realistic.",
+  },
+  {
+    question: "Do I need a local buyer agent if I already found homes online?",
+    answer:
+      "Yes. Online listings show the property, but they do not always show the full picture. A local buyer agent helps evaluate location, pricing, neighbourhood context, resale risk, offer strategy, inspection concerns, and whether the home actually fits your goals once you see it in person.",
+  },
+  {
+    question: "How does Finally Home Agents help buyers compare NorthSide GTA communities?",
+    answer:
+      "We help buyers understand how each town feels, functions, and compares before they commit to a search. That includes pricing, commute options, schools, lifestyle, neighbourhood feel, property types, local amenities, and resale considerations across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog.",
+  },
+  {
+    question: "What should buyers know before leaving Toronto for a smaller town?",
+    answer:
+      "The biggest shift is lifestyle. Many buyers gain space, quieter streets, trails, lakes, golf, and a stronger community feel, but they also need to think carefully about commute patterns, school zones, winter driving, local services, restaurants, activities, and how often they still need to be in the city.",
+  },
+  {
+    question: "Can you help us decide whether to buy first or sell first?",
+    answer:
+      "Yes. The right order depends on your finances, current home, target area, market conditions, timing, and risk tolerance. We help buyers and sellers compare both paths clearly so they understand the tradeoffs before making a move.",
+  },
+  {
+    question: "What is the Town Match quiz for?",
+    answer:
+      "The Town Match quiz helps buyers think through lifestyle, pace, commute, and community fit before they start chasing listings. It is not a replacement for a real strategy conversation, but it gives buyers a useful starting point for comparing NorthSide GTA towns.",
+  },
+];
+
+const buyerFaqSchema = {
+  "@type": "FAQPage",
+  "@id": `${BUYERS_URL}#faq`,
+  url: BUYERS_URL,
+  name: "Buyer Questions We Hear Most Often",
+  inLanguage: "en-CA",
+  mainEntity: BUYER_FAQS.map(({ question, answer }) => ({
+    "@type": "Question",
+    name: question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: answer,
+    },
+  })),
+};
+
 export const BUYERS_SCHEMA = {
   "@context": "https://schema.org",
   "@graph": [
@@ -56,7 +125,7 @@ export const BUYERS_SCHEMA = {
       image: BUYERS_SEO_IMAGE,
       about: { "@id": `${SITE_URL}/#realestateagent` },
       provider: { "@id": `${SITE_URL}/#realestateagent` },
-      mainEntity: { "@id": `${BUYERS_URL}#service` },
+      mainEntity: [{ "@id": `${BUYERS_URL}#service` }, { "@id": `${BUYERS_URL}#faq` }],
       breadcrumb: { "@id": `${BUYERS_URL}#breadcrumb` },
     },
     {
@@ -71,6 +140,7 @@ export const BUYERS_SCHEMA = {
       description:
         "Buyer representation and town-by-town home search guidance across the NorthSide GTA communities north of Toronto.",
     },
+    buyerFaqSchema,
     {
       "@type": "BreadcrumbList",
       "@id": `${BUYERS_URL}#breadcrumb`,


### PR DESCRIPTION
### Motivation
- Improve buyer-intent topical authority and user usefulness on the `/buyers` page by adding a visible FAQ addressing high-intent questions about towns, commute, lifestyle, and buyer representation north of Toronto. 
- Preserve the existing buyer content, CTAs, reviews, Town Match quiz, and page layout while supporting search engines with matching structured FAQ markup.

### Description
- Added `BUYER_FAQS` data and a `buyerFaqSchema` (`FAQPage`) to the existing `src/components/seo/buyersSchema.mjs` and included the FAQ entry in the `@graph` while preserving `RealEstateAgent`, `WebPage`, `Service`, and `BreadcrumbList` items and non-www canonical/OG/Twitter values. 
- Added a visible `BuyersFaqSection` React component to `src/BuyersPage.js` and inserted it after the reviews section and before the final CTA so page flow and conversion elements remain intact. 
- Rendered the FAQ as an accessible accordion (`<details>`/`<summary>`) with premium-consistent styling and lightweight logic to insert one natural internal link per town where helpful (links map to existing `/communities/*` routes). 
- Kept schema answers as plain text (no extra claims, reviews, ratings, or aggregateRating markup) and ensured the `FAQPage` JSON-LD matches the visible FAQ content exactly and is added to `BUYERS_SCHEMA` rather than inlining a separate schema in `BuyersPage.js`.

### Testing
- Validated the `BUYERS_SCHEMA` JSON-LD programmatically with a Node check that confirms an `FAQPage` in `@graph`, matching question/answer pairs, and no `review` or `aggregateRating` (passed). 
- Ran unit/integration tests with `npm test` which passed (65 tests, 0 failures). 
- Built the app with `npm run build` which completed successfully (existing warnings for Browserslist freshness and `rrule` source-map files only). 
- Automated Playwright checks and screenshots confirmed the FAQ is visible on mobile and desktop, `faqCount` matches (10 items), the visible FAQ text equals the `FAQPage` JSON-LD, reviews/quiz/form/CTA remain visible and functional, and canonical/OG/Twitter image URLs use the non-www canonical site.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ab1fa61708324afcbcf39c5068a87)