### PR TITLE
Fix homepage hero video CSS stacking

### DIFF
--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -1594,22 +1594,28 @@ main { padding-top: 0; }
 }
 
 .hero__copy {
-  background: #0a1604;
+  background-color: #0a1604;
+  position: relative;
+  overflow: hidden;
 }
 
-.agent-video,
+.agent-video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: right center;
+  opacity: 0.55;
+  z-index: 0;
+}
+
 .hero__video-overlay {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   pointer-events: none;
-}
-.agent-video {
-  object-fit: cover;
-  object-position: right center;
-  mix-blend-mode: multiply;
-  opacity: 0.9;
 }
 .agent-video img {
   width: 100%;
@@ -1666,11 +1672,12 @@ main { padding-top: 0; }
 
 .hero__copy {
   isolation: isolate;
-  background: #0a1604;
+  background-color: #0a1604;
+  position: relative;
+  overflow: hidden;
 }
 
 .agent-video {
-  z-index: 0;
   display: block;
 }
 


### PR DESCRIPTION
### Motivation
- The hero MP4 was loading but invisible because the video used `mix-blend-mode: multiply`, so the intent is to make the video visible while keeping overlay gradients and readable text intact.
- The left hero panel must use the dark green background `#0a1604` and maintain the existing overlay and content layering without changing markup or behavior.

### Description
- Modified `src/HomePage.css` to remove `mix-blend-mode: multiply` from the `.agent-video` rule and replace it with absolute full-cover positioning, `object-fit: cover`, `object-position: right center`, `opacity: 0.55`, and `z-index: 0`.
- Ensured the left hero container `.hero__copy` uses `background-color: #0a1604`, `position: relative`, and `overflow: hidden`.
- Added an explicit `.hero__video-overlay` positioning block and preserved the existing overlay gradient values for `hero__video-overlay--side` and `hero__video-overlay--bottom`.
- Confirmed stacking order is video `.agent-video` at `z-index: 0`, overlays `.hero__video-overlay` at `z-index: 1`, and content `.hero__copy-inner` at `z-index: 2`.

### Testing
- Ran `npm run build`, which succeeded and produced the build directory with only warnings about Browserslist and missing source maps for a dependency.
- Ran `npm test`, which completed successfully with all tests passing (67 tests passed).
- An attempt to run `npm test -- --watchAll=false` failed because the project uses `node --test` which does not accept the `--watchAll=false` flag.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3037b1761c8324ab51b52b1914837b)