### PR TITLE
Redesign homepage hero routing experience

### DIFF
--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -271,7 +271,7 @@ function BuyersFaqSection() {
   );
 }
 
-function TownMatchQuiz() {
+export function TownMatchQuiz({ variant = "buyers", onComplete } = {}) {
   const [step, setStep] = useState(0);
   const [answers, setAnswers] = useState([]);
   const [result, setResult] = useState(null);
@@ -297,7 +297,9 @@ function TownMatchQuiz() {
     const ranked = COMMUNITIES
       .map((town, index) => ({ town, score: scores[town], index }))
       .sort((a, b) => b.score - a.score || a.index - b.index);
-    setResult(ranked.slice(0, 3).map((item) => item.town));
+    const resultTowns = ranked.slice(0, 3).map((item) => item.town);
+    setResult(resultTowns);
+    onComplete?.(resultTowns);
   }
 
   function nextStep() {
@@ -322,19 +324,22 @@ function TownMatchQuiz() {
       <div className="quiz-card result-card">
         <div className="result-primary">
           <h3>{primary}</h3>
-          <p>Based on your answers, {primary} is your strongest fit.</p>
+          <p>{variant === "modal" ? `Looks like ${primary} could be a great fit.` : `Based on your answers, ${primary} is your strongest fit.`}</p>
           <ul>
             {primaryData.reasons.map((reason) => (
               <li key={reason}><span>✓</span>{reason}</li>
             ))}
           </ul>
-          <div className="result-conversion">
-            <strong>Want us to pressure-test this against your budget, commute, and timing?</strong>
-            <p>Send us your basics and we’ll build a practical NorthSide GTA shortlist around your actual move.</p>
-            <button type="button" onClick={() => scrollToSection("cta-section")}>Send me my town shortlist</button>
-          </div>
+          {variant !== "modal" && (
+            <div className="result-conversion">
+              <strong>Want us to pressure-test this against your budget, commute, and timing?</strong>
+              <p>Send us your basics and we’ll build a practical NorthSide GTA shortlist around your actual move.</p>
+              <button type="button" onClick={() => scrollToSection("cta-section")}>Send me my town shortlist</button>
+            </div>
+          )}
           <div className="result-actions secondary-actions">
             <a href={`/communities/${primaryData.slug}`}>Explore {primary} →</a>
+            {variant === "modal" && <a href="/contact">Talk to Matt &amp; Landon →</a>}
           </div>
         </div>
         <div className="also-like">

--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -1582,3 +1582,79 @@ main { padding-top: 0; }
 .town-match-modal .also-card p { margin: 0 0 8px; color: #6f6655; font-size: 13px; }
 .town-match-modal .also-card a, .town-match-modal .result-actions a { border-radius: 6px; border: 1px solid #1a3a08; padding: 10px 12px; color: #1a3a08; font-weight: 700; text-decoration: none; }
 .town-match-modal .retake-button { margin-top: 16px; border: 0; background: transparent; color: #1a3a08; font-weight: 700; cursor: pointer; }
+
+/* Homepage hero v2 refinements: video background + viewport-fit sizing. */
+@media (min-width: 1024px) {
+  .hero__grid {
+    grid-template-columns: 50% 50%;
+    height: calc(100vh - 80px - 45px - 137px);
+    min-height: 480px;
+    max-height: 680px;
+  }
+}
+
+.hero__copy {
+  background: #0a1604;
+}
+
+.agent-video,
+.hero__video-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.agent-video {
+  object-fit: cover;
+  object-position: right center;
+  mix-blend-mode: multiply;
+  opacity: 0.9;
+}
+.agent-video img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: right center;
+}
+.hero__video-overlay--side {
+  background: linear-gradient(to right, rgba(10, 22, 4, 0.96) 0%, rgba(10, 22, 4, 0.88) 35%, rgba(10, 22, 4, 0.62) 60%, rgba(10, 22, 4, 0.28) 100%);
+}
+.hero__video-overlay--bottom {
+  background: linear-gradient(to bottom, rgba(10, 22, 4, 0.0) 0%, rgba(10, 22, 4, 0.0) 55%, rgba(10, 22, 4, 0.55) 100%);
+}
+.hero__copy-inner { justify-content: space-between; }
+.hero__intro { max-width: 280px; }
+.hero__divider { width: 36px; background: rgba(125, 196, 90, 0.45); margin: 22px 0; }
+.hero__agents-label { font-size: 9.5px; color: #7dc45a; }
+.hero__agents-title { font-size: 18px; font-weight: 800; }
+.hero__agents-copy { max-width: 300px; font-size: 13px; color: rgba(255,255,255,0.52); }
+.hero__agents-attribution { font-size: 10px; color: rgba(255,255,255,0.28); }
+.hero-badges { gap: 8px; }
+.hero-badge { display: flex; align-items: center; gap: 8px; background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.11); border-radius: 8px; padding: 8px 13px; }
+
+.options-bar { border-bottom: 2px solid rgba(0,0,0,0.1); }
+.opt { padding: 16px 22px; }
+.opt-tag { font-size: 9px; }
+.opt-title { font-size: 15px; font-weight: 800; }
+.opt--guided {
+  background: linear-gradient(135deg, #1a3a08 0%, #2d5a14 100%);
+  border-left: 3px solid #7dc45a;
+  border-right: 1px solid rgba(0,0,0,0.15);
+}
+.opt--guided:hover { background: linear-gradient(135deg, #1e4409 0%, #336618 100%); }
+.opt--guided .opt-tag { color: rgba(125,196,90,0.7); }
+.opt--self { background: #faf6ef; position: relative; color: #1a1a1a; }
+.opt--self:hover { background: #f2ece1; }
+.opt--self .opt-tag { color: #8a9a7a; }
+.opt-action__arrow { display: inline-block; animation: bounceDown 1.4s ease-in-out infinite; }
+@keyframes bounceDown { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(4px); } }
+.map-pulse { box-shadow: 0 0 0 3px rgba(125, 196, 90, 0.6); transition: box-shadow 0.3s ease; }
+.town-match-modal__panel { animation: modalSlide 0.25s ease-out both; }
+@keyframes modalSlide { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+
+@media (max-width: 767px) {
+  .hero__grid { height: auto; max-height: none; }
+  .hero__copy-inner { min-height: 520px; }
+  .agent-video { object-position: right center; }
+}

--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -1658,3 +1658,59 @@ main { padding-top: 0; }
   .hero__copy-inner { min-height: 520px; }
   .agent-video { object-position: right center; }
 }
+
+/* Production hero bug fixes: isolate media layers and keep logo rail clean/visible. */
+.hero__grid {
+  overflow: hidden;
+}
+
+.hero__copy {
+  isolation: isolate;
+  background: #0a1604;
+}
+
+.agent-video {
+  z-index: 0;
+  display: block;
+}
+
+.hero__video-overlay {
+  z-index: 1;
+}
+
+.hero__copy-inner {
+  z-index: 2;
+}
+
+.hero__intro {
+  max-width: 260px;
+}
+
+@media (min-width: 1024px) {
+  .hero__grid {
+    height: calc(100vh - 81px - 48px);
+    min-height: 480px;
+    max-height: 680px;
+  }
+
+  .hero__copy,
+  .hero__map-panel {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .hero__map-frame {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .focus-community-rail__track {
+    overflow-x: auto;
+  }
+
+  .focus-community-rail__tile {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 88px;
+  }
+}

--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -1495,3 +1495,90 @@ main { padding-top: 0; }
   cursor: wait;
   opacity: 0.68;
 }
+
+.hero__photo,
+.hero__photo-overlay,
+.hero__photo-vignette {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.hero__photo { object-fit: cover; object-position: center 12%; }
+.hero__photo-overlay {
+  background: linear-gradient(to bottom, rgba(12, 24, 5, 0.78) 0%, rgba(12, 24, 5, 0.62) 38%, rgba(12, 24, 5, 0.70) 65%, rgba(12, 24, 5, 0.88) 100%);
+}
+.hero__photo-vignette { background: linear-gradient(to right, rgba(12,24,5,0.4) 0%, transparent 60%); }
+.hero__copy-inner { position: relative; z-index: 1; height: 100%; display: flex; flex-direction: column; justify-content: center; }
+.hero__divider { width: 40px; height: 2px; background: rgba(125, 196, 90, 0.4); margin: 28px 0; }
+.hero__agents-label { margin: 0 0 12px; color: #7dc45a; font-size: 10px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase; }
+.hero__agents-title { margin: 0; color: #fff; font-family: var(--font-ui); font-size: 20px; font-weight: 700; line-height: 1.2; }
+.hero__agents-copy { margin: 14px 0 0; max-width: 520px; color: rgba(255,255,255,0.72); font-size: 15px; line-height: 1.55; }
+.hero__agents-attribution { margin: 26px 0 0; color: rgba(255,255,255,0.42); font-size: 12px; letter-spacing: 0.02em; }
+
+.options-bar { display: grid; grid-template-columns: 1fr 1fr; border-bottom: 1px solid rgba(0,0,0,0.08); flex-shrink: 0; }
+.opt { border: 0; padding: 20px 24px; cursor: pointer; display: flex; flex-direction: column; align-items: flex-start; text-align: left; gap: 6px; transition: background 0.18s; font-family: var(--font-ui); }
+.opt-tag { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.13em; }
+.opt-title { font-size: 14px; font-weight: 700; line-height: 1.25; letter-spacing: -0.01em; }
+.opt-action { font-size: 11px; font-weight: 700; margin-top: 4px; display: inline-flex; align-items: center; gap: 5px; transition: gap 0.15s; }
+.opt:hover .opt-action { gap: 8px; }
+.opt--guided { background: #1a3a08; color: #fff; }
+.opt--guided:hover { background: #1e4409; }
+.opt--guided .opt-tag { color: rgba(255,255,255,0.58); }
+.opt--guided .opt-action { color: #7dc45a; }
+.opt--self { background: #f5f2ec; color: #1f241b; }
+.opt--self:hover { background: #eee9e0; }
+.opt--self .opt-tag { color: #8a987f; }
+.opt--self .opt-action { color: #1a3a08; }
+
+.hero__map-frame--pulse { animation: mapHeroPulse 1.5s ease; }
+@keyframes mapHeroPulse { 0%,100% { box-shadow: inset 0 0 0 0 rgba(125,196,90,0); } 25%,75% { box-shadow: inset 0 0 0 8px rgba(125,196,90,0.45); } }
+
+.town-match-modal { position: fixed; inset: 0; z-index: 1000; display: flex; justify-content: center; align-items: center; padding: 24px; background: rgba(0,0,0,0.55); animation: modalFade 180ms ease both; }
+.town-match-modal__panel { position: relative; width: min(100%, 520px); max-height: min(92vh, 760px); overflow: auto; background: #f9f7f2; border-radius: 18px; padding: 28px; box-shadow: 0 28px 90px rgba(0,0,0,0.32); animation: modalSlide 220ms ease both; }
+.town-match-modal__close { position: absolute; top: 12px; right: 14px; border: 0; background: transparent; color: #1a3a08; font-size: 30px; line-height: 1; cursor: pointer; }
+.town-match-modal__eyebrow { margin: 0 0 8px; color: #1a3a08; font-size: 10px; font-weight: 800; letter-spacing: 0.18em; text-transform: uppercase; }
+.town-match-modal__panel h2 { margin: 0 34px 18px 0; color: #101a0c; font-family: var(--font-serif); font-size: 30px; line-height: 1.05; }
+.town-match-modal .quiz-card { max-width: none; box-shadow: none; }
+.town-match-modal .result-actions { display: flex; flex-wrap: wrap; gap: 10px; }
+.town-match-modal .result-actions a:first-child { background: #1a3a08; color: #fff; }
+.town-match-modal__buyers-link { display: inline-flex; margin-top: 14px; color: #1a3a08; font-size: 13px; font-weight: 700; text-decoration: none; }
+@keyframes modalFade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes modalSlide { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: translateY(0); } }
+
+@media (min-width: 1024px) { .hero__copy { min-height: 720px; } }
+@media (max-width: 767px) {
+  .hero__copy { min-height: 280px; }
+  .hero__heading { font-size: clamp(2rem, 11vw, 3rem); }
+  .hero-badges { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .options-bar { grid-template-columns: 1fr; }
+}
+@media (max-width: 640px) {
+  .town-match-modal { padding: 0; align-items: stretch; }
+  .town-match-modal__panel { width: 100%; max-height: none; min-height: 100vh; border-radius: 0; }
+}
+.hero-badges { gap: 10px; margin-top: 0; }
+.hero-badge { border-radius: 8px; padding: 9px 14px; background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.12); gap: 10px; white-space: normal; text-decoration: none; }
+.hero-badge__text { display: flex; flex-direction: column; line-height: 1.05; }
+.hero-badge__text strong { color: #fff; font-size: 15px; font-weight: 800; }
+.hero-badge__text span { margin-top: 3px; color: rgba(255,255,255,0.55); font-size: 11px; font-weight: 500; }
+.town-match-modal .quiz-card { width: 100%; background: #fff; border: 1px solid #e3ded2; border-radius: 10px; padding: 24px; }
+.town-match-modal .quiz-progress { height: 2px; background: #e8e4db; margin-bottom: 16px; }
+.town-match-modal .quiz-progress span { display: block; height: 100%; background: #1a3a08; transition: width 180ms ease; }
+.town-match-modal .quiz-step { margin: 0 0 10px; color: #6f6655; font-size: 11px; }
+.town-match-modal .quiz-card h3 { margin: 0 0 18px; color: #1f241b; font-family: var(--font-serif); font-size: 24px; line-height: 1.2; }
+.town-match-modal .quiz-options { display: flex; flex-wrap: wrap; gap: 9px; margin-bottom: 22px; }
+.town-match-modal .quiz-options button { background: #f4efe5; border: 1px solid #ddd6c8; border-radius: 20px; padding: 8px 16px; color: #1f241b; font-size: 12.5px; cursor: pointer; }
+.town-match-modal .quiz-options button.selected { background: #1a3a08; color: #fff; border-color: #1a3a08; }
+.town-match-modal .quiz-next { background: #1a3a08; color: #fff; border: 0; border-radius: 6px; padding: 11px 22px; font-weight: 700; cursor: pointer; }
+.town-match-modal .quiz-next:disabled { opacity: 0.45; cursor: not-allowed; }
+.town-match-modal .result-primary ul { margin: 16px 0; padding: 0; list-style: none; display: grid; gap: 8px; color: #43513c; }
+.town-match-modal .result-primary li span { color: #1a3a08; margin-right: 8px; font-weight: 800; }
+.town-match-modal .also-like { margin-top: 18px; }
+.town-match-modal .also-grid { display: grid; gap: 10px; }
+.town-match-modal .also-card { border: 1px solid #e3ded2; border-radius: 8px; padding: 12px; }
+.town-match-modal .also-card h4 { margin: 0 0 4px; }
+.town-match-modal .also-card p { margin: 0 0 8px; color: #6f6655; font-size: 13px; }
+.town-match-modal .also-card a, .town-match-modal .result-actions a { border-radius: 6px; border: 1px solid #1a3a08; padding: 10px 12px; color: #1a3a08; font-weight: 700; text-decoration: none; }
+.town-match-modal .retake-button { margin-top: 16px; border: 0; background: transparent; color: #1a3a08; font-weight: 700; cursor: pointer; }

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -1,9 +1,11 @@
-import React, { useEffect } from "react";
+import React, { Suspense, lazy, useCallback, useEffect, useState } from "react";
 import DynamicMetaTags from "./components/seo/DynamicMetaTags";
 import "./HomePage.css";
 import HeaderShell from "./components/HeaderShell";
 
 import { HOMEPAGE_MARKUP } from "./homepageMarkup";
+
+const TownMatchModal = lazy(() => import("./components/modals/TownMatchModal"));
 
 const HOME_TITLE = "NorthSide GTA Real Estate | Buy & Sell North of Toronto | Finally Home Agents";
 const HOME_DESCRIPTION = "Buy or sell north of Toronto with Finally Home Agents. Explore NorthSide GTA real estate, homes, market data, and community guidance across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog.";
@@ -133,7 +135,30 @@ const structuredData = {
   ],
 };
 
+function trackHeroEvent(name, params) {
+  if (typeof window !== "undefined" && typeof window.gtag === "function") {
+    window.gtag("event", name, params);
+  }
+}
+
 export default function HomePage() {
+  const [isTownMatchOpen, setIsTownMatchOpen] = useState(false);
+  const [quizCompleted, setQuizCompleted] = useState(false);
+
+  const openTownMatch = useCallback(() => {
+    trackHeroEvent("hero_option_click", { option: "guided", label: "Help me find the right town" });
+    trackHeroEvent("quiz_modal_open", { source: "homepage_hero" });
+    setQuizCompleted(false);
+    setIsTownMatchOpen(true);
+  }, []);
+
+  const closeTownMatch = useCallback(() => {
+    if (!quizCompleted) {
+      trackHeroEvent("quiz_modal_dismiss", { source: "homepage_hero" });
+    }
+    setIsTownMatchOpen(false);
+  }, [quizCompleted]);
+
   useEffect(() => {
     function animateCounter(el) {
       const target = parseFloat(el.dataset.target);
@@ -219,11 +244,32 @@ export default function HomePage() {
 
     form?.addEventListener("submit", handleLeadSubmit);
 
+    function handleHeroOptionClick(event) {
+      const guided = event.target.closest?.("[data-hero-option='guided']");
+      const selfGuided = event.target.closest?.("[data-hero-option='self-guided']");
+
+      if (guided) {
+        openTownMatch();
+        return;
+      }
+
+      if (selfGuided) {
+        trackHeroEvent("hero_option_click", { option: "self_guided", label: "Browse the Map Below" });
+        const mapFrame = document.getElementById("northside-map-container");
+        mapFrame?.scrollIntoView({ behavior: "smooth", block: "center" });
+        mapFrame?.classList.add("hero__map-frame--pulse");
+        window.setTimeout(() => mapFrame?.classList.remove("hero__map-frame--pulse"), 1500);
+      }
+    }
+
+    document.addEventListener("click", handleHeroOptionClick);
+
     return () => {
       observer?.disconnect();
       form?.removeEventListener("submit", handleLeadSubmit);
+      document.removeEventListener("click", handleHeroOptionClick);
     };
-  }, []);
+  }, [openTownMatch]);
 
   return (
     <>
@@ -257,6 +303,11 @@ export default function HomePage() {
       </DynamicMetaTags>
       <HeaderShell />
       <div className="homepage-v4" dangerouslySetInnerHTML={{ __html: HOMEPAGE_MARKUP }} />
+      {isTownMatchOpen && (
+        <Suspense fallback={null}>
+          <TownMatchModal isOpen={isTownMatchOpen} onClose={closeTownMatch} onComplete={() => setQuizCompleted(true)} />
+        </Suspense>
+      )}
     </>
   );
 }

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -257,8 +257,8 @@ export default function HomePage() {
         trackHeroEvent("hero_option_click", { option: "self_guided", label: "Browse the Map Below" });
         const mapFrame = document.getElementById("northside-map-container");
         mapFrame?.scrollIntoView({ behavior: "smooth", block: "center" });
-        mapFrame?.classList.add("hero__map-frame--pulse");
-        window.setTimeout(() => mapFrame?.classList.remove("hero__map-frame--pulse"), 1500);
+        mapFrame?.classList.add("map-pulse");
+        window.setTimeout(() => mapFrame?.classList.remove("map-pulse"), 1500);
       }
     }
 
@@ -305,7 +305,15 @@ export default function HomePage() {
       <div className="homepage-v4" dangerouslySetInnerHTML={{ __html: HOMEPAGE_MARKUP }} />
       {isTownMatchOpen && (
         <Suspense fallback={null}>
-          <TownMatchModal isOpen={isTownMatchOpen} onClose={closeTownMatch} onComplete={() => setQuizCompleted(true)} />
+          <TownMatchModal
+            isOpen={isTownMatchOpen}
+            onClose={closeTownMatch}
+            onComplete={(resultTowns) => {
+              const [townName] = resultTowns || [];
+              setQuizCompleted(true);
+              trackHeroEvent("quiz_complete", { source: "homepage_hero", quiz_result: townName });
+            }}
+          />
         </Suspense>
       )}
     </>

--- a/src/components/modals/TownMatchModal.js
+++ b/src/components/modals/TownMatchModal.js
@@ -1,18 +1,62 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { TownMatchQuiz } from "../../BuyersPage";
 
+const FOCUSABLE_SELECTOR = [
+  "button",
+  "[href]",
+  "input",
+  "select",
+  "textarea",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
 export default function TownMatchModal({ isOpen, onClose, onComplete }) {
+  const closeButtonRef = useRef(null);
+  const modalPanelRef = useRef(null);
+  const previouslyFocusedRef = useRef(null);
+
   useEffect(() => {
     if (!isOpen) return undefined;
+
+    previouslyFocusedRef.current = document.activeElement;
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
+    closeButtonRef.current?.focus();
+
     const onKeyDown = (event) => {
-      if (event.key === "Escape") onClose?.();
+      if (event.key === "Escape") {
+        onClose?.();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusableElements = Array.from(
+        modalPanelRef.current?.querySelectorAll(FOCUSABLE_SELECTOR) || []
+      ).filter((element) => !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true");
+
+      if (!focusableElements.length) {
+        event.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
     };
+
     window.addEventListener("keydown", onKeyDown);
     return () => {
       document.body.style.overflow = previousOverflow;
       window.removeEventListener("keydown", onKeyDown);
+      previouslyFocusedRef.current?.focus?.();
     };
   }, [isOpen, onClose]);
 
@@ -21,13 +65,14 @@ export default function TownMatchModal({ isOpen, onClose, onComplete }) {
   return (
     <div className="town-match-modal" role="presentation" onMouseDown={onClose}>
       <div
+        ref={modalPanelRef}
         className="town-match-modal__panel"
         role="dialog"
         aria-modal="true"
         aria-labelledby="town-match-modal-title"
         onMouseDown={(event) => event.stopPropagation()}
       >
-        <button className="town-match-modal__close" type="button" aria-label="Close Town Match quiz" onClick={onClose}>×</button>
+        <button ref={closeButtonRef} className="town-match-modal__close" type="button" aria-label="Close Town Match quiz" onClick={onClose}>×</button>
         <p className="town-match-modal__eyebrow">Town Match Quiz</p>
         <h2 id="town-match-modal-title">Find your NorthSide town fit.</h2>
         <TownMatchQuiz variant="modal" onComplete={onComplete} />

--- a/src/components/modals/TownMatchModal.js
+++ b/src/components/modals/TownMatchModal.js
@@ -1,0 +1,38 @@
+import React, { useEffect } from "react";
+import { TownMatchQuiz } from "../../BuyersPage";
+
+export default function TownMatchModal({ isOpen, onClose, onComplete }) {
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="town-match-modal" role="presentation" onMouseDown={onClose}>
+      <div
+        className="town-match-modal__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="town-match-modal-title"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <button className="town-match-modal__close" type="button" aria-label="Close Town Match quiz" onClick={onClose}>×</button>
+        <p className="town-match-modal__eyebrow">Town Match Quiz</p>
+        <h2 id="town-match-modal-title">Find your NorthSide town fit.</h2>
+        <TownMatchQuiz variant="modal" onComplete={onComplete} />
+        <a className="town-match-modal__buyers-link" href="/buyers">Visit the buyers guide for more detail →</a>
+      </div>
+    </div>
+  );
+}

--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -7,46 +7,63 @@ export const HOMEPAGE_MARKUP = String.raw`
 
       
       <div class="hero__copy hero-animate">
-        <span class="hero__eyebrow">NorthSide GTA · Real Estate Platform</span>
+        <img class="hero__photo" src="/assets/homepage/matthew-landon-northside-gta.jpg" alt="" aria-hidden="true" fetchpriority="high">
+        <div class="hero__photo-overlay" aria-hidden="true"></div>
+        <div class="hero__photo-vignette" aria-hidden="true"></div>
+        <div class="hero__copy-inner">
+          <section class="hero__brand-section" aria-label="NorthSide GTA introduction">
+            <span class="hero__eyebrow">NorthSide GTA · Real Estate Platform</span>
 
-        <h1 class="hero__heading" id="hero-heading">
-          NorthSide GTA Real Estate,
-          <span class="hero__heading-em">Guided by Finally Home Agents.</span>
-        </h1>
+            <h1 class="hero__heading" id="hero-heading">
+              NorthSide GTA Real Estate,
+              <span class="hero__heading-em">Guided by Finally Home Agents.</span>
+            </h1>
 
-        <p class="hero__intro">
-          Buy or sell north of Toronto with Finally Home Agents across Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog — with trusted support in King, Bradford, Vaughan, Richmond Hill, Markham, Pickering, Ajax, Whitby, and Oshawa.
-        </p>
-        <p class="hero__sub">
-          Explore the communities, compare the lifestyle, and get clear guidance before your next move.
-        </p>
+            <p class="hero__intro">
+              Buy or sell north of Toronto with trusted local guidance — community by community, decision by decision.
+            </p>
+          </section>
 
-        <div class="hero__ctas">
-          <a href="/buyers" class="btn btn--green btn--lg">Start Your NorthSide Move <span aria-hidden>→</span></a>
-          <a href="#communities" class="btn btn--ghost btn--lg">Explore Communities</a>
-        </div>
+          <div class="hero__divider" aria-hidden="true"></div>
 
-        
-        <div class="hero-badges">
-          <a href="https://share.google/GJz2QTQ8GqZIifaNH" target="_blank" rel="noopener" class="hero-badge hero-badge--google" aria-label="5.0 Google Rating — view reviews">
-            <img src="/Images/google-logo.png" alt="Google" width="16" height="16">
-            <span>★ 5.0 Google Rating</span>
-            <span class="sr-only">Based on client reviews</span>
-          </a>
-          <span class="hero-badge">
-            <span aria-hidden="true">✓</span> RECO Licensed
-          </span>
-          <span class="hero-badge">
-            <span aria-hidden="true">📍</span> 7 Communities
-          </span>
-          <span class="hero-badge">
-            <span aria-hidden="true">🔄</span> Updated Monthly
-          </span>
+          <section class="hero__agents" aria-label="Meet Finally Home Agents">
+            <p class="hero__agents-label">Finally Home Agents</p>
+            <h2 class="hero__agents-title">Meet Matthew &amp; Landon Mulhall</h2>
+            <p class="hero__agents-copy">Two agents, seven communities, one focus — helping you find the right home north of Toronto before you start chasing listings.</p>
+            <p class="hero__agents-attribution">HomeLife Optimum Realty, Brokerage · Licensed by RECO</p>
+          </section>
+
+          <div class="hero-badges" aria-label="NorthSide GTA trust signals">
+            <a href="https://share.google/GJz2QTQ8GqZIifaNH" target="_blank" rel="noopener" class="hero-badge hero-badge--google" aria-label="5.0 Rating — Google Reviews">
+              <span class="hero-badge__icon" aria-hidden="true">⭐</span>
+              <span class="hero-badge__text"><strong>5.0 Rating</strong><span>Google Reviews</span></span>
+            </a>
+            <span class="hero-badge">
+              <span class="hero-badge__icon" aria-hidden="true">📍</span>
+              <span class="hero-badge__text"><strong>7 Communities</strong><span>North of Toronto</span></span>
+            </span>
+            <span class="hero-badge">
+              <span class="hero-badge__icon" aria-hidden="true">🔄</span>
+              <span class="hero-badge__text"><strong>Updated Monthly</strong><span>Market Data</span></span>
+            </span>
+          </div>
         </div>
       </div>
 
       
       <div class="hero__map-panel">
+        <div class="options-bar" aria-label="Choose how to explore NorthSide GTA towns">
+          <button class="opt opt--guided" type="button" data-hero-option="guided">
+            <span class="opt-tag">Guided path</span>
+            <span class="opt-title">Help me find the right town</span>
+            <span class="opt-action">Take the Town Match Quiz →</span>
+          </button>
+          <button class="opt opt--self" type="button" data-hero-option="self-guided">
+            <span class="opt-tag">Self-guided</span>
+            <span class="opt-title">I'll explore the towns myself</span>
+            <span class="opt-action">Browse the Map Below →</span>
+          </button>
+        </div>
         <div class="hero__map-header">
           <div>
             <p class="map-label">Explore the NorthSide GTA</p>

--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -7,9 +7,12 @@ export const HOMEPAGE_MARKUP = String.raw`
 
       
       <div class="hero__copy hero-animate">
-        <img class="hero__photo" src="/assets/homepage/matthew-landon-northside-gta.jpg" alt="" aria-hidden="true" fetchpriority="high">
-        <div class="hero__photo-overlay" aria-hidden="true"></div>
-        <div class="hero__photo-vignette" aria-hidden="true"></div>
+        <video autoplay loop muted playsinline aria-hidden="true" class="agent-video" poster="/assets/homepage/matthew-landon-northside-gta.jpg">
+          <source src="/assets/homepage/matthew-landon-hero.mp4" type="video/mp4">
+          <img src="/assets/homepage/matthew-landon-northside-gta.jpg" alt="" aria-hidden="true">
+        </video>
+        <div class="hero__video-overlay hero__video-overlay--side" aria-hidden="true"></div>
+        <div class="hero__video-overlay hero__video-overlay--bottom" aria-hidden="true"></div>
         <div class="hero__copy-inner">
           <section class="hero__brand-section" aria-label="NorthSide GTA introduction">
             <span class="hero__eyebrow">NorthSide GTA · Real Estate Platform</span>
@@ -54,14 +57,14 @@ export const HOMEPAGE_MARKUP = String.raw`
       <div class="hero__map-panel">
         <div class="options-bar" aria-label="Choose how to explore NorthSide GTA towns">
           <button class="opt opt--guided" type="button" data-hero-option="guided">
-            <span class="opt-tag">Guided path</span>
+            <span class="opt-tag">Guided Path</span>
             <span class="opt-title">Help me find the right town</span>
             <span class="opt-action">Take the Town Match Quiz →</span>
           </button>
           <button class="opt opt--self" type="button" data-hero-option="self-guided">
-            <span class="opt-tag">Self-guided</span>
+            <span class="opt-tag">Self-Guided</span>
             <span class="opt-title">I'll explore the towns myself</span>
-            <span class="opt-action">Browse the Map Below →</span>
+            <span class="opt-action">Browse the Map Below <span class="opt-action__arrow" aria-hidden="true">↓</span></span>
           </button>
         </div>
         <div class="hero__map-header">


### PR DESCRIPTION
### Motivation
- Update the homepage hero to match the new visual design: replace the left-panel solid green with a full-bleed photo + multi-layer overlay, restructure left content into three stacked sections, and replace pill badges with glass-style trust badges. 
- Add a clear two-option routing bar above the existing map to let visitors choose a guided path (Town Match quiz) or self-guided map exploration while leaving the interactive map and town logo strip unchanged. 
- Surface the existing Town Match quiz in a modal so users can complete it without navigating away and instrument new GA4 events for the new hero interactions. 

### Description
- Restructured hero markup in `src/homepageMarkup.js` to add the decorative image (`/assets/homepage/matthew-landon-northside-gta.jpg`) with `alt=""` and `aria-hidden="true"`, the overlay/vignette layers, the three new stacked sections (brand, agents, badges), and removed the RECO pill from the badge row. 
- Added the two-option bar markup and styles and map pulse animation, and wired interaction handlers in `src/HomePage.js` to (a) open the quiz modal for the guided path and (b) smooth-scroll + pulse the map for the self-guided option, with safe GA4 calls guarded by `window.gtag`. 
- Exported and adapted the existing quiz so it can run inside a modal by updating `src/BuyersPage.js` (`TownMatchQuiz` export with `variant` and `onComplete`), added a modal wrapper at `src/components/modals/TownMatchModal.js`, and lazy-loaded the modal from `HomePage` for performance. 
- Added styles and responsive rules in `src/HomePage.css` for the photo background, overlays, divider, agent block, glass trust badges, options bar, modal, and mobile stacking/height rules. 

### Testing
- `npm run build` completed successfully and produced the production bundle (build finished with unrelated `rrule` source-map warnings). 
- `npm test` (Node's test runner) passed all tests (67/67). 
- End-to-end visual verification was automated with Playwright after installing required browser dependencies and captured a screenshot at `/tmp/home-hero-redesign.png` to confirm the new hero and modal render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301294151083248260a4963493c450)