### PR TITLE
SEO: enforce non-www canonicals and durable per-route metadata; add validation

### DIFF
--- a/config/site.json
+++ b/config/site.json
@@ -1,4 +1,4 @@
 {
-  "siteOrigin": "https://www.northsidegta.ca",
+  "siteOrigin": "https://northsidegta.ca",
   "includeEventsArchiveInSitemap": true
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "generate:insights": "node scripts/generate-insights-data.js",
     "insights:migrate-images": "node scripts/migrate-insight-image-paths.js",
     "insights:check-images": "node scripts/check-insight-images.js",
-    "seed:spotlights": "ts-node --transpile-only scripts/seedTownSpotlightsFromGoogle.ts"
+    "seed:spotlights": "ts-node --transpile-only scripts/seedTownSpotlightsFromGoogle.ts",
+    "seo:check": "node scripts/seo-check.cjs"
   },
   "dependencies": {
     "@fastify/busboy": "^3.2.0",

--- a/public/data/community-stories.json
+++ b/public/data/community-stories.json
@@ -5,7 +5,7 @@
     "summary": "From the Nokiidaa to Durham Forest, here are reader-favourite routes with paved stretches, stroller-friendly loops and post-ride coffee stops.",
     "publishedAt": "2025-04-18T09:00:00-04:00",
     "image": "/Images/towns/newmarket.jpg",
-    "url": "https://www.northsidegta.ca/blog/scenic-bike-trails",
+    "url": "https://northsidegta.ca/blog/scenic-bike-trails",
     "tags": ["community", "outdoors"]
   },
   {
@@ -14,7 +14,7 @@
     "summary": "Indoor climbing, maker studios, libraries with gaming lounges and splash pads that stay open under glass—you shared your go-tos.",
     "publishedAt": "2025-04-26T12:30:00-04:00",
     "image": "/Images/towns/aurora.jpg",
-    "url": "https://www.northsidegta.ca/blog/rainy-day-escapes",
+    "url": "https://northsidegta.ca/blog/rainy-day-escapes",
     "tags": ["community", "family"]
   },
   {
@@ -23,7 +23,7 @@
     "summary": "Course openings, twilight deals and women's league sign-ups across Aurora, Uxbridge, Georgina and beyond.",
     "publishedAt": "2025-04-30T08:15:00-04:00",
     "image": "/Images/golf-league.jpg",
-    "url": "https://www.northsidegta.ca/blog/golf-season-preview",
+    "url": "https://northsidegta.ca/blog/golf-season-preview",
     "tags": ["community", "events"]
   }
 ]

--- a/public/data/seo/home.json
+++ b/public/data/seo/home.json
@@ -6,5 +6,5 @@
   "og_title": "NorthSide GTA Real Estate | Buy & Sell North of Toronto | Finally Home Agents",
   "og_description": "Buy or sell north of Toronto with Finally Home Agents. Explore NorthSide GTA real estate, homes, market data, and community guidance across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog.",
   "og_image": "/uploads/northside-gta-finally-home-agents-hero.jpg",
-  "canonical_url": "https://www.northsidegta.ca/"
+  "canonical_url": "https://northsidegta.ca/"
 }

--- a/public/listings/33-st-augustine-drive-brooklin/index.html
+++ b/public/listings/33-st-augustine-drive-brooklin/index.html
@@ -46,7 +46,6 @@
     <meta name="twitter:description" content="Explore 33 St Augustine Drive in Brooklin, Whitby. View the walkthrough video, photos, floor plans, listing details, and request a showing with Finally Home Agents." >
     <meta name="twitter:image" content="https://northsidegta.ca/Images/33-st-augustine-drive-og.jpg" >
     <meta name="twitter:image:alt" content="33 St Augustine Drive in Brooklin, Whitby" >
-    <meta name="keywords" content="NorthSide GTA, real estate, homes for sale North GTA, sell my home, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog" >
     <meta property="og:image:secure_url" content="https://northsidegta.ca/Images/33-st-augustine-drive-og.jpg" ></head>
   <body>
     <div id="root"></div>

--- a/public/listings/5670-thomas-drive-baldwin/index.html
+++ b/public/listings/5670-thomas-drive-baldwin/index.html
@@ -46,7 +46,6 @@
     <meta name="twitter:description" content="Explore 5670 Thomas Drive in Baldwin, Georgina. View the walkthrough video, photos, floor plans, listing details, and request a showing with Finally Home Agents." >
     <meta name="twitter:image" content="https://northsidegta.ca/Images/5670-thomas-drive-og.jpg" >
     <meta name="twitter:image:alt" content="5670 Thomas Drive in Baldwin, Georgina" >
-    <meta name="keywords" content="NorthSide GTA, real estate, homes for sale North GTA, sell my home, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog" >
     <meta property="og:image:secure_url" content="https://northsidegta.ca/Images/5670-thomas-drive-og.jpg" ></head>
   <body>
     <div id="root"></div>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -22,9 +22,9 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://northsidegta.ca/vip</loc>
+    <loc>https://northsidegta.ca/communities</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://northsidegta.ca/about</loc>
@@ -52,39 +52,59 @@
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://northsidegta.ca/georgina</loc>
+    <loc>https://northsidegta.ca/communities/georgina</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://northsidegta.ca/east-gwillimbury</loc>
+    <loc>https://northsidegta.ca/communities/east-gwillimbury</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://northsidegta.ca/newmarket</loc>
+    <loc>https://northsidegta.ca/communities/newmarket</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://northsidegta.ca/aurora</loc>
+    <loc>https://northsidegta.ca/communities/aurora</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://northsidegta.ca/stouffville</loc>
+    <loc>https://northsidegta.ca/communities/stouffville</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://northsidegta.ca/uxbridge</loc>
+    <loc>https://northsidegta.ca/communities/uxbridge</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://northsidegta.ca/scugog</loc>
+    <loc>https://northsidegta.ca/communities/scugog</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/1m-north-of-toronto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/detached-homes-georgina</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/detached-homes-northsidegta</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/collections/estates-of-wyndance-homes-for-sale</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://northsidegta.ca/collections/golfunder2m</loc>
@@ -164,6 +184,132 @@
     <lastmod>2025-10-06T16:03:30.000Z</lastmod>
   </url>
   <url>
+    <loc>https://northsidegta.ca/events/20251213-allison-lupton-s-celtic-christmas-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251217-acc-public-board-meeting-december-2025-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251217-open-studio-ages-18-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251220-lol-playlab-grand-opening-whitchurch-stouffville</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251222-winter-break-daily-art-camp-dec-22-ages-4-7-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251222-winter-break-daily-art-camp-dec-22-ages-7-12-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251222-y-a-r-portfolio-review-spark-sessions-charm-making-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251223-winter-break-daily-art-camp-dec-23-ages-4-7-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251223-winter-break-daily-art-camp-dec-23-ages-7-12-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251229-winter-break-daily-art-camp-dec-29-ages-4-7-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251229-winter-break-daily-art-camp-dec-29-ages-7-12-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251230-winter-break-daily-art-camp-dec-30-ages-4-7-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20251230-winter-break-daily-art-camp-dec-30-ages-7-12-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20260102-shifting-realities-new-years-art-jamboree-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20260112-comic-drawing-for-children-7-12yrs-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20260112-comic-drawing-for-children-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-02T08:39:36.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20260112-intro-to-wood-carving-16-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-11T08:39:24.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20260112-intro-to-wood-carving-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-02T08:39:36.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20260124-john-sheard-s-british-invasion-charmie-2-00pm-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-11-29T08:34:31.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20260206-blain-milatz-duo-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-11-29T08:34:31.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/20260301-little-magic-sam-awbf-aurora</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <lastmod>2025-12-01T08:40:20.000Z</lastmod>
+  </url>
+  <url>
     <loc>https://northsidegta.ca/events/aurora-cultural-centre-10002603-1759518000-1759527000-auroraculturalcentre-ca-20251003</loc>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
@@ -198,6 +344,11 @@
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
     <lastmod>2025-05-01T14:00:00.000Z</lastmod>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/events/discover-stouffville-https-discoverstouffvilleca-event-the-stouffville-christmas-market-20251213</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
   </url>
   <url>
     <loc>https://northsidegta.ca/events/experience-york-region-10014157-1759582800-1759593600-www-experienceyorkregion-com-20251003</loc>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -96,7 +96,7 @@ function main() {
     { path: '/buyers', changefreq: 'weekly', priority: '0.9' },
     { path: '/sellers', changefreq: 'weekly', priority: '0.9' },
     { path: '/homeanalysis', changefreq: 'monthly', priority: '0.7' },
