### PR TITLE
Fix /buyers static SEO shell metadata

### DIFF
--- a/scripts/generate-static-route-html.js
+++ b/scripts/generate-static-route-html.js
@@ -142,7 +142,7 @@ function resolveTagKey(tag) {
 function stringifyTag(tag) {
   if (!tag) return "";
   if (tag.type === "title") {
-    return `<title>${escapeHtml(tag.content || "")}</title>`;
+    return `<title data-rh="true">${escapeHtml(tag.content || "")}</title>`;
   }
   if (tag.type === "meta") {
     const attrs = tag.attributes || {};
@@ -150,7 +150,7 @@ function stringifyTag(tag) {
       .filter(([, value]) => value != null && value !== "")
       .map(([key, value]) => `${key}="${escapeAttribute(value)}"`)
       .join(" ");
-    return attrText ? `<meta ${attrText} />` : "";
+    return attrText ? `<meta ${attrText} data-rh="true" />` : "";
   }
   if (tag.type === "link") {
     const attrs = tag.attributes || {};
@@ -158,7 +158,7 @@ function stringifyTag(tag) {
       .filter(([, value]) => value != null && value !== "")
       .map(([key, value]) => `${key}="${escapeAttribute(value)}"`)
       .join(" ");
-    return attrText ? `<link ${attrText} />` : "";
+    return attrText ? `<link ${attrText} data-rh="true" />` : "";
   }
   return "";
 }
@@ -167,7 +167,7 @@ function stringifyJsonLdScript(schema) {
   if (!schema) return "";
   const json = typeof schema === "string" ? schema : JSON.stringify(schema);
   if (!json) return "";
-  return `<script type="application/ld+json">${json.replace(/</g, "\\u003c")}</script>`;
+  return `<script type="application/ld+json" data-rh="true">${json.replace(/</g, "\\u003c")}</script>`;
 }
 
 function escapeHtml(value) {
@@ -189,7 +189,18 @@ function getOutputPath(root, route) {
   return path.join(root, normalized, "index.html");
 }
 
-main().catch((error) => {
-  console.error("[generate-static-route-html] Failed:", error);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("[generate-static-route-html] Failed:", error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildHeadFragments,
+  mergeMetaTags,
+  resolveTagKey,
+  stringifyTag,
+  stringifyJsonLdScript,
+  getOutputPath,
+};

--- a/src/components/seo/GlobalStructuredData.js
+++ b/src/components/seo/GlobalStructuredData.js
@@ -1,12 +1,17 @@
 import React from "react";
 import { Helmet } from "react-helmet-async";
+import { useLocation } from "react-router-dom";
 
 const { getGlobalGraphJson } = require("../../lib/structuredData/globalGraph");
 
+const ROUTES_WITH_ROUTE_SPECIFIC_SCHEMA_ONLY = new Set(["/buyers"]);
+
 export default function GlobalStructuredData() {
+  const { pathname } = useLocation();
+  const normalizedPathname = pathname.replace(/\/$/, "") || "/";
   const graphJson = React.useMemo(() => getGlobalGraphJson(), []);
 
-  if (!graphJson) return null;
+  if (!graphJson || ROUTES_WITH_ROUTE_SPECIFIC_SCHEMA_ONLY.has(normalizedPathname)) return null;
 
   return (
     <Helmet>

--- a/src/components/seo/metaTagUtils.js
+++ b/src/components/seo/metaTagUtils.js
@@ -171,6 +171,7 @@ function normalizeAdditionalMeta(additionalMeta) {
       const name = safeString(meta.name);
       const property = safeString(meta.property);
       const content = safeString(meta.content);
+      if (name.toLowerCase() === "keywords") return null;
       if (!content || (!name && !property)) return null;
       const key = safeString(meta.key);
       return {

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -55,13 +55,6 @@ const STATIC_ROUTE_META_CONFIGS = [
       twitterCard: "summary_large_image",
       twitterImage: "https://www.northsidegta.ca/Images/seo/keswick-lower-priced-homes-og.jpg",
       siteName: "NorthSide GTA",
-      additionalMeta: [
-        {
-          name: "keywords",
-          content:
-            "Keswick homes for sale, Keswick houses for sale, lower priced homes in Keswick, homes for sale in Keswick Ontario, Georgina homes for sale, affordable homes in Georgina, homes north of Toronto",
-        },
-      ],
     },
   },
   {
@@ -116,14 +109,7 @@ const STATIC_ROUTE_META_CONFIGS = [
       twitterCard: "summary_large_image",
       twitterImage: "https://northsidegta.ca/Images/northsidegta-map-bg.jpg",
       siteName: "NorthSide GTA",
-      additionalMeta: [
-        { name: "robots", content: "index,follow" },
-        {
-          name: "keywords",
-          content:
-            "sell my home NorthSide GTA, list my home Georgina, list my home East Gwillimbury, sell house Newmarket, sell house Aurora, sell house Stouffville, sell house Uxbridge, sell house Scugog, home marketing, real estate agent",
-        },
-      ],
+      additionalMeta: [{ name: "robots", content: "index,follow" }],
     },
   },
   {
@@ -300,13 +286,6 @@ const STATIC_ROUTE_META_CONFIGS = [
       twitterCard: "summary_large_image",
       twitterImage: "/Images/northsidegta-map-bg.jpg",
       siteName: "NorthSide GTA",
-      additionalMeta: [
-        {
-          name: "keywords",
-          content:
-            "about Finally Home Agents, NorthSide GTA realtors, local real estate team, Newmarket, Aurora, Uxbridge",
-        },
-      ],
     },
   },
   {

--- a/tests/static-buyers-shell.test.cjs
+++ b/tests/static-buyers-shell.test.cjs
@@ -1,0 +1,72 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { buildHeadFragments } = require("../scripts/generate-static-route-html.js");
+const { getMetaTagsFromData } = require("../src/components/seo/metaTagUtils.js");
+
+const TEMPLATE = `<!DOCTYPE html><html lang="en"><head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="keywords" content="stale keywords" />
+  <meta property="og:image" content="https://www.northsidegta.ca/uploads/buyers-page-seo.jpg" />
+  <meta name="twitter:image" content="https://www.northsidegta.ca/uploads/buyers-page-seo.jpg" />
+</head><body><div id="root"></div></body></html>`;
+
+test("buyers static HTML shell includes route SEO before JavaScript runs", async () => {
+  const { DEFAULT_GLOBAL_META_CONFIG, STATIC_ROUTE_META_CONFIGS } = await import(
+    "../src/components/seo/staticRouteMetaConfigs.mjs"
+  );
+  const buyersEntry = STATIC_ROUTE_META_CONFIGS.find((entry) => entry.route === "/buyers");
+  assert.ok(buyersEntry, "buyers route is configured for static shell generation");
+
+  const baseMeta = getMetaTagsFromData(DEFAULT_GLOBAL_META_CONFIG);
+  const html = buildHeadFragments(
+    TEMPLATE,
+    "<!DOCTYPE html>",
+    baseMeta && Array.isArray(baseMeta.tags) ? baseMeta.tags : [],
+    buyersEntry.meta,
+  );
+
+  assert.match(html, /<link rel="canonical" href="https:\/\/northsidegta\.ca\/buyers"/);
+  assert.match(html, /<meta property="og:url" content="https:\/\/northsidegta\.ca\/buyers"/);
+  assert.match(
+    html,
+    /<meta property="og:image" content="https:\/\/northsidegta\.ca\/uploads\/buyers-page-seo\.jpg"/,
+  );
+  assert.match(
+    html,
+    /<meta name="twitter:image" content="https:\/\/northsidegta\.ca\/uploads\/buyers-page-seo\.jpg"/,
+  );
+  assert.match(html, /<meta name="author" content="Finally Home Agents"/);
+  assert.match(html, /<meta name="publisher" content="Finally Home Agents"/);
+  assert.match(html, /<script type="application\/ld\+json"[^>]*>/);
+  assert.match(html, /"@type":"RealEstateAgent"/);
+  assert.match(html, /"@type":"WebPage"/);
+  assert.match(html, /"@type":"Service"/);
+  assert.match(html, /"@type":"BreadcrumbList"/);
+  assert.match(html, /"@type":"FAQPage"/);
+  assert.doesNotMatch(html, /name="keywords"/i);
+  assert.doesNotMatch(html, /https:\/\/www\.northsidegta\.ca\/uploads\/buyers-page-seo\.jpg/);
+  assert.doesNotMatch(html, /aggregateRating/i);
+  assert.doesNotMatch(html, /"@type":"Review"/);
+});
+
+test("meta tag utility suppresses keyword meta descriptors", () => {
+  const meta = getMetaTagsFromData({
+    route: "/keyword-filter-test",
+    title: "Keyword filter test",
+    description: "Keyword filter test description",
+    additionalMeta: [
+      { name: "keywords", content: "do not render" },
+      { name: "author", content: "Finally Home Agents" },
+    ],
+  });
+
+  const names = meta.tags
+    .filter((tag) => tag.type === "meta")
+    .map((tag) => tag.attributes && tag.attributes.name)
+    .filter(Boolean);
+
+  assert.ok(names.includes("author"));
+  assert.ok(!names.includes("keywords"));
+});


### PR DESCRIPTION
### Motivation

- Ensure the initial (no-JS) HTML shell for `/buyers` exposes the correct SEO tags and images so crawlers and social previews see the non-www values before React hydrates. 
- Remove stale `meta name="keywords"` from any static head output so keyword tags are not present in initial HTML. 
- Provide the buyers JSON-LD graph and author/publisher metadata in the static shell while preventing the global graph (which contains reviews/aggregateRating) from duplicating or exposing review schema for this route.

### Description

- Updated `scripts/generate-static-route-html.js` so generated head tags and JSON-LD are emitted with Helmet-compatible `data-rh` attributes and the generator exports its helpers for unit testing (`buildHeadFragments`, `stringifyJsonLdScript`, etc.).
- Added a filter in `src/components/seo/metaTagUtils.js` to suppress any `additionalMeta` entries with `name: "keywords"` and removed keyword entries from `src/components/seo/staticRouteMetaConfigs.mjs` to prevent keywords from being emitted into static shells.
- Prevented the global structured-data graph from being injected on the `/buyers` route by making `GlobalStructuredData` skip rendering on that route so only the route-specific `BUYERS_SCHEMA` is present in the static shell.
- Added a regression test `tests/static-buyers-shell.test.cjs` that builds the `/buyers` head fragment from a stale template and asserts the raw shell includes the non-www canonical/og/twitter image values, `author`/`publisher` meta, route JSON-LD graph types (RealEstateAgent, WebPage, Service, BreadcrumbList, FAQPage), and that `keywords` and review/aggregateRating schema are not present.

### Testing

- Ran `node --test tests/static-buyers-shell.test.cjs` and the new regression tests passed. 
- Ran `npm run build` (CRA production build + postbuild scripts) and the build completed successfully while preserving existing CRA warnings about source maps and Browserslist (these are unrelated warnings and expected). 
- Served `build/` locally and verified with an automated `curl` + assertions that the raw `build/buyers/index.html` contains the non-www `og:image`/`twitter:image`, `author`/`publisher`, canonical `https://northsidegta.ca/buyers`, and the buyers JSON-LD graph, and that no `meta name="keywords"`, `aggregateRating`, or `Review` schema appear. 
- Ran an automated Playwright rendering check against the local build to confirm the FAQ is visible, canonical is `https://northsidegta.ca/buyers`, FAQ schema remains present in the rendered page, and no review/aggregateRating schema is present (the check passed); a raw production `curl -L https://northsidegta.ca/buyers` attempt from this environment failed due to an outbound proxy `CONNECT` restriction, so production raw-source verification should be re-run after deployment or via Vercel HTML output inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2abff767548324b3cbc1e10563551f)