### PR TITLE
Wire homepage lead form to Formspree

### DIFF
--- a/api/homepage-lead.js
+++ b/api/homepage-lead.js
@@ -1,31 +1,18 @@
-import { Resend } from 'resend'
-
-const resendClient = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null
-const LEAD_TO_EMAIL = process.env.LEAD_TO_EMAIL || process.env.AGENT_EMAIL || 'contact@finallyhomeagents.com'
-const LEAD_FROM_EMAIL =
-  process.env.LEAD_FROM_EMAIL || 'NorthSide GTA <no-reply@northsidegta.ca>'
-const THANK_YOU_PATH = '/thank-you?source=homepage-lead'
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const FORMSPREE_ENDPOINT = (process.env.FORMSPREE_ENDPOINT ?? '').trim()
+const DEFAULT_PAGE_URL = 'https://northsidegta.ca/'
 
 function normalizeText(value, max = 250) {
   if (typeof value !== 'string') return ''
   return value.replace(/\s+/g, ' ').trim().slice(0, max)
 }
 
-function escapeHtml(value = '') {
-  return String(value)
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#039;')
-}
-
-function getClientIp(req) {
-  const header = req.headers['x-forwarded-for']
-  if (Array.isArray(header)) return header[0] || 'unknown'
-  if (typeof header === 'string') return header.split(',')[0].trim() || 'unknown'
-  return req.socket?.remoteAddress || 'unknown'
+function isHttpUrl(value) {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 
 async function readBody(req) {
@@ -68,13 +55,13 @@ function wantsJson(req) {
   return accept.includes('application/json') || contentType.includes('application/json')
 }
 
-function sendError(req, res, status, error) {
+function sendJson(req, res, status, body) {
   if (wantsJson(req)) {
-    res.status(status).json({ ok: false, error })
+    res.status(status).json(body)
     return
   }
 
-  res.status(status).send(error)
+  res.status(status).send(body.error || 'Unable to submit lead right now.')
 }
 
 export default async function handler(req, res) {
@@ -88,87 +75,71 @@ export default async function handler(req, res) {
   try {
     body = await readBody(req)
   } catch (error) {
-    sendError(req, res, 400, 'Invalid request body.')
+    sendJson(req, res, 400, { ok: false, error: 'Invalid request body.' })
     return
   }
 
   if (normalizeText(body['bot-field'] || body.botField, 120)) {
-    if (wantsJson(req)) {
-      res.status(200).json({ ok: true })
-      return
-    }
-    res.writeHead(303, { Location: THANK_YOU_PATH })
-    res.end()
+    sendJson(req, res, 200, { ok: true })
     return
   }
 
+  const submittedAt = normalizeText(body.submittedAt, 80) || new Date().toISOString()
+  const pageUrl = normalizeText(body.pageUrl || body.sourceUrl, 500) || DEFAULT_PAGE_URL
   const payload = {
     name: normalizeText(body.name, 120),
     contact: normalizeText(body.contact, 180),
     community: normalizeText(body.community, 120),
-    sourceUrl: normalizeText(body.sourceUrl, 500),
-    formName: normalizeText(body['form-name'] || body.formName || 'homepage-lead', 120),
+    source: 'Homepage form',
+    pageUrl,
+    submittedAt,
   }
 
   if (!payload.name || !payload.contact || !payload.community) {
-    sendError(req, res, 400, 'Please complete name, contact, and community.')
+    sendJson(req, res, 400, { ok: false, error: 'Please complete name, contact, and community.' })
     return
   }
 
-  const replyTo = EMAIL_REGEX.test(payload.contact) ? payload.contact : undefined
-  const ip = getClientIp(req)
-  const submittedAt = new Date().toISOString()
-
-  if (!resendClient) {
-    sendError(req, res, 500, 'Email service not configured.')
+  if (!FORMSPREE_ENDPOINT || !isHttpUrl(FORMSPREE_ENDPOINT)) {
+    console.error('[homepage-lead] Formspree endpoint is not configured')
+    sendJson(req, res, 500, { ok: false, error: 'Lead form is not configured right now.' })
     return
   }
-
-  const html = `
-    <div style="font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#0f172a;">
-      <h2 style="margin-bottom:12px;">New Homepage Lead</h2>
-      <table style="width:100%;border-collapse:collapse;font-size:14px;">
-        <tr><td style="padding:6px 0;font-weight:600;">Name</td><td style="padding:6px 0;">${escapeHtml(payload.name)}</td></tr>
-        <tr><td style="padding:6px 0;font-weight:600;">Phone or email</td><td style="padding:6px 0;">${escapeHtml(payload.contact)}</td></tr>
-        <tr><td style="padding:6px 0;font-weight:600;">Community interest</td><td style="padding:6px 0;">${escapeHtml(payload.community)}</td></tr>
-        <tr><td style="padding:6px 0;font-weight:600;">Source page</td><td style="padding:6px 0;">${escapeHtml(payload.sourceUrl || 'https://northsidegta.ca/')}</td></tr>
-        <tr><td style="padding:6px 0;font-weight:600;">Form</td><td style="padding:6px 0;">${escapeHtml(payload.formName)}</td></tr>
-        <tr><td style="padding:6px 0;font-weight:600;">Submitted</td><td style="padding:6px 0;">${escapeHtml(submittedAt)}</td></tr>
-        <tr><td style="padding:6px 0;font-weight:600;">IP</td><td style="padding:6px 0;">${escapeHtml(ip)}</td></tr>
-      </table>
-    </div>
-  `
-
-  const text = [
-    'New Homepage Lead',
-    `Name: ${payload.name}`,
-    `Phone or email: ${payload.contact}`,
-    `Community interest: ${payload.community}`,
-    `Source page: ${payload.sourceUrl || 'https://northsidegta.ca/'}`,
-    `Form: ${payload.formName}`,
-    `Submitted: ${submittedAt}`,
-    `IP: ${ip}`,
-  ].join('\n')
 
   try {
-    await resendClient.emails.send({
-      from: LEAD_FROM_EMAIL,
-      to: [LEAD_TO_EMAIL],
-      subject: `Homepage Lead — ${payload.community} — ${payload.name}`,
-      ...(replyTo ? { replyTo } : {}),
-      html,
-      text,
+    const formspreeResponse = await fetch(FORMSPREE_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        Name: payload.name,
+        'Phone or email': payload.contact,
+        'Selected town/community': payload.community,
+        Source: payload.source,
+        'Page URL': payload.pageUrl,
+        'Submitted date/time': payload.submittedAt,
+        _subject: `Homepage Lead — ${payload.community} — ${payload.name}`,
+        _gotcha: '',
+      }),
     })
 
-    if (wantsJson(req)) {
-      res.status(200).json({ ok: true })
+    if (!formspreeResponse.ok) {
+      let responseText = ''
+      try {
+        responseText = await formspreeResponse.text()
+      } catch (error) {
+        console.error('[homepage-lead] failed to read Formspree error response', error)
+      }
+      console.error('[homepage-lead] Formspree error', formspreeResponse.status, responseText)
+      sendJson(req, res, 502, { ok: false, error: 'Unable to send lead right now.' })
       return
     }
 
-    res.writeHead(303, { Location: THANK_YOU_PATH })
-    res.end()
+    sendJson(req, res, 200, { ok: true })
   } catch (error) {
-    console.error('[homepage-lead] failed', error)
-    sendError(req, res, 502, 'Unable to send lead right now.')
+    console.error('[homepage-lead] Formspree request failed', error)
+    sendJson(req, res, 502, { ok: false, error: 'Unable to send lead right now.' })
   }
 }

--- a/api/homepage-lead.js
+++ b/api/homepage-lead.js
@@ -1,5 +1,7 @@
 const FORMSPREE_ENDPOINT = (process.env.FORMSPREE_ENDPOINT ?? '').trim()
 const DEFAULT_PAGE_URL = 'https://northsidegta.ca/'
+const SUCCESS_MESSAGE_HEADING = 'Thanks — we received your request.'
+const SUCCESS_MESSAGE_BODY = 'We’ll reach out within 24 hours to learn more about what you’re looking for and help you compare your options in the NorthSide GTA.'
 
 function normalizeText(value, max = 250) {
   if (typeof value !== 'string') return ''
@@ -55,9 +57,29 @@ function wantsJson(req) {
   return accept.includes('application/json') || contentType.includes('application/json')
 }
 
-function sendJson(req, res, status, body) {
+function sendResponse(req, res, status, body) {
   if (wantsJson(req)) {
     res.status(status).json(body)
+    return
+  }
+
+  if (body.ok) {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8')
+    res.status(status).send(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Homepage form received | NorthSide GTA</title>
+  </head>
+  <body>
+    <main role="main" aria-labelledby="homepage-lead-success" style="max-width:42rem;margin:4rem auto;padding:0 1.5rem;font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;line-height:1.6;color:#0f172a;">
+      <h1 id="homepage-lead-success" style="font-size:1.5rem;line-height:1.3;margin:0 0 1rem;">${SUCCESS_MESSAGE_HEADING}</h1>
+      <p style="margin:0 0 1.5rem;">${SUCCESS_MESSAGE_BODY}</p>
+      <p><a href="/" style="color:#32610e;font-weight:600;">Return to the homepage</a></p>
+    </main>
+  </body>
+</html>`)
     return
   }
 
@@ -75,12 +97,12 @@ export default async function handler(req, res) {
   try {
     body = await readBody(req)
   } catch (error) {
-    sendJson(req, res, 400, { ok: false, error: 'Invalid request body.' })
+    sendResponse(req, res, 400, { ok: false, error: 'Invalid request body.' })
     return
   }
 
   if (normalizeText(body['bot-field'] || body.botField, 120)) {
-    sendJson(req, res, 200, { ok: true })
+    sendResponse(req, res, 200, { ok: true })
     return
   }
 
@@ -96,13 +118,13 @@ export default async function handler(req, res) {
   }
 
   if (!payload.name || !payload.contact || !payload.community) {
-    sendJson(req, res, 400, { ok: false, error: 'Please complete name, contact, and community.' })
+    sendResponse(req, res, 400, { ok: false, error: 'Please complete name, contact, and community.' })
     return
   }
 
   if (!FORMSPREE_ENDPOINT || !isHttpUrl(FORMSPREE_ENDPOINT)) {
     console.error('[homepage-lead] Formspree endpoint is not configured')
-    sendJson(req, res, 500, { ok: false, error: 'Lead form is not configured right now.' })
+    sendResponse(req, res, 500, { ok: false, error: 'Lead form is not configured right now.' })
     return
   }
 
@@ -133,13 +155,13 @@ export default async function handler(req, res) {
         console.error('[homepage-lead] failed to read Formspree error response', error)
       }
       console.error('[homepage-lead] Formspree error', formspreeResponse.status, responseText)
-      sendJson(req, res, 502, { ok: false, error: 'Unable to send lead right now.' })
+      sendResponse(req, res, 502, { ok: false, error: 'Unable to send lead right now.' })
       return
     }
 
-    sendJson(req, res, 200, { ok: true })
+    sendResponse(req, res, 200, { ok: true })
   } catch (error) {
     console.error('[homepage-lead] Formspree request failed', error)
-    sendJson(req, res, 502, { ok: false, error: 'Unable to send lead right now.' })
+    sendResponse(req, res, 502, { ok: false, error: 'Unable to send lead right now.' })
   }
 }

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -197,16 +197,25 @@ export default function HomePage() {
     const form = document.querySelector('form[name="homepage-lead"]');
     const status = form?.querySelector("[data-inline-lead-status]");
     const sourceUrl = form?.querySelector('input[name="sourceUrl"]');
+    const pageUrl = form?.querySelector('input[name="pageUrl"]');
+    const submittedAt = form?.querySelector('input[name="submittedAt"]');
     const submitButton = form?.querySelector('button[type="submit"]');
 
     if (sourceUrl) {
       sourceUrl.value = window.location.href;
+    }
+    if (pageUrl) {
+      pageUrl.value = window.location.href;
     }
 
     async function handleLeadSubmit(event) {
       event.preventDefault();
 
       if (!form.reportValidity()) return;
+
+      if (submittedAt) {
+        submittedAt.value = new Date().toISOString();
+      }
 
       const formData = new FormData(form);
       if (formData.get("bot-field")) return;
@@ -231,7 +240,13 @@ export default function HomePage() {
           throw new Error(result.error || "Unable to send right now.");
         }
 
-        window.location.href = "/thank-you?source=homepage-lead";
+        form.innerHTML = `
+          <div class="inline-lead__success" role="status" aria-live="polite" tabindex="-1">
+            <p>Thanks — we received your request.</p>
+            <p>We’ll reach out within 24 hours to learn more about what you’re looking for and help you compare your options in the NorthSide GTA.</p>
+          </div>
+        `;
+        form.querySelector(".inline-lead__success")?.focus();
       } catch (error) {
         if (status) {
           status.textContent = error.message || "Sorry, something went wrong. Please try again.";

--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -1057,6 +1057,8 @@ export const HOMEPAGE_MARKUP = String.raw`
       >
         <input type="hidden" name="form-name" value="homepage-lead">
         <input type="hidden" name="sourceUrl" value="/">
+        <input type="hidden" name="pageUrl" value="/">
+        <input type="hidden" name="submittedAt" value="">
         <p class="inline-lead__honeypot" aria-hidden="true">
           <label>Don't fill this out: <input name="bot-field" tabindex="-1"></label>
         </p>
@@ -1111,7 +1113,7 @@ export const HOMEPAGE_MARKUP = String.raw`
         <p class="inline-lead__disclaimer">
           No spam. No pressure. Regulated by RECO · HomeLife Optimum Realty, Brokerage.
         </p>
-        <p class="inline-lead__status" data-inline-lead-status aria-live="polite"></p>
+        <p class="inline-lead__status" data-inline-lead-status role="alert" aria-live="assertive"></p>
       </form>
     </div>
   </section>

--- a/tests/homepage-lead.test.cjs
+++ b/tests/homepage-lead.test.cjs
@@ -1,0 +1,146 @@
+'use strict'
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { pathToFileURL } = require('node:url')
+const { createRequire } = require('node:module')
+const require_ = createRequire(__filename)
+
+async function loadHandler() {
+  const moduleUrl = pathToFileURL(require_.resolve('../api/homepage-lead.js')).href
+  const namespace = await import(`${moduleUrl}?t=${Date.now()}`)
+  return namespace.default || namespace
+}
+
+async function withEnv(overrides, fn) {
+  const backup = {}
+  for (const [key, value] of Object.entries(overrides)) {
+    backup[key] = Object.prototype.hasOwnProperty.call(process.env, key) ? process.env[key] : undefined
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+
+  try {
+    return await fn()
+  } finally {
+    for (const [key, value] of Object.entries(backup)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    setHeader(name, value) {
+      this.headers[name] = value
+      return this
+    },
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(payload) {
+      this.body = payload
+      return this
+    },
+    send(payload) {
+      this.body = payload
+      return this
+    },
+  }
+}
+
+function createPostRequest({ body, accept = '', contentType = 'application/json' }) {
+  return {
+    method: 'POST',
+    headers: {
+      accept,
+      'content-type': contentType,
+    },
+    body,
+  }
+}
+
+test('homepage lead returns JSON success for JavaScript submissions', async () => {
+  await withEnv({ FORMSPREE_ENDPOINT: 'https://formspree.io/f/testform' }, async () => {
+    const originalFetch = global.fetch
+    global.fetch = async () => ({ ok: true, status: 200, text: async () => '' })
+
+    try {
+      const handler = await loadHandler()
+      const res = createMockRes()
+      await handler(
+        createPostRequest({
+          accept: 'application/json',
+          body: { name: 'Jane Buyer', contact: 'jane@example.com', community: 'Aurora' },
+        }),
+        res
+      )
+
+      assert.equal(res.statusCode, 200)
+      assert.deepEqual(res.body, { ok: true })
+    } finally {
+      global.fetch = originalFetch
+    }
+  })
+})
+
+test('homepage lead returns accessible success HTML for native form submissions', async () => {
+  await withEnv({ FORMSPREE_ENDPOINT: 'https://formspree.io/f/testform' }, async () => {
+    const originalFetch = global.fetch
+    global.fetch = async () => ({ ok: true, status: 200, text: async () => '' })
+
+    try {
+      const handler = await loadHandler()
+      const res = createMockRes()
+      await handler(
+        createPostRequest({
+          contentType: 'application/x-www-form-urlencoded',
+          body: 'name=Jane+Buyer&contact=4165551212&community=Aurora',
+        }),
+        res
+      )
+
+      assert.equal(res.statusCode, 200)
+      assert.equal(res.headers['Content-Type'], 'text/html; charset=utf-8')
+      assert.match(res.body, /Thanks — we received your request\./)
+      assert.match(res.body, /We’ll reach out within 24 hours/)
+      assert.doesNotMatch(res.body, /Unable to submit lead right now\./)
+    } finally {
+      global.fetch = originalFetch
+    }
+  })
+})
+
+test('homepage lead returns clear non-JSON errors when Formspree fails', async () => {
+  await withEnv({ FORMSPREE_ENDPOINT: 'https://formspree.io/f/testform' }, async () => {
+    const originalFetch = global.fetch
+    global.fetch = async () => ({ ok: false, status: 500, text: async () => 'bad gateway' })
+
+    try {
+      const handler = await loadHandler()
+      const res = createMockRes()
+      await handler(
+        createPostRequest({
+          contentType: 'application/x-www-form-urlencoded',
+          body: 'name=Jane+Buyer&contact=4165551212&community=Aurora',
+        }),
+        res
+      )
+
+      assert.equal(res.statusCode, 502)
+      assert.equal(res.body, 'Unable to send lead right now.')
+    } finally {
+      global.fetch = originalFetch
+    }
+  })
+})


### PR DESCRIPTION
### Motivation
- Ensure the homepage lead form uses the existing Formspree integration so leads are delivered to the Finally Home Agents inbox without adding a new provider or sending visitor auto-emails/SMS. 
- Preserve the current visible form layout and spam protection while making submissions include source metadata (page URL and submitted timestamp) and provide inline, accessible success/error UX.

### Description
- Replace the previous Resend-centric flow in `/api/homepage-lead.js` with a Formspree POST using the existing `FORMSPREE_ENDPOINT` env var and send the fields: `Name`, `Phone or email`, `Selected town/community`, `Source: Homepage form`, `Page URL`, and `Submitted date/time` while preserving the honeypot (`_gotcha`/bot-field) handling. 
- Validate required fields (`name`, `contact`, `community`) server-side and return JSON error responses on failure; require a configured, valid `FORMSPREE_ENDPOINT` before attempting delivery. 
- Update client-side homepage JS (`src/HomePage.js`) to add hidden `pageUrl` and `submittedAt` inputs, populate them (current page URL and ISO timestamp) before submit, submit JSON to `/api/homepage-lead`, and on success replace the form inline with the exact success message: 

“Thanks — we received your request.

We’ll reach out within 24 hours to learn more about what you’re looking for and help you compare your options in the NorthSide GTA.”

- Add the two hidden inputs and adjust ARIA attributes in the static markup (`src/homepageMarkup.js`) so the visible form, labels, CTA, layout and styling remain unchanged and the inline status message is accessible to screen readers (role="alert", `aria-live="assertive"`).

### Testing
- Ran the project test suite with `npm test` and all tests passed (67/67). 
- Verified `git diff --check` produced no issues. 
- Built the site with `npm run build` successfully; the build completed with known non-blocking warnings about Browserslist freshness and source-map parsing for `rrule` but no new build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a317db411c48324944551a233824a07)