-    { path: '/vip', changefreq: 'monthly', priority: '0.6' },
+    { path: '/communities', changefreq: 'monthly', priority: '0.8' },
     { path: '/about', changefreq: 'yearly', priority: '0.5' },
     { path: '/contact', changefreq: 'yearly', priority: '0.5' },
     { path: '/community', changefreq: 'daily', priority: '0.8' },
@@ -112,7 +112,7 @@ function main() {
     .map((town) => (typeof town === 'object' ? town.slug : null))
     .filter((slug) => typeof slug === 'string' && slug.trim())
     .forEach((slug) => {
-      staticRoutes.push({ path: `/${slug.trim()}`, changefreq: 'monthly', priority: '0.7' })
+      staticRoutes.push({ path: `/communities/${slug.trim()}`, changefreq: 'monthly', priority: '0.8' })
     })
 
   const collections = loadCollections(collectionsDir)

--- a/scripts/ingest-events.js
+++ b/scripts/ingest-events.js
@@ -13,7 +13,7 @@ const rootDir = path.resolve(__dirname, '..')
 const configPath = path.join(rootDir, 'config', 'event-feeds.json')
 const eventsDir = path.join(rootDir, 'public', 'data', 'events')
 
-const DEFAULT_USER_AGENT = 'NorthSideGTA-EventBot/1.0 (+https://www.northsidegta.ca/community)'
+const DEFAULT_USER_AGENT = 'NorthSideGTA-EventBot/1.0 (+https://northsidegta.ca/community)'
 const MIN_REQUEST_DELAY_MS = 6000
 const DEFAULT_PRIORITY = 50
 

--- a/scripts/inject-homepage-static-html.js
+++ b/scripts/inject-homepage-static-html.js
@@ -15,10 +15,10 @@ if (!fs.existsSync(buildIndex)) {
   process.exit(0);
 }
 
-const homeUrl = "https://www.northsidegta.ca/";
-const title = "NorthSide GTA Real Estate | Buy & Sell North of Toronto | Finally Home Agents";
-const description = "Buy or sell north of Toronto with Finally Home Agents. Explore NorthSide GTA real estate, homes, market data, and community guidance across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog.";
-const image = "https://www.northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg";
+const homeUrl = "https://northsidegta.ca/";
+const title = "NorthSide GTA Real Estate | Finally Home Agents";
+const description = "Buy or sell north of Toronto with Finally Home Agents. Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.";
+const image = "https://northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg";
 const faq = [
   ["What is the NorthSide GTA?", "The NorthSide GTA refers to communities north of Toronto including Aurora, Newmarket, Whitchurch-Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog — areas where buyers often find more space, established communities, and lifestyle options while staying connected to the Greater Toronto Area."],
   ["Who helps buyers and sellers in the NorthSide GTA?", "Finally Home Agents — Matthew Mulhall and Landon Mulhall — provide buyer and seller representation across the NorthSide GTA, operating under HomeLife Optimum Realty, Brokerage, and regulated by RECO (Real Estate Council of Ontario)."],
@@ -31,7 +31,7 @@ const schema = {
   "@graph": [
     { "@type": "Organization", "@id": `${homeUrl}#organization`, name: "Finally Home Agents", alternateName: "NorthSide GTA", url: homeUrl, telephone: "+16476684646", foundingDate: "2017", parentOrganization: { "@type": "Organization", name: "HomeLife Optimum Realty, Brokerage" }, sameAs: ["https://www.instagram.com/finallyhomeagents/", "https://www.facebook.com/finallyhomeagents/"] },
     { "@type": ["RealEstateAgent", "LocalBusiness"], "@id": `${homeUrl}#realestateagent`, name: "Finally Home Agents — NorthSide GTA", url: homeUrl, image, telephone: "+16476684646", areaServed: ["Aurora", "Newmarket", "Whitchurch-Stouffville", "Uxbridge", "Georgina", "East Gwillimbury", "Scugog"], employee: [{ "@type": "Person", name: "Matthew Mulhall", telephone: "+16476684646" }, { "@type": "Person", name: "Landon Mulhall", telephone: "+14164554594" }] },
-    { "@type": "WebSite", "@id": `${homeUrl}#website`, url: homeUrl, name: "NorthSide GTA", publisher: { "@id": `${homeUrl}#organization` }, potentialAction: { "@type": "SearchAction", target: "https://www.northsidegta.ca/search?q={search_term_string}", "query-input": "required name=search_term_string" } },
+    { "@type": "WebSite", "@id": `${homeUrl}#website`, url: homeUrl, name: "NorthSide GTA", publisher: { "@id": `${homeUrl}#organization` }, potentialAction: { "@type": "SearchAction", target: "https://northsidegta.ca/search?q={search_term_string}", "query-input": "required name=search_term_string" } },
     { "@type": "WebPage", "@id": `${homeUrl}#webpage`, url: homeUrl, name: title, description, isPartOf: { "@id": `${homeUrl}#website` }, about: { "@id": `${homeUrl}#realestateagent` }, datePublished: "2017-01-01", dateModified: "2026-06-03", breadcrumb: { "@type": "BreadcrumbList", itemListElement: [{ "@type": "ListItem", position: 1, name: "NorthSide GTA", item: homeUrl }] } },
     { "@type": "FAQPage", "@id": `${homeUrl}#faq`, mainEntity: faq.map(([question, answer]) => ({ "@type": "Question", name: question, acceptedAnswer: { "@type": "Answer", text: answer } })) },
   ],
@@ -39,8 +39,8 @@ const schema = {
 
 let html = fs.readFileSync(buildIndex, "utf8");
 html = html.replace(/<div id="root">[\s\S]*?<\/div>/, `<div id="root">${HOMEPAGE_MARKUP}</div>`);
-if (!html.includes('rel="alternate" hreflang="en-CA"')) {
-  html = html.replace("</head>", `<meta http-equiv="content-language" content="en-CA"><link rel="alternate" hreflang="en-CA" href="${homeUrl}"><script type="application/ld+json">${JSON.stringify(schema).replace(/</g, "\\u003c")}</script></head>`);
+if (!html.includes('data-static-homepage-schema="true"')) {
+  html = html.replace("</head>", `<meta http-equiv="content-language" content="en-CA"><script type="application/ld+json" data-static-homepage-schema="true">${JSON.stringify(schema).replace(/</g, "\\u003c")}</script></head>`);
 }
 fs.writeFileSync(buildIndex, html, "utf8");
 console.log("[inject-homepage-static-html] Injected crawlable homepage body and JSON-LD into build/index.html");

--- a/scripts/seo-check.cjs
+++ b/scripts/seo-check.cjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { parse } = require('node-html-parser');
+
+const ROOT = path.resolve(__dirname, '..');
+const BUILD_DIR = path.join(ROOT, 'build');
+const SITE = 'https://northsidegta.ca';
+const ROUTES = [
+  '/', '/buyers', '/sellers', '/communities', '/homeanalysis',
+  '/communities/georgina', '/communities/newmarket', '/communities/aurora',
+  '/communities/stouffville', '/communities/uxbridge', '/communities/scugog',
+  '/communities/east-gwillimbury', '/contact', '/about', '/sign', '/vip',
+];
+const HOME_TITLE = 'NorthSide GTA Real Estate | Finally Home Agents';
+const NOINDEX = new Set(['/sign', '/vip']);
+
+function fileForRoute(route) {
+  return route === '/' ? path.join(BUILD_DIR, 'index.html') : path.join(BUILD_DIR, route.replace(/^\//, ''), 'index.html');
+}
+function get(doc, selector, attr = 'content') {
+  const el = doc.querySelector(selector);
+  if (!el) return '';
+  return attr === 'text' ? el.text.trim() : (el.getAttribute(attr) || '').trim();
+}
+function assert(ok, message, errors) {
+  if (!ok) errors.push(message);
+}
+
+let failures = 0;
+for (const route of ROUTES) {
+  const file = fileForRoute(route);
+  const errors = [];
+  if (!fs.existsSync(file)) {
+    console.error(`❌ ${route}: missing ${path.relative(ROOT, file)}`);
+    failures += 1;
+    continue;
+  }
+  const html = fs.readFileSync(file, 'utf8');
+  const doc = parse(html);
+  const title = get(doc, 'title', 'text');
+  const description = get(doc, 'meta[name="description"]');
+  const canonical = get(doc, 'link[rel="canonical"]', 'href');
+  const robots = get(doc, 'meta[name="robots"]');
+  const ogUrl = get(doc, 'meta[property="og:url"]');
+  const ogImage = get(doc, 'meta[property="og:image"]');
+  const twitterImage = get(doc, 'meta[name="twitter:image"]');
+  const jsonLdCount = doc.querySelectorAll('script[type="application/ld+json"]').length;
+  const expectedCanonical = `${SITE}${route === '/' ? '/' : route}`;
+
+  assert(Boolean(title), 'missing title', errors);
+  assert(Boolean(description), 'missing description', errors);
+  assert(canonical === expectedCanonical, `canonical mismatch: ${canonical}`, errors);
+  assert(!canonical.includes('www.'), 'canonical uses www', errors);
+  assert(ogUrl === canonical, `og:url mismatch: ${ogUrl}`, errors);
+  assert(Boolean(ogImage), 'missing og:image', errors);
+  assert(Boolean(twitterImage), 'missing twitter:image', errors);
+  assert(!ogImage.includes('www.'), 'og:image uses www', errors);
+  assert(!twitterImage.includes('www.'), 'twitter:image uses www', errors);
+  assert(!/\.svg(?:$|[?#])/i.test(ogImage), `og:image uses SVG: ${ogImage}`, errors);
+  assert(!/\.svg(?:$|[?#])/i.test(twitterImage), `twitter:image uses SVG: ${twitterImage}`, errors);
+  assert(!doc.querySelector('meta[name="keywords"]'), 'meta keywords present', errors);
+  assert(get(doc, 'meta[name="author"]') === 'Finally Home Agents', 'missing author', errors);
+  assert(get(doc, 'meta[name="publisher"]') === 'Finally Home Agents', 'missing publisher', errors);
+  assert(jsonLdCount > 0, 'missing JSON-LD', errors);
+
+  if (NOINDEX.has(route)) {
+    assert(/noindex/i.test(robots) && /follow/i.test(robots), `expected noindex, follow robots: ${robots}`, errors);
+  } else {
+    assert(/index/i.test(robots) && /follow/i.test(robots) && !/noindex/i.test(robots), `expected index, follow robots: ${robots}`, errors);
+  }
+
+  if (route.startsWith('/communities/')) {
+    assert(canonical !== `${SITE}/`, 'town canonical points to homepage', errors);
+    assert(title !== HOME_TITLE, 'town uses homepage title', errors);
+  }
+
+  if (errors.length) {
+    failures += 1;
+    console.error(`❌ ${route}: ${errors.join('; ')}`);
+  } else {
+    console.log(`✅ ${route}: ${title} | ${canonical}`);
+  }
+}
+
+if (failures) {
+  console.error(`SEO check failed for ${failures} route(s).`);
+  process.exit(1);
+}
+console.log('SEO check passed.');

--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -28,7 +28,7 @@ const reportsDir = path.join(rootDir, 'public', 'data', 'sync-reports')
 const urlUpdateLogPath = path.join(rootDir, 'logs', 'events-url-updates.log')
 const { allowNetworkInCi, networkBlockedReason } = require('../lib/events/env.js')
 
-const DEFAULT_USER_AGENT = 'NorthSideGTA-EventBot/1.0 (+https://www.northsidegta.ca/community)'
+const DEFAULT_USER_AGENT = 'NorthSideGTA-EventBot/1.0 (+https://northsidegta.ca/community)'
 const DEFAULT_PRIORITY = 50
 const DEFAULT_TIMEOUT_MS = 15000
 const DEFAULT_RETRY_ATTEMPTS = 3

--- a/src/App.js
+++ b/src/App.js
@@ -32,6 +32,7 @@ import TasteHubRequestTabletopSignPage from "./TasteHubRequestTabletopSignPage";
 import GuidedPathPage from "./GuidedPathPage";
 import GlobalDefaultMeta from "./components/seo/GlobalDefaultMeta";
 import GlobalStructuredData from "./components/seo/GlobalStructuredData";
+import RouteSpecificMeta from "./components/seo/RouteSpecificMeta";
 import ThankYou209BarriePage from "./ThankYou209BarriePage";
 import Inquiry209BarrieStreetPage from "./listings/Inquiry209BarrieStreetPage";
 import Inquiry33StAugustineDriveBrooklinPage from "./listings/Inquiry33StAugustineDriveBrooklinPage";
@@ -165,6 +166,7 @@ function App() {
           {/* Catch-all for any slug not yet in towns.json (optional) */}
           <Route path="/:slug" element={<TownPage />} />
         </Routes>
+        <RouteSpecificMeta />
         </HeaderShellProvider>
       </Router>
       <Analytics />

--- a/src/HomeAnalysisPage.js
+++ b/src/HomeAnalysisPage.js
@@ -313,56 +313,23 @@ export default function HomeAnalysisPage() {
       <div className="min-h-screen bg-gray-50 text-gray-900">
         <HeaderShell />
         <Helmet>
-  <title>Free Home Value Estimate — NorthSide GTA | Finally Home Agents</title>
-  <meta
-    name="description"
-    content="Get a fast, expert home value estimate for the NorthSide GTA. AI-assisted analysis plus local agent insight for Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog."
-  />
-  <link rel="canonical" href="https://www.northsidegta.ca/homeanalysis" />
-  <meta name="robots" content="index,follow" />
-
-  <meta
-    name="keywords"
-    content="home value NorthSide GTA, free home estimate, what is my home worth Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog, CMA, home valuation"
-  />
-
-  {/* Open Graph */}
-  <meta property="og:title" content="Free Home Value Estimate — NorthSide GTA | Finally Home Agents" />
-  <meta
-    property="og:description"
-    content="AI-assisted valuation + local expertise. Get your estimate for Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog."
-  />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.northsidegta.ca/homeanalysis" />
-  <meta property="og:image" content="https://www.northsidegta.ca/Images/northsidegta-map-bg.jpg" />
-
-  {/* JSON-LD */}
-  <script type="application/ld+json">
-    {JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      "name": "Free Home Value Estimate — NorthSide GTA | Finally Home Agents",
-      "url": "https://www.northsidegta.ca/homeanalysis",
-      "description":
-        "Request a fast, expert home valuation for the NorthSide GTA.",
-      "about": {
-        "@type": "RealEstateAgent",
-        "name": "Finally Home Agents",
-        "areaServed": [
-          "Georgina",
-          "East Gwillimbury",
-          "Newmarket",
-          "Aurora",
-          "Stouffville",
-          "Uxbridge",
-          "Scugog"
-        ],
-        "url": "https://www.northsidegta.ca",
-        "brand": "Finally Home Agents"
-      }
-    })}
-  </script>
-</Helmet>
+          <title>Get a Home Value Opinion | NorthSide GTA | Finally Home Agents</title>
+          <meta
+            name="description"
+            content="Find out what your home in Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, or Scugog could sell for today."
+          />
+          <meta name="robots" content="index, follow" />
+          <meta name="author" content="Finally Home Agents" />
+          <meta name="publisher" content="Finally Home Agents" />
+          <link rel="canonical" href="https://northsidegta.ca/homeanalysis" />
+          <meta property="og:title" content="Get a Home Value Opinion | NorthSide GTA | Finally Home Agents" />
+          <meta property="og:description" content="Find out what your home north of Toronto could sell for today." />
+          <meta property="og:type" content="website" />
+          <meta property="og:url" content="https://northsidegta.ca/homeanalysis" />
+          <meta property="og:image" content="https://northsidegta.ca/uploads/sellers-page-seo.jpg" />
+          <meta name="twitter:card" content="summary_large_image" />
+          <meta name="twitter:image" content="https://northsidegta.ca/uploads/sellers-page-seo.jpg" />
+        </Helmet>
         <main className="mx-auto max-w-3xl px-4 py-16 text-center">
           <div
             className="inline-flex items-center gap-2 rounded-full bg-emerald-50 text-emerald-700 px-4 py-1 text-sm font-medium"

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -7,8 +7,8 @@ import { HOMEPAGE_MARKUP } from "./homepageMarkup";
 
 const HOME_TITLE = "NorthSide GTA Real Estate | Buy & Sell North of Toronto | Finally Home Agents";
 const HOME_DESCRIPTION = "Buy or sell north of Toronto with Finally Home Agents. Explore NorthSide GTA real estate, homes, market data, and community guidance across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog.";
-const HOME_URL = "https://www.northsidegta.ca/";
-const HOME_IMAGE = "https://www.northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg";
+const HOME_URL = "https://northsidegta.ca/";
+const HOME_IMAGE = "https://northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg";
 const HOME_IMAGE_ALT = "Interactive NorthSide GTA real estate map showing Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog";
 
 const FAQS = [
@@ -101,7 +101,7 @@ const structuredData = {
       publisher: { "@id": `${HOME_URL}#organization` },
       potentialAction: {
         "@type": "SearchAction",
-        target: "https://www.northsidegta.ca/search?q={search_term_string}",
+        target: "https://northsidegta.ca/search?q={search_term_string}",
         "query-input": "required name=search_term_string",
       },
     },

--- a/src/KeswickLowerPricedHomesPage.js
+++ b/src/KeswickLowerPricedHomesPage.js
@@ -126,9 +126,9 @@ export default function KeswickLowerPricedHomesPage() {
   return <div className="bg-[#f7f6f1] pb-20 text-[#102218] md:pb-0"><DynamicMetaTags {...meta} />
     <Helmet>
       {/* TODO: if /Images/seo/keswick-lower-priced-homes-og.jpg is unavailable, configure a safe fallback OG image in staticRouteMetaConfigs.mjs. */}
-      <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"WebPage",name:"More Buyers Are Suddenly Looking at Keswick",url:"https://www.northsidegta.ca/keswick-lower-priced-homes",description:meta.description})}</script>
-      <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"BreadcrumbList",itemListElement:[{"@type":"ListItem",position:1,name:"Home",item:"https://www.northsidegta.ca/"},{"@type":"ListItem",position:2,name:"Keswick Lower Priced Homes",item:"https://www.northsidegta.ca/keswick-lower-priced-homes"}]})}</script>
-      <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"RealEstateAgent",name:"Finally Home Agents",legalName:"Finally Home Agents | HomeLife Optimum Realty, Brokerage",areaServed:["Keswick","Georgina","York Region"],url:"https://www.northsidegta.ca/keswick-lower-priced-homes"})}</script>
+      <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"WebPage",name:"More Buyers Are Suddenly Looking at Keswick",url:"https://northsidegta.ca/keswick-lower-priced-homes",description:meta.description})}</script>
+      <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"BreadcrumbList",itemListElement:[{"@type":"ListItem",position:1,name:"Home",item:"https://northsidegta.ca/"},{"@type":"ListItem",position:2,name:"Keswick Lower Priced Homes",item:"https://northsidegta.ca/keswick-lower-priced-homes"}]})}</script>
+      <script type="application/ld+json">{JSON.stringify({"@context":"https://schema.org","@type":"RealEstateAgent",name:"Finally Home Agents",legalName:"Finally Home Agents | HomeLife Optimum Realty, Brokerage",areaServed:["Keswick","Georgina","York Region"],url:"https://northsidegta.ca/keswick-lower-priced-homes"})}</script>
     </Helmet>
     <HeaderShell />
     <main className="mx-auto max-w-6xl space-y-12 px-4 py-8 md:py-12">

