### PR TITLE
Fix hero brightness and upgrade trust badge icons

### DIFF
--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -7,9 +7,9 @@ export const HOMEPAGE_MARKUP = String.raw`
 
       
       <div class="hero__copy hero-animate">
-        <video autoplay loop muted playsinline aria-hidden="true" class="agent-video" poster="/assets/homepage/matthew-landon-northside-gta.jpg">
+        <video autoplay loop muted playsinline aria-hidden="true" class="agent-video" poster="/assets/homepage/matthew-landon-northside-gta.jpg" style="filter: brightness(1.15) contrast(1.05);">
           <source src="/assets/homepage/matthew-landon-hero.mp4" type="video/mp4">
-          <img src="/assets/homepage/matthew-landon-northside-gta.jpg" alt="" aria-hidden="true">
+          <img src="/assets/homepage/matthew-landon-northside-gta.jpg" alt="" aria-hidden="true" style="filter: brightness(1.15) contrast(1.05);">
         </video>
         <div class="hero__video-overlay hero__video-overlay--side" aria-hidden="true"></div>
         <div class="hero__video-overlay hero__video-overlay--bottom" aria-hidden="true"></div>
@@ -38,15 +38,34 @@ export const HOMEPAGE_MARKUP = String.raw`
 
           <div class="hero-badges" aria-label="NorthSide GTA trust signals">
             <a href="https://share.google/GJz2QTQ8GqZIifaNH" target="_blank" rel="noopener" class="hero-badge hero-badge--google" aria-label="5.0 Rating — Google Reviews">
-              <span class="hero-badge__icon" aria-hidden="true">⭐</span>
+              <span class="hero-badge__icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                  <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                  <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                  <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
+                  <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                </svg>
+              </span>
               <span class="hero-badge__text"><strong>5.0 Rating</strong><span>Google Reviews</span></span>
             </a>
             <span class="hero-badge">
-              <span class="hero-badge__icon" aria-hidden="true">📍</span>
+              <span class="hero-badge__icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/>
+                  <circle cx="12" cy="9" r="2.5"/>
+                </svg>
+              </span>
               <span class="hero-badge__text"><strong>7 Communities</strong><span>North of Toronto</span></span>
             </span>
             <span class="hero-badge">
-              <span class="hero-badge__icon" aria-hidden="true">🔄</span>
+              <span class="hero-badge__icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <rect x="3" y="4" width="18" height="18" rx="2"/>
+                  <line x1="16" y1="2" x2="16" y2="6"/>
+                  <line x1="8" y1="2" x2="8" y2="6"/>
+                  <line x1="3" y1="10" x2="21" y2="10"/>
+                </svg>
+              </span>
               <span class="hero-badge__text"><strong>Updated Monthly</strong><span>Market Data</span></span>
             </span>
           </div>


### PR DESCRIPTION
### Motivation
- Make the homepage hero media slightly brighter and higher-contrast so the agents imagery reads better over overlays.  
- Replace loose emoji trust badges with accessible, consistent inline SVGs to improve visual fidelity and control.  
- Ensure icon strokes inherit badge text color so badges match the surrounding UI theme.

### Description
- Added an inline `style="filter: brightness(1.15) contrast(1.05);"` to the hero `<video>` and its fallback `<img>` in `src/homepageMarkup.js`.  
- Replaced the three hero trust badge emoji spans with the provided inline SVGs for Google (multi-path, coloured), pin, and calendar icons in `src/homepageMarkup.js`.  
- Set `stroke="currentColor"` on the pin and calendar SVGs so they inherit the badge text colour.  
- Changes were limited to the homepage hero block and trust badges only; no other sections were modified.

### Testing
- Ran `git diff --check` to validate whitespace and diff sanity (no issues found).  
- Ran `npm test` and all automated tests passed (`70` tests, `0` failures).  
- Started the dev server with `npm start` which compiled successfully with existing `rrule` source-map warnings.  
- Performed a Playwright smoke screenshot of the homepage after installing browsers/deps with `npx playwright install chromium` and `npx playwright install-deps chromium`, producing `artifacts/homepage-hero-trust-badges.png` as a visual verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3540e7de208324b8548d196431a56e)