--- a/src/MembershipCardPreviewPage.js
+++ b/src/MembershipCardPreviewPage.js
@@ -182,7 +182,7 @@ const MembershipCardPreviewPage = () => {
           name="description"
           content="Join the NorthSide GTA membership and get your digital card instantly."
         />
-        <link rel="canonical" href="https://www.northsidegta.ca/northside-pass-preview" />
+        <link rel="canonical" href="https://northsidegta.ca/northside-pass-preview" />
       </Helmet>
 
       <HeaderShell />

--- a/src/ReferralPartnersPage.js
+++ b/src/ReferralPartnersPage.js
@@ -449,8 +449,8 @@ export default function ReferralPartnersPage() {
           content="A dedicated referral partner page for agents with clients moving to the NorthSide GTA, including Uxbridge, Stouffville, Newmarket, Aurora, Georgina, East Gwillimbury, and Scugog."
         />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://www.northsidegta.ca/referral-partners" />
-        <link rel="canonical" href="https://www.northsidegta.ca/referral-partners" />
+        <meta property="og:url" content="https://northsidegta.ca/referral-partners" />
+        <link rel="canonical" href="https://northsidegta.ca/referral-partners" />
       </Helmet>
 
       <HeaderShell />

--- a/src/SignWithUsPage.js
+++ b/src/SignWithUsPage.js
@@ -22,23 +22,23 @@ export default function SignWithUsPage() {
       <HeaderShell />
 
       <Helmet>
-  <title>Sell With Finally Home Agents | NorthSide GTA Listing Experts</title>
-  <meta
-    name="description"
-    content="List with confidence in the NorthSide GTA. Strategy, staging, premium media and negotiation that delivers top results in Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
-  />
-  <meta
-    name="keywords"
-    content="list my home NorthSide GTA, sell house Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog, real estate listing agent"
-  />
-  <link rel="canonical" href="https://www.northsidegta.ca/signwithus" />
-
-  <meta property="og:title" content="Sell With Finally Home Agents | NorthSide GTA" />
-  <meta property="og:description" content="Strategy-first listing team with premium media and strong negotiation." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.northsidegta.ca/signwithus" />
-  <meta property="og:image" content="/Images/northsidegta-map-bg.jpg" />
-</Helmet>
+        <title>Work With Finally Home Agents | NorthSide GTA</title>
+        <meta
+          name="description"
+          content="Share your buying or selling goals with Finally Home Agents for NorthSide GTA real estate guidance."
+        />
+        <meta name="robots" content="noindex, follow" />
+        <meta name="author" content="Finally Home Agents" />
+        <meta name="publisher" content="Finally Home Agents" />
+        <link rel="canonical" href="https://northsidegta.ca/sign" />
+        <meta property="og:title" content="Work With Finally Home Agents | NorthSide GTA" />
+        <meta property="og:description" content="Share your buying or selling goals with Finally Home Agents." />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://northsidegta.ca/sign" />
+        <meta property="og:image" content="https://northsidegta.ca/uploads/sellers-page-seo.jpg" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:image" content="https://northsidegta.ca/uploads/sellers-page-seo.jpg" />
+      </Helmet>
 
       <div className="px-4 md:px-20 py-16 space-y-12">
 

--- a/src/community/EventsArchivePage.js
+++ b/src/community/EventsArchivePage.js
@@ -160,7 +160,7 @@ export default function EventsArchivePage() {
       <Helmet>
         <title>Past Events Archive • NorthSide GTA</title>
         <meta name="description" content={pageDescription} />
-        <link rel="canonical" href="https://www.northsidegta.ca/events/archive" />
+        <link rel="canonical" href="https://northsidegta.ca/events/archive" />
         <meta property="og:title" content="Past Events Archive" />
         <meta property="og:description" content={pageDescription} />
       </Helmet>

--- a/src/components/contact/LegacyContactPage.js
+++ b/src/components/contact/LegacyContactPage.js
@@ -89,16 +89,12 @@ export default function LegacyContactPage() {
     name="description"
     content="Questions about buying or selling in the NorthSide GTA? Contact Finally Home Agents—local experts for Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
   />
-  <meta
-    name="keywords"
-    content="contact realtor NorthSide GTA, real estate agent contact, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog"
-  />
-  <link rel="canonical" href="https://www.northsidegta.ca/contact" />
+  <link rel="canonical" href="https://northsidegta.ca/contact" />
 
   <meta property="og:title" content="Contact Finally Home Agents | NorthSide GTA" />
   <meta property="og:description" content="Talk to a local NorthSide GTA agent today." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.northsidegta.ca/contact" />
+  <meta property="og:url" content="https://northsidegta.ca/contact" />
   <meta property="og:image" content="/Images/northsidegta-map-bg.jpg" />
 </Helmet>
 

--- a/src/components/contact/contactConfig.js
+++ b/src/components/contact/contactConfig.js
@@ -283,7 +283,7 @@ export function getJsonLd(config) {
   const organization = {
     "@type": "Organization",
     name: "Finally Home Agents",
-    url: "https://www.northsidegta.ca/contact",
+    url: "https://northsidegta.ca/contact",
     telephone: phone || undefined,
     sameAs: [...sameAs, ...(config.jsonLd?.sameAs || [])].filter(Boolean),
   };
@@ -304,7 +304,7 @@ export function getJsonLd(config) {
     "@type": "ContactPage",
     name: config.heroHeadline,
     description: config.heroSubhead,
-    url: "https://www.northsidegta.ca/contact",
+    url: "https://northsidegta.ca/contact",
     mainEntity: organization,
     areaServed: config.jsonLd?.areaServed || DEFAULT_CONFIG.jsonLd.areaServed,
   };

--- a/src/components/seo/RouteSpecificMeta.js
+++ b/src/components/seo/RouteSpecificMeta.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { Helmet } from "react-helmet-async";
+import { useLocation } from "react-router-dom";
+
+import renderHelmetTag from "./renderHelmetTag";
+import { getStaticRouteMeta } from "./staticRouteMetaExports";
+import { getMetaTagsFromData } from "./metaTagUtils";
+
+export default function RouteSpecificMeta() {
+  const location = useLocation();
+  const pathname = (location?.pathname || "/").replace(/\/$/, "") || "/";
+  const routeMeta = getStaticRouteMeta(pathname);
+
+  if (!routeMeta) return null;
+
+  const meta = getMetaTagsFromData(routeMeta);
+  const tags = meta && Array.isArray(meta.tags) ? meta.tags : [];
+  const schema = routeMeta.schema ? JSON.stringify(routeMeta.schema).replace(/</g, "\\u003c") : "";
+
+  return (
+    <Helmet>
+      {tags.map(renderHelmetTag)}
+      {schema ? <script type="application/ld+json">{schema}</script> : null}
+    </Helmet>
+  );
+}

--- a/src/components/seo/metaTagUtils.js
+++ b/src/components/seo/metaTagUtils.js
@@ -1,6 +1,6 @@
 const { getSiteSeoForRoute } = require("./siteSeoConfig");
 
-const SITE_BASE_URL = "https://www.northsidegta.ca";
+const SITE_BASE_URL = "https://northsidegta.ca";
 const DEFAULT_META_IMAGE_PATH = "/Images/og-home.jpg";
 const DEFAULT_TWITTER_CARD = "summary_large_image";
 const SOCIAL_IMAGE_WIDTH = "1200";
@@ -80,6 +80,10 @@ function isAbsoluteUrl(value) {
   return /^https?:\/\//i.test(value);
 }
 
+function normalizeNorthsideUrl(value) {
+  return safeString(value).replace(/^https:\/\/www\.northsidegta\.ca/i, SITE_BASE_URL);
+}
+
 function normalizeCanonicalUrl(value, routeValue) {
   const provided = safeString(value);
   if (provided) {
@@ -94,7 +98,7 @@ function buildAbsoluteUrl(value) {
   const trimmed = safeString(value);
   if (!trimmed) return "";
   if (isAbsoluteUrl(trimmed)) {
-    return trimmed;
+    return normalizeNorthsideUrl(trimmed);
   }
   if (trimmed.startsWith("//")) {
     return `https:${trimmed}`;
@@ -154,7 +158,7 @@ function normalizeImageCandidate(candidate) {
 
   if (isAbsoluteUrl(value)) {
     try {
-      return new URL(value).toString();
+      return normalizeNorthsideUrl(new URL(value).toString());
     } catch (error) {
       return "";
     }
@@ -186,7 +190,7 @@ function normalizeAdditionalMeta(additionalMeta) {
 
 function getMetaTagsFromData(raw = {}) {
   const routeValue = safeString(raw.route);
-  const siteSeo = routeValue ? getSiteSeoForRoute(routeValue) : null;
+  const siteSeo = raw.ignoreSiteSeo ? null : (routeValue ? getSiteSeoForRoute(routeValue) : null);
   const siteSeoTitle = safeString(siteSeo && siteSeo.seo_title);
   const siteSeoDescription = safeString(siteSeo && siteSeo.seo_description);
   const siteSeoImage = safeString(siteSeo && siteSeo.seo_image);

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -2,23 +2,25 @@ import { BUYERS_SCHEMA } from "./buyersSchema.mjs";
 
 const DEFAULT_GLOBAL_META_CONFIG = {
   route: "/",
-  documentTitle: "NorthSide GTA Real Estate | Buy & Sell North of Toronto | Finally Home Agents",
-  title: "NorthSide GTA Real Estate | Buy & Sell North of Toronto | Finally Home Agents",
+  documentTitle: "NorthSide GTA Real Estate | Finally Home Agents",
+  title: "NorthSide GTA Real Estate | Finally Home Agents",
   description:
-    "Buy or sell north of Toronto with Finally Home Agents. Explore NorthSide GTA real estate, homes, market data, and community guidance across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog.",
-  canonicalUrl: "https://www.northsidegta.ca/",
+    "Buy or sell north of Toronto with Finally Home Agents. Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.",
+  canonicalUrl: "https://northsidegta.ca/",
   ogType: "website",
-  ogImage: "https://www.northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg",
+  ogImage: "https://northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg",
   ogImageAlt:
     "Interactive NorthSide GTA real estate map showing Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog",
   twitterCard: "summary_large_image",
-  twitterImage: "https://www.northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg",
+  twitterImage: "https://northsidegta.ca/uploads/northside-gta-finally-home-agents-hero.jpg",
   twitterImageAlt:
     "Interactive NorthSide GTA real estate map showing Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog",
   siteName: "NorthSide GTA",
   additionalMeta: [
     { name: "robots", content: "index, follow" },
     { property: "og:locale", content: "en_CA" },
+    { name: "author", content: "Finally Home Agents" },
+    { name: "publisher", content: "Finally Home Agents" },
     { name: "twitter:site", content: "@northsidegta" },
     { name: "facebook-domain-verification", content: "1tfwypal0s72obxs9238figl03nk5i" },
     { name: "geo.region", content: "CA-ON" },
@@ -49,11 +51,11 @@ const STATIC_ROUTE_META_CONFIGS = [
       title: "Lower-Priced Keswick Homes | NorthSide GTA",
       description:
         "Browse current lower-priced homes in Keswick and Georgina. See price bands, local market notes, and get alerts for new opportunities north of Toronto.",
-      canonicalUrl: "https://www.northsidegta.ca/keswick-lower-priced-homes",
+      canonicalUrl: "https://northsidegta.ca/keswick-lower-priced-homes",
       ogType: "website",
-      ogImage: "https://www.northsidegta.ca/Images/seo/keswick-lower-priced-homes-og.jpg",
+      ogImage: "https://northsidegta.ca/Images/seo/keswick-lower-priced-homes-og.jpg",
       twitterCard: "summary_large_image",
-      twitterImage: "https://www.northsidegta.ca/Images/seo/keswick-lower-priced-homes-og.jpg",
+      twitterImage: "https://northsidegta.ca/Images/seo/keswick-lower-priced-homes-og.jpg",
       siteName: "NorthSide GTA",
     },
   },
@@ -406,6 +408,160 @@ const STATIC_ROUTE_META_CONFIGS = [
   },
 ];
 
+const SITE_URL = "https://northsidegta.ca";
+const AUTHOR_PUBLISHER_META = [
+  { name: "author", content: "Finally Home Agents" },
+  { name: "publisher", content: "Finally Home Agents" },
+];
+const INDEX_META = [{ name: "robots", content: "index, follow" }, ...AUTHOR_PUBLISHER_META];
+const NOINDEX_META = [{ name: "robots", content: "noindex, follow" }, ...AUTHOR_PUBLISHER_META];
+const CORE_TOWNS = ["Georgina", "East Gwillimbury", "Newmarket", "Aurora", "Stouffville", "Uxbridge", "Scugog"];
+const COMMUNITY_IMAGE = `${SITE_URL}/uploads/community-page-seo.jpg`;
+const HOME_IMAGE = `${SITE_URL}/uploads/northside-gta-finally-home-agents-hero.jpg`;
+const SELLERS_IMAGE = `${SITE_URL}/uploads/sellers-page-seo.jpg`;
+
+function areaServedPlaces(townNames = CORE_TOWNS) {
+  return townNames.map((name) => ({ "@type": "Place", name: `${name}, Ontario` }));
+}
+
+function breadcrumbSchema(path, label) {
+  const url = `${SITE_URL}${path === "/" ? "/" : path}`;
+  const items = [{ "@type": "ListItem", position: 1, name: "Home", item: `${SITE_URL}/` }];
+  if (path !== "/") {
+    if (path.startsWith("/communities/")) {
+      items.push({ "@type": "ListItem", position: 2, name: "Communities", item: `${SITE_URL}/communities` });
+      items.push({ "@type": "ListItem", position: 3, name: label, item: url });
+    } else {
+      items.push({ "@type": "ListItem", position: 2, name: label, item: url });
+    }
+  }
+  return { "@type": "BreadcrumbList", "@id": `${url}#breadcrumb`, itemListElement: items };
+}
+
+function baseAgentNode() {
+  return {
+    "@type": ["RealEstateAgent", "LocalBusiness"],
+    "@id": `${SITE_URL}/#finally-home-agents`,
+    name: "Finally Home Agents",
+    alternateName: "NorthSide GTA",
+    url: SITE_URL,
+    brand: { "@type": "Brand", name: "NorthSide GTA", url: SITE_URL },
+    parentOrganization: { "@type": "Organization", name: "HomeLife Optimum Realty, Brokerage" },
+    employee: [{ "@type": "Person", name: "Matthew Mulhall" }, { "@type": "Person", name: "Landon Mulhall" }],
+    areaServed: areaServedPlaces(),
+  };
+}
+
+function makePageSchema({ path, title, description, pageType = "WebPage", image, serviceType, collectionItems, town }) {
+  const url = `${SITE_URL}${path === "/" ? "/" : path}`;
+  const label = town || (path === "/" ? "Home" : title.split("|")[0].trim());
+  const graph = [baseAgentNode(), {
+    "@type": path === "/" ? "WebSite" : pageType,
+    "@id": path === "/" ? `${SITE_URL}/#website` : `${url}#webpage`,
+    url,
+    name: title,
+    description,
+    inLanguage: "en-CA",
+    publisher: { "@id": `${SITE_URL}/#finally-home-agents` },
+    image,
+  }];
+  if (path !== "/") graph.push(breadcrumbSchema(path, label));
+  if (serviceType) {
+    graph.push({
+      "@type": "Service",
+      "@id": `${url}#service`,
+      name: serviceType,
+      serviceType,
+      url,
+      provider: { "@id": `${SITE_URL}/#finally-home-agents` },
+      areaServed: areaServedPlaces(town ? [town] : CORE_TOWNS),
+      description,
+    });
+  }
+  if (collectionItems) {
+    graph.push({
+      "@type": "ItemList",
+      "@id": `${url}#itemlist`,
+      name: "NorthSide GTA Communities",
+      itemListElement: collectionItems.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: item.name,
+        url: `${SITE_URL}${item.path}`,
+      })),
+    });
+  }
+  return { "@context": "https://schema.org", "@graph": graph };
+}
+
+function routeMeta({ route, title, description, image, robots = "index, follow", pageType = "WebPage", schema, serviceType, collectionItems, town }) {
+  const canonicalUrl = `${SITE_URL}${route === "/" ? "/" : route}`;
+  return {
+    route,
+    ignoreSiteSeo: true,
+    documentTitle: title,
+    title,
+    description,
+    canonicalUrl,
+    ogType: pageType === "Article" ? "article" : "website",
+    ogImage: image,
+    twitterCard: "summary_large_image",
+    twitterImage: image,
+    siteName: "NorthSide GTA",
+    additionalMeta: [
+      { name: "robots", content: robots },
+      { property: "og:locale", content: "en_CA" },
+      ...AUTHOR_PUBLISHER_META,
+    ],
+    schema: schema || makePageSchema({ path: route, title, description, pageType, image, serviceType, collectionItems, town }),
+  };
+}
+
+const COMMUNITY_ITEMS = [
+  { name: "Georgina", path: "/communities/georgina" },
+  { name: "East Gwillimbury", path: "/communities/east-gwillimbury" },
+  { name: "Newmarket", path: "/communities/newmarket" },
+  { name: "Aurora", path: "/communities/aurora" },
+  { name: "Stouffville", path: "/communities/stouffville" },
+  { name: "Uxbridge", path: "/communities/uxbridge" },
+  { name: "Scugog", path: "/communities/scugog" },
+];
+
+const TOWN_REMEDIATION = [
+  ["/communities/georgina", "Georgina", "Georgina Real Estate | Buying & Selling in Georgina | Finally Home Agents", "Buy or sell in Georgina with Finally Home Agents. Compare Keswick, Sutton, Jackson's Point, lake access, local market trends, and NorthSide GTA lifestyle fit."],
+  ["/communities/east-gwillimbury", "East Gwillimbury", "East Gwillimbury Real Estate | Finally Home Agents", "Buy or sell in East Gwillimbury with Finally Home Agents. Compare Holland Landing, Sharon, Queensville, Mount Albert, commute options, and local market fit."],
+  ["/communities/newmarket", "Newmarket", "Newmarket Real Estate | Buying & Selling in Newmarket | Finally Home Agents", "Buy or sell in Newmarket with Finally Home Agents. Compare Main Street, GO Transit access, schools, established neighbourhoods, and local market trends."],
+  ["/communities/aurora", "Aurora", "Aurora Real Estate | Buying & Selling in Aurora | Finally Home Agents", "Buy or sell in Aurora with Finally Home Agents. Compare established neighbourhoods, schools, GO Transit access, luxury homes, and NorthSide GTA market trends."],
+  ["/communities/stouffville", "Stouffville", "Stouffville Real Estate | Buying & Selling in Stouffville | Finally Home Agents", "Buy or sell in Stouffville with Finally Home Agents. Compare family neighbourhoods, Main Street, GO Transit, newer homes, and Whitchurch-Stouffville market trends."],
+  ["/communities/uxbridge", "Uxbridge", "Uxbridge Real Estate | Buying & Selling in Uxbridge | Finally Home Agents", "Buy or sell in Uxbridge with Finally Home Agents. Compare trails, golf, rural properties, family neighbourhoods, and NorthSide GTA market trends."],
+  ["/communities/scugog", "Scugog", "Scugog Real Estate | Port Perry Homes | Finally Home Agents", "Buy or sell in Scugog with Finally Home Agents. Compare Port Perry, Lake Scugog, waterfront homes, small-town lifestyle, and local market trends."],
+];
+
+const SEO_REMEDIATION_ROUTE_META_CONFIGS = [
+  { route: "/", meta: routeMeta({ route: "/", title: "NorthSide GTA Real Estate | Finally Home Agents", description: "Buy or sell north of Toronto with Finally Home Agents. Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.", image: HOME_IMAGE, pageType: "WebSite" }) },
+  { route: "/buyers", meta: routeMeta({ route: "/buyers", title: "Buying a Home North of Toronto | Finally Home Agents", description: "Buying north of Toronto? Compare Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog with local buyer guidance.", image: `${SITE_URL}/uploads/buyers-page-seo.jpg`, schema: BUYERS_SCHEMA }) },
+  { route: "/sellers", meta: routeMeta({ route: "/sellers", title: "Selling Your Home in the NorthSide GTA | Finally Home Agents", description: "Thinking about selling in Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, or Scugog? Get local pricing, media, and strategy.", image: SELLERS_IMAGE, serviceType: "Seller representation" }) },
+  { route: "/communities", meta: routeMeta({ route: "/communities", title: "NorthSide GTA Communities | Compare Towns North of Toronto", description: "Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog with Finally Home Agents.", image: COMMUNITY_IMAGE, pageType: "CollectionPage", collectionItems: COMMUNITY_ITEMS }) },
+  { route: "/contact", meta: routeMeta({ route: "/contact", title: "Contact Finally Home Agents | NorthSide GTA Real Estate", description: "Contact Matthew and Landon Mulhall for buying, selling, and local real estate guidance across Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.", image: `${SITE_URL}/uploads/og-contact-northsidegta.jpg`, pageType: "ContactPage" }) },
+  { route: "/about", meta: routeMeta({ route: "/about", title: "About Finally Home Agents | NorthSide GTA Real Estate", description: "Meet Matthew and Landon Mulhall of Finally Home Agents, helping buyers and sellers across Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.", image: `${SITE_URL}/uploads/og-about-northsidegta.jpg` }) },
+  { route: "/homeanalysis", meta: routeMeta({ route: "/homeanalysis", title: "Get a Home Value Opinion | NorthSide GTA | Finally Home Agents", description: "Find out what your home in Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, or Scugog could sell for today.", image: SELLERS_IMAGE, serviceType: "Home value opinion" }) },
+  { route: "/sign", meta: routeMeta({ route: "/sign", title: "Work With Finally Home Agents | NorthSide GTA", description: "Share your buying or selling goals with Finally Home Agents for NorthSide GTA real estate guidance.", image: SELLERS_IMAGE, robots: "noindex, follow", serviceType: "Real estate consultation" }) },
+  { route: "/vip", meta: routeMeta({ route: "/vip", title: "VIP Listing Access | NorthSide GTA", description: "Private NorthSide GTA listing access for registered clients and invited buyers.", image: `${SITE_URL}/vip-hero.png`, robots: "noindex, follow", serviceType: "Private listing alerts" }) },
+  ...TOWN_REMEDIATION.map(([route, town, title, description]) => ({
+    route,
+    meta: routeMeta({ route, title, description, image: COMMUNITY_IMAGE, serviceType: `${town} real estate guidance`, town }),
+  })),
+];
+
+function mergeRouteMetaConfigs(baseConfigs, overrideConfigs) {
+  const routeToEntry = new Map();
+  [...baseConfigs, ...overrideConfigs].forEach((entry) => {
+    if (!entry || !entry.route || !entry.meta) return;
+    routeToEntry.set(entry.route, { route: entry.route, meta: entry.meta });
+  });
+  return Array.from(routeToEntry.values());
+}
+
 function cloneMeta(meta = {}) {
   return JSON.parse(JSON.stringify(meta));
 }
@@ -413,13 +569,15 @@ function cloneMeta(meta = {}) {
 export function getStaticRouteMeta(route) {
   if (!route) return null;
   const normalized = route === "/" ? "/" : `/${route.replace(/^\//, "")}`;
-  const entry = STATIC_ROUTE_META_CONFIGS.find((item) => item.route === normalized);
+  const entry = EFFECTIVE_STATIC_ROUTE_META_CONFIGS.find((item) => item.route === normalized);
   if (!entry) return null;
   return cloneMeta(entry.meta);
 }
 
 const CLONED_DEFAULT_GLOBAL_META_CONFIG = cloneMeta(DEFAULT_GLOBAL_META_CONFIG);
-const CLONED_STATIC_ROUTE_META_CONFIGS = STATIC_ROUTE_META_CONFIGS.map((item) => ({
+const EFFECTIVE_STATIC_ROUTE_META_CONFIGS = mergeRouteMetaConfigs(STATIC_ROUTE_META_CONFIGS, SEO_REMEDIATION_ROUTE_META_CONFIGS);
+
+const CLONED_STATIC_ROUTE_META_CONFIGS = EFFECTIVE_STATIC_ROUTE_META_CONFIGS.map((item) => ({
   route: item.route,
   meta: cloneMeta(item.meta),
 }));

--- a/src/lib/structuredData/globalGraph.js
+++ b/src/lib/structuredData/globalGraph.js
@@ -130,111 +130,6 @@ const PLACE_NODES = [
   containedInPlace: place.containedInPlace,
 }));
 
-const REVIEW_TEMPLATE = {
-  "@type": "Review",
-  reviewRating: {
-    "@type": "Rating",
-    ratingValue: "5",
-    bestRating: "5",
-  },
-  itemReviewed: { "@id": `${BASE_URL}/#finally-home-agents` },
-};
-
-const GOOGLE_REVIEWS = [
-  {
-    author: "Kevin Hickey",
-    body:
-      "Landon was fantastic—he toured dozens of homes with me, kept everything on budget, and was always available.",
-    datePublished: "2025-07-01",
-  },
-  {
-    author: "Glenn Tappenden",
-    body:
-      "Matthew and Landon handled multiple transactions for us with professionalism, quick replies, and great advice.",
-    datePublished: "2025-07-01",
-  },
-  {
-    author: "Ryan Porter",
-    body: "Matt was always available and guided us smoothly into our new place. Thanks for the help!",
-    datePublished: "2025-07-01",
-  },
-  {
-    author: "Susan Booth",
-    body:
-      "The Finally Home Agents team made selling straightforward and stress-free with clear communication throughout.",
-  },
-  {
-    author: "Logan Abernethy",
-    body:
-      "Responsive, knowledgeable, and friendly—Matthew made buying in the NorthSide GTA feel effortless.",
-  },
-  {
-    author: "Jessica Le",
-    body:
-      "Landon made renting stress-free, easy to communicate with, and incredibly thoughtful about my needs.",
-    datePublished: "2023-09-01",
-  },
-  {
-    author: "Tessa Conway",
-    body:
-      "Moving to a brand-new city felt easy with Landon guiding the rental process from start to finish.",
-    datePublished: "2024-01-01",
-  },
-  {
-    author: "Olivia Oprea",
-    body:
-      "Matthew found my dream home in a challenging market and negotiated a winning offer.",
-    datePublished: "2022-10-01",
-  },
-  {
-    author: "Arron Breen",
-    body:
-      "Matt sold our house above market and negotiated our forever home for less—highly recommend.",
-    datePublished: "2022-05-01",
-  },
-  {
-    author: "Dawn Rouse",
-    body:
-      "Honest guidance, organized showings, and great marketing. We felt supported every step of the way.",
-  },
-  {
-    author: "Glenn Tappenden",
-    body: "Thoughtful follow-up and detailed advice kept every deal on track.",
-  },
-].map((review) => ({
-  ...REVIEW_TEMPLATE,
-  author: { "@type": "Person", name: review.author },
-  reviewBody: review.body,
-  datePublished: review.datePublished,
-}));
-
-const FACEBOOK_RECOMMENDATIONS = [
-  "Sjeli Pearse",
-  "Michelle Revell",
-  "Sagen Pearse",
-  "Raul Tec",
-  "Tommy Hogan",
-  "Mike Kloepfer",
-  "Nickolas Goldring",
-  "Shane Oliver",
-  "Jordan Fontaine",
-  "Sara Saloojee",
-  "Nikki Moran",
-  "Samantha Smith",
-  "Reid Moran",
-  "Pankil Shah",
-  "Gary Semeniuk",
-  "Shiraz Griffin",
-  "Kyle Orlando",
-].map((name) => ({
-  ...REVIEW_TEMPLATE,
-  author: { "@type": "Person", name },
-  reviewBody:
-    "Recommended the Finally Home Agents team for their responsiveness, marketing, and care for clients across the NorthSide GTA.",
-}));
-
-const REVIEWS = [...GOOGLE_REVIEWS, ...FACEBOOK_RECOMMENDATIONS];
-
 export function buildGlobalGraph() {
   const logoUrl = `${BASE_URL}/Images/newtoolbar.png`;
   const northsideLogo = logoUrl;
@@ -275,19 +170,12 @@ export function buildGlobalGraph() {
       "https://www.tiktok.com/@northsidegta",
       "https://www.facebook.com/MGLMREALESTATE",
     ],
-    aggregateRating: {
-      "@type": "AggregateRating",
-      ratingValue: "5",
-      reviewCount: 11,
-      bestRating: "5",
-    },
-    review: REVIEWS,
   };
 
   const homelifeOptimum = {
     "@type": "Organization",
     "@id": `${BASE_URL}/#homelife-optimum`,
-    name: "HomeLife Optimum Realty",
+    name: "HomeLife Optimum Realty, Brokerage",
     address: finallyHomeAgents.address,
     sameAs: [],
   };

--- a/src/membership/NorthsidePassPreviewV2Page.jsx
+++ b/src/membership/NorthsidePassPreviewV2Page.jsx
@@ -91,7 +91,7 @@ const NorthsidePassPreviewV2Page = () => {
     <div className="min-h-screen bg-[#05070d] text-white">
       <Helmet>
         <title>NorthSide Pass — Preview V2</title>
-        <link rel="canonical" href="https://www.northsidegta.ca/northside-pass-preview-v2" />
+        <link rel="canonical" href="https://northsidegta.ca/northside-pass-preview-v2" />
       </Helmet>
 
       <HeaderShell />

--- a/src/membership/OptionFivePage.jsx
+++ b/src/membership/OptionFivePage.jsx
@@ -45,7 +45,7 @@ const OptionFivePage = () => {
     <div className="min-h-screen bg-slate-950 text-white">
       <Helmet>
         <title>NorthSide Pass — Membership</title>
-        <link rel="canonical" href="https://www.northsidegta.ca/northside-pass-preview" />
+        <link rel="canonical" href="https://northsidegta.ca/northside-pass-preview" />
       </Helmet>
 
       <HeaderShell />

--- a/src/membership/OptionFourPage.jsx
+++ b/src/membership/OptionFourPage.jsx
@@ -18,7 +18,7 @@ const OptionFourPage = () => {
     <div className="min-h-screen bg-slate-950 text-white">
       <Helmet>
         <title>NorthSide Pass — Option 4</title>
-        <link rel="canonical" href="https://www.northsidegta.ca/northside-pass-preview/option-4" />
+        <link rel="canonical" href="https://northsidegta.ca/northside-pass-preview/option-4" />
       </Helmet>
       <HeaderShell />
 

--- a/src/membership/OptionOnePage.jsx
+++ b/src/membership/OptionOnePage.jsx
@@ -14,7 +14,7 @@ const OptionOnePage = () => {
     <div className="min-h-screen bg-slate-950 text-white">
       <Helmet>
         <title>NorthSide Pass — Option 1</title>
-        <link rel="canonical" href="https://www.northsidegta.ca/northside-pass-preview/option-1" />
+        <link rel="canonical" href="https://northsidegta.ca/northside-pass-preview/option-1" />
       </Helmet>
       <HeaderShell />
 

--- a/src/membership/OptionThreePage.jsx
+++ b/src/membership/OptionThreePage.jsx
@@ -14,7 +14,7 @@ const OptionThreePage = () => {
     <div className="min-h-screen bg-slate-50 text-slate-900">
       <Helmet>
         <title>NorthSide Pass — Option 3</title>
-        <link rel="canonical" href="https://www.northsidegta.ca/northside-pass-preview/option-3" />
+        <link rel="canonical" href="https://northsidegta.ca/northside-pass-preview/option-3" />
       </Helmet>
       <HeaderShell />
 

--- a/src/membership/OptionTwoPage.jsx
+++ b/src/membership/OptionTwoPage.jsx
@@ -74,7 +74,7 @@ const OptionTwoPage = () => {
     <div className="min-h-screen bg-slate-50">
       <Helmet>
         <title>NorthSide Pass — Option 2</title>
-        <link rel="canonical" href="https://www.northsidegta.ca/northside-pass-preview/option-2" />
+        <link rel="canonical" href="https://northsidegta.ca/northside-pass-preview/option-2" />
       </Helmet>
       <HeaderShell />
 

--- a/src/vip.js
+++ b/src/vip.js
@@ -5,22 +5,22 @@ import HeaderShell from "./components/HeaderShell";
 
 const HELMET_CONTENT = (
   <Helmet>
-    <title>VIP Listing Alerts | NorthSide GTA Buyer Advantage</title>
+    <title>VIP Listing Access | NorthSide GTA</title>
     <meta
       name="description"
-      content="Get VIP alerts for NorthSide GTA listings and off-market opportunities across Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge & Scugog."
+      content="Private NorthSide GTA listing access for registered clients and invited buyers."
     />
-    <meta
-      name="keywords"
-      content="VIP listing alerts NorthSide GTA, off-market homes, buyer alerts, Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, Scugog"
-    />
-    <link rel="canonical" href="https://www.northsidegta.ca/vip" />
-
-    <meta property="og:title" content="VIP Listing Alerts | NorthSide GTA" />
-    <meta property="og:description" content="Be first to know about new and off-market opportunities." />
+    <meta name="robots" content="noindex, follow" />
+    <meta name="author" content="Finally Home Agents" />
+    <meta name="publisher" content="Finally Home Agents" />
+    <link rel="canonical" href="https://northsidegta.ca/vip" />
+    <meta property="og:title" content="VIP Listing Access | NorthSide GTA" />
+    <meta property="og:description" content="Private listing access for registered clients and invited buyers." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.northsidegta.ca/vip" />
-    <meta property="og:image" content="/Images/northsidegta-map-bg.jpg" />
+    <meta property="og:url" content="https://northsidegta.ca/vip" />
+    <meta property="og:image" content="https://northsidegta.ca/vip-hero.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:image" content="https://northsidegta.ca/vip-hero.png" />
   </Helmet>
 );
 

--- a/tests/schema-global.test.cjs
+++ b/tests/schema-global.test.cjs
@@ -17,7 +17,7 @@ function loadGraph(getGlobalGraphJson) {
   return parsed['@graph'] || []
 }
 
-test('global graph includes core identities and reviews', async () => {
+test('global graph includes core identities without review or aggregateRating schema', async () => {
   const { getGlobalGraphJson, PLACE_IDS } = await loadGraphModule()
   const graph = loadGraph(getGlobalGraphJson)
   const ids = new Set(graph.map((node) => node['@id']))
@@ -33,8 +33,9 @@ test('global graph includes core identities and reviews', async () => {
   )
 
   const business = graph.find((node) => node['@id'] === 'https://northsidegta.ca/#finally-home-agents')
-  assert.ok(Array.isArray(business?.review) && business.review.length >= 10)
-  assert.equal(business?.aggregateRating?.ratingValue, '5')
+  assert.ok(business, 'Finally Home Agents business node should exist')
+  assert.equal(business?.review, undefined)
+  assert.equal(business?.aggregateRating, undefined)
 })
 
 test('global graph exposes region, places, and relationships', async () => {


### PR DESCRIPTION
### Motivation
- The site is a Create‑React‑App SPA using `react-helmet-async` plus build-time utilities that generate static head fragments and a sitemap, and town pages previously fell back to homepage/site-level metadata or used `www` and SVG social images in raw HTML. 
- The goal was to ensure every SEO-critical route emits correct page-specific metadata in raw HTML (build output) and to make the metadata system a single source of truth with automated checks to prevent regressions.

### Description
- Centralized remediation: added a durable remediation layer merged into the existing `STATIC_ROUTE_META_CONFIGS` (new `SEO_REMEDIATION_ROUTE_META_CONFIGS`, `mergeRouteMetaConfigs`, and `EFFECTIVE_STATIC_ROUTE_META_CONFIGS`) and set `ignoreSiteSeo` to force route-specific overrides for critical pages and all seven town pages. 
- Canonical / image normalization: changed `SITE_BASE_URL` to `https://northsidegta.ca`, added URL normalization in `metaTagUtils.js` to force non‑www absolute URLs for `canonical`, `og:image`, and `twitter:image`, and removed SVGs as social images where necessary. 
- Per-route metadata emission: updated static generation flow to use the effective static meta configs (`scripts/generate-static-route-html.js` already present) and added `RouteSpecificMeta` React component and an App injection so route schema/tags are consistently produced; updated `SignWithUsPage`, `vip.js`, and `HomeAnalysisPage` Helmet blocks to use non‑www canonicals, author/publisher meta, and proper robots handling. 
- Structured data and schema: moved site JSON‑LD into build/inject pipeline and removed aggregateRating/review schema from global graph to comply with requirements; ensured `application/ld+json` is present in static HTML for site and page graphs. 
- Sitemap / robots: updated sitemap generation to list `/communities/<slug>` entries and updated `config/site.json` and injection script to use non‑www origin; `public/robots.txt` already references sitemap and remains permissive. 
- Validation tooling: added `scripts/seo-check.cjs` and `npm run seo:check` to validate built/raw HTML for all critical routes (title, description, canonical non‑www, og:url, og/image, twitter:image, robots, no keywords, JSON‑LD, town-specific differences). 

### Testing
- Ran unit/test suite: `npm test` (node --test) — 67 tests passed, 0 failed. 
- Built production output: `npm run build` — build completed and postbuild scripts executed (`generate-static-route-html`, `inject-homepage-static-html`, `generate-sitemap`), static route pages were created (31 pages) and sitemap updated. 
- SEO validation: `npm run seo:check` (new) executed against the local `build/` output and passed for all listed routes including homepage, `/buyers`, `/sellers`, `/communities`, `/homeanalysis`, all seven `/communities/<town>` routes, `/contact`, `/about`, `/sign`, and `/vip`. 
- Raw and rendered verification: static raw‑HTML checks on `build/.../index.html` files confirmed correct `title`, `meta[name=description]`, `link rel="canonical"` (non‑www), `meta[property=og:url]` matching canonical, `og:image` and `twitter:image` non‑www and not SVG, correct `robots`, no `meta[name=keywords]`, and JSON‑LD presence; Playwright rendering checks were performed against a locally served `build/` (headless browser install and host deps steps were executed) and confirmed browser DOM matches the static output for sampled routes. 

Known limitation: live site fetch attempts from this environment were blocked (outbound fetch returned 403), so all verification was performed against the local production build output generated by `npm run build`; if you want live-site verification I recommend running the included `seo:check` and the Playwright checks against the deployed URL in CI or from an environment with outbound access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2acb85b9ec8324aa511782672ac6ff)