### PR TITLE
Add Mill Run lockbox contest page and secure /api/unlock endpoint

### DIFF
--- a/api/unlock.js
+++ b/api/unlock.js
@@ -1,0 +1,88 @@
+const FORMSPREE_ENDPOINT = (process.env.FORMSPREE_ENDPOINT ?? '').trim()
+
+function normalizeText(value, max = 250) {
+  if (typeof value !== 'string') return ''
+  return value.replace(/\s+/g, ' ').trim().slice(0, max)
+}
+
+function isHttpUrl(value) {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+async function readBody(req) {
+  if (req.body) {
+    if (typeof req.body === 'object') return req.body
+    if (typeof req.body === 'string') return JSON.parse(req.body || '{}')
+  }
+
+  const chunks = []
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  if (!chunks.length) return {}
+  return JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}')
+}
+
+async function submitToFormspree(payload) {
+  if (!FORMSPREE_ENDPOINT || !isHttpUrl(FORMSPREE_ENDPOINT)) return
+
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 1500)
+    try {
+      await fetch(FORMSPREE_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timeout)
+    }
+  } catch {
+    // Lead capture must never block the lockbox result.
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).json({ unlocked: false })
+    return
+  }
+
+  let body = {}
+  try {
+    body = await readBody(req)
+  } catch {
+    res.status(400).json({ unlocked: false })
+    return
+  }
+
+  const winningCode = normalizeText(process.env.LOCKBOX_WINNING_CODE, 5)
+  const submittedCode = normalizeText(body.code, 5)
+  const unlocked = Boolean(winningCode && /^\d{5}$/.test(winningCode) && submittedCode === winningCode)
+  const timestamp = new Date().toISOString()
+
+  const payload = {
+    contest: 'Unlock the Prize',
+    name: normalizeText(body.name, 120),
+    phone: normalizeText(body.phone, 80),
+    instagramHandle: normalizeText(body.instagramHandle, 80),
+    code: submittedCode,
+    followedFinallyHomeAgents: Boolean(body.followedFinallyHomeAgents),
+    followedNorthSideGTA: Boolean(body.followedNorthSideGTA),
+    result: unlocked ? 'unlocked' : 'locked',
+    timestamp,
+    pageUrl: normalizeText(body.pageUrl, 500),
+  }
+
+  await submitToFormspree(payload)
+  res.status(200).json({ unlocked })
+}

--- a/api/unlock.js
+++ b/api/unlock.js
@@ -1,8 +1,37 @@
 const FORMSPREE_ENDPOINT = (process.env.FORMSPREE_ENDPOINT ?? '').trim()
+const WINDOW_MS = 10 * 60 * 1000
+const MAX_IP_ATTEMPTS = 5
+const ipAttempts = new Map()
+const codeAttempts = new Map()
+
+// This temporary contest uses in-memory throttling. Durable storage would be
+// needed for production-critical abuse prevention across serverless instances.
+function pruneAttempts(store, now) {
+  for (const [key, attempts] of store.entries()) {
+    const freshAttempts = attempts.filter((timestamp) => now - timestamp < WINDOW_MS)
+    if (freshAttempts.length) store.set(key, freshAttempts)
+    else store.delete(key)
+  }
+}
+
+function isThrottled(store, key, limit, now) {
+  pruneAttempts(store, now)
+  const attempts = store.get(key) || []
+  if (attempts.length >= limit) return true
+  attempts.push(now)
+  store.set(key, attempts)
+  return false
+}
 
 function normalizeText(value, max = 250) {
   if (typeof value !== 'string') return ''
   return value.replace(/\s+/g, ' ').trim().slice(0, max)
+}
+
+function getClientIp(req) {
+  const forwardedFor = normalizeText(req.headers['x-forwarded-for'], 500)
+  if (forwardedFor) return forwardedFor.split(',')[0].trim()
+  return normalizeText(req.headers['x-real-ip'], 100) || req.socket?.remoteAddress || 'unknown'
 }
 
 function isHttpUrl(value) {
@@ -65,24 +94,43 @@ export default async function handler(req, res) {
     return
   }
 
-  const winningCode = normalizeText(process.env.LOCKBOX_WINNING_CODE, 5)
-  const submittedCode = normalizeText(body.code, 5)
-  const unlocked = Boolean(winningCode && /^\d{5}$/.test(winningCode) && submittedCode === winningCode)
+  const submittedCode = normalizeText(body.code, 20)
+  const validSubmittedCode = /^\d{5}$/.test(submittedCode)
   const timestamp = new Date().toISOString()
-
-  const payload = {
+  const basePayload = {
     contest: 'Unlock the Prize',
+    prize: 'Entry into the 2026 Finally Home Fall Scramble',
     name: normalizeText(body.name, 120),
     phone: normalizeText(body.phone, 80),
     instagramHandle: normalizeText(body.instagramHandle, 80),
     code: submittedCode,
     followedFinallyHomeAgents: Boolean(body.followedFinallyHomeAgents),
     followedNorthSideGTA: Boolean(body.followedNorthSideGTA),
-    result: unlocked ? 'unlocked' : 'locked',
     timestamp,
     pageUrl: normalizeText(body.pageUrl, 500),
   }
 
-  await submitToFormspree(payload)
+  if (!validSubmittedCode) {
+    await submitToFormspree({ ...basePayload, result: 'locked' })
+    res.status(200).json({ unlocked: false })
+    return
+  }
+
+  const now = Date.now()
+  const clientIp = getClientIp(req)
+  const throttled =
+    isThrottled(ipAttempts, clientIp, MAX_IP_ATTEMPTS, now) ||
+    isThrottled(codeAttempts, submittedCode, 1, now)
+
+  if (throttled) {
+    await submitToFormspree({ ...basePayload, result: 'locked' })
+    res.status(429).json({ error: 'Too many attempts. Please try again later.' })
+    return
+  }
+
+  const winningCode = normalizeText(process.env.LOCKBOX_WINNING_CODE, 20)
+  const unlocked = Boolean(/^\d{5}$/.test(winningCode) && submittedCode === winningCode)
+
+  await submitToFormspree({ ...basePayload, result: unlocked ? 'unlocked' : 'locked' })
   res.status(200).json({ unlocked })
 }

--- a/src/App.js
+++ b/src/App.js
@@ -49,6 +49,7 @@ import NorthsidePassPreviewV2Page from "./membership/NorthsidePassPreviewV2Page"
 import CoffeePage, { BookCoffeeAliasPage } from "./CoffeePage";
 import PowerOfSaleSupportPage from "./PowerOfSaleSupportPage";
 import KeswickLowerPricedHomesPage from "./KeswickLowerPricedHomesPage";
+import UnlockPage from "./UnlockPage";
 
 import AuroraPage from "./AuroraPage";
 import NewmarketPage from "./NewmarketPage";
@@ -137,6 +138,7 @@ function App() {
           <Route path="/book-coffee" element={<BookCoffeeAliasPage />} />
           <Route path="/power-of-sale-support" element={<PowerOfSaleSupportPage />} />
           <Route path="/keswick-lower-priced-homes" element={<KeswickLowerPricedHomesPage />} />
+          <Route path="/unlock" element={<UnlockPage />} />
           <Route path="/northside-pass-preview" element={<OptionFivePage />} />
           <Route path="/northside-pass-preview-v2" element={<NorthsidePassPreviewV2Page />} />
           <Route path="/northside-pass-preview/option-1" element={<OptionOnePage />} />

--- a/src/UnlockPage.css
+++ b/src/UnlockPage.css
@@ -1,0 +1,77 @@
+.unlock-page {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 50% -10%, rgba(203, 166, 75, 0.22), transparent 34rem),
+    radial-gradient(circle at 0 20%, rgba(42, 89, 57, 0.48), transparent 24rem),
+    linear-gradient(145deg, #020503 0%, #06120c 46%, #010201 100%);
+  color: #fffaf0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 1rem;
+}
+.unlock-page::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(255,255,255,.025) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.018) 1px, transparent 1px);
+  background-size: 34px 34px;
+  mask-image: linear-gradient(to bottom, rgba(0,0,0,.7), transparent 78%);
+}
+.unlock-shell {
+  position: relative;
+  width: min(100%, 32rem);
+  margin: 0 auto;
+  padding: 1.1rem 0 2.2rem;
+}
+.brand-row {
+  display: grid;
+  grid-template-columns: 4.4rem 1px 4.4rem;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+.brand-row img { width: 4.4rem; height: 4.4rem; object-fit: contain; filter: drop-shadow(0 12px 26px rgba(0,0,0,.45)); }
+.brand-row span { height: 2.75rem; background: linear-gradient(transparent, rgba(214,180,93,.72), transparent); }
+.hero-lockup { text-align: center; padding: .4rem 0 1rem; }
+.lockbox-visual { width: min(15.5rem, 76vw); height: 15rem; margin: 0 auto 1.2rem; position: relative; display: grid; place-items: end center; }
+.lockbox-shackle { position: absolute; top: .45rem; width: 7.4rem; height: 7.6rem; border: .9rem solid #d7b35f; border-bottom: 0; border-radius: 4.2rem 4.2rem 0 0; box-shadow: inset 0 0 14px rgba(255,255,255,.25), 0 20px 50px rgba(0,0,0,.35); }
+.lockbox-body { position: relative; width: 13rem; height: 10rem; border-radius: 1.65rem; background: linear-gradient(145deg, #f9f4e6, #cba64d 34%, #2a2617 36%, #050705 100%); border: 1px solid rgba(255,237,181,.55); box-shadow: 0 32px 90px rgba(0,0,0,.62), inset 0 1px 0 rgba(255,255,255,.45); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: .3rem; }
+.lockbox-body img { width: 4.8rem; height: 4.8rem; object-fit: contain; border-radius: 999px; background: rgba(255,255,255,.95); padding: .25rem; }
+.lockbox-body strong { letter-spacing: .24em; font-size: .77rem; color: #ffe7a3; }
+.lockbox-body small { color: rgba(255,255,255,.78); text-transform: uppercase; letter-spacing: .18em; }
+.eyebrow { margin: 0 0 .6rem; color: #d8b968; text-transform: uppercase; letter-spacing: .18em; font-size: .72rem; font-weight: 800; }
+.hero-lockup h1, .result-card h1 { margin: 0; font-size: clamp(3.15rem, 14vw, 5.6rem); line-height: .88; letter-spacing: -.075em; }
+.subheadline { margin: .95rem auto 0; color: rgba(255,250,240,.76); font-size: 1.08rem; max-width: 19rem; line-height: 1.45; }
+.prize-card, .steps-card, .unlock-form, .birdie-card, .result-card { border: 1px solid rgba(214,180,93,.28); background: rgba(255,255,255,.075); box-shadow: 0 24px 80px rgba(0,0,0,.32); backdrop-filter: blur(18px); }
+.prize-card { border-radius: 1.5rem; padding: 1.15rem; margin: 1.1rem 0; }
+.prize-card span { display:block; color:#d8b968; text-transform:uppercase; letter-spacing:.16em; font-size:.72rem; font-weight:800; margin-bottom:.3rem; }
+.prize-card strong { font-size: 1.35rem; line-height: 1.2; }
+.steps-card { margin: 0 0 1rem; padding: 1.1rem 1.1rem 1.1rem 2.35rem; border-radius: 1.35rem; color: rgba(255,250,240,.82); line-height: 1.55; }
+.unlock-form { border-radius: 1.7rem; padding: 1rem; display: grid; gap: .85rem; }
+.unlock-form label { display: grid; gap: .35rem; color: rgba(255,250,240,.82); font-size: .88rem; font-weight: 750; }
+.unlock-form input { width: 100%; box-sizing: border-box; border: 1px solid rgba(255,255,255,.16); background: rgba(0,0,0,.35); color: #fffaf0; border-radius: 1rem; padding: .95rem 1rem; font: inherit; outline: none; }
+.unlock-form input:focus { border-color: #d8b968; box-shadow: 0 0 0 4px rgba(216,185,104,.13); }
+.code-label input { font-size: 2rem; letter-spacing: .34em; text-align: center; font-weight: 900; padding: 1.05rem 1rem; }
+.checks { display: grid; gap: .65rem; padding: .25rem 0; }
+.checks label { grid-template-columns: 1.1rem 1fr; align-items: center; font-weight: 700; }
+.checks input { width: 1.1rem; height: 1.1rem; accent-color: #d8b968; padding: 0; }
+.form-error { margin: 0; border: 1px solid rgba(255,120,120,.4); background: rgba(120,0,0,.25); color: #ffd7d7; border-radius: .9rem; padding: .8rem .9rem; font-weight: 750; }
+.unlock-button, .ghost-button { border: 0; border-radius: 999px; min-height: 3.5rem; background: linear-gradient(135deg, #fff2b8, #d1a33f 48%, #8d6418); color: #0a0e09; font-weight: 950; letter-spacing: .04em; text-transform: uppercase; box-shadow: 0 18px 42px rgba(210,163,63,.24); cursor: pointer; }
+.unlock-button:disabled { opacity: .68; cursor: wait; }
+.birdie-card { margin: 1rem 0 1.2rem; border-radius: 1.5rem; padding: 1.2rem; }
+.birdie-card h2 { margin: 0 0 .6rem; font-size: 1.65rem; letter-spacing: -.04em; }
+.birdie-card p:not(.eyebrow) { color: rgba(255,250,240,.78); line-height: 1.5; margin: .45rem 0 0; }
+.unlock-shell footer { text-align: center; color: rgba(255,250,240,.62); font-size: .86rem; line-height: 1.5; padding: .7rem 0 0; }
+.result-page { display: grid; place-items: center; padding: 1rem; }
+.result-card { width: min(100%, 31rem); border-radius: 2rem; padding: 2rem 1.25rem; text-align: center; }
+.result-copy { font-size: 1.35rem; line-height: 1.32; color: rgba(255,250,240,.86); margin: 1.2rem auto 0; }
+.handoff { color: #ffe7a3; font-weight: 900; font-size: 1.1rem; }
+.ghost-button { margin-top: 1rem; padding: 0 1.5rem; background: transparent; color: #fffaf0; border: 1px solid rgba(255,255,255,.25); box-shadow: none; }
+.is-unlocked { background: radial-gradient(circle at 50% 22%, rgba(216,185,104,.38), transparent 22rem), linear-gradient(145deg, #07170e, #010201); }
+@media (min-width: 720px) {
+  .unlock-page { padding: 2rem; }
+  .unlock-shell { width: min(100%, 39rem); }
+  .unlock-form { grid-template-columns: 1fr 1fr; padding: 1.2rem; }
+  .unlock-form label:nth-child(3), .code-label, .checks, .form-error, .unlock-button { grid-column: 1 / -1; }
+}

--- a/src/UnlockPage.js
+++ b/src/UnlockPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import { Helmet } from "react-helmet-async";
 import "./UnlockPage.css";
 
@@ -28,14 +28,6 @@ export default function UnlockPage() {
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState(null);
-  const codeRef = useRef(null);
-
-  useEffect(() => {
-    if (form.name && form.phone && form.instagramHandle && !form.code) {
-      codeRef.current?.focus();
-    }
-  }, [form.name, form.phone, form.instagramHandle, form.code]);
-
   const update = (key, value) => setForm((current) => ({ ...current, [key]: value }));
 
   async function onSubmit(event) {
@@ -57,6 +49,10 @@ export default function UnlockPage() {
         body: JSON.stringify({ ...form, pageUrl: window.location.href }),
       });
       const data = await response.json();
+      if (response.status === 429) {
+        setError(data.error || "Too many attempts. Please try again later.");
+        return;
+      }
       setResult(data.unlocked ? "unlocked" : "locked");
     } catch {
       setError("We couldn't reach the lockbox. Please try again.");
@@ -75,10 +71,10 @@ export default function UnlockPage() {
           <h1>{won ? "Unlocked." : "Still locked."}</h1>
           <p className="result-copy">
             {won
-              ? "You won 3 Dozen Callaway Chrome Soft Golf Balls."
+              ? "You won an entry into the 2026 Finally Home Fall Scramble."
               : "Thanks for playing. Winners announced at dinner."}
           </p>
-          {won && <p className="handoff">Show this screen to Matthew or Landon.</p>}
+          {won && <p className="handoff">We’ll be in contact with you.</p>}
           <button className="ghost-button" type="button" onClick={() => setResult(null)}>Try another code</button>
         </section>
       </main>
@@ -114,7 +110,7 @@ export default function UnlockPage() {
 
         <div className="prize-card">
           <span>Prize</span>
-          <strong>3 Dozen Callaway Chrome Soft Golf Balls</strong>
+          <strong>Entry into the 2026 Finally Home Fall Scramble</strong>
         </div>
 
         <ol className="steps-card">
@@ -128,7 +124,7 @@ export default function UnlockPage() {
           <label>Name<input value={form.name} onChange={(e) => update("name", e.target.value)} autoComplete="name" required /></label>
           <label>Phone<input value={form.phone} onChange={(e) => update("phone", e.target.value)} autoComplete="tel" inputMode="tel" required /></label>
           <label>Instagram Handle<input value={form.instagramHandle} onChange={(e) => update("instagramHandle", e.target.value)} placeholder="@yourhandle" autoComplete="off" required /></label>
-          <label className="code-label">5-Digit Code<input ref={codeRef} value={form.code} onChange={(e) => update("code", e.target.value.replace(/\D/g, "").slice(0, 5))} inputMode="numeric" pattern="[0-9]*" maxLength="5" placeholder="•••••" required /></label>
+          <label className="code-label">5-Digit Code<input value={form.code} onChange={(e) => update("code", e.target.value.replace(/\D/g, "").slice(0, 5))} inputMode="numeric" pattern="[0-9]*" maxLength="5" placeholder="•••••" required /></label>
 
           <div className="checks">
             <label><input type="checkbox" checked={form.followedFinallyHomeAgents} onChange={(e) => update("followedFinallyHomeAgents", e.target.checked)} /> I followed @FinallyHomeAgents</label>
@@ -142,7 +138,7 @@ export default function UnlockPage() {
         <section className="birdie-card">
           <p className="eyebrow">Bonus contest</p>
           <h2>Longest Birdie of the Day</h2>
-          <p>The longest made birdie on this hole wins a FREE entry into the 2027 Finally Home Cup.</p>
+          <p>The longest made birdie on this hole wins an entry into the 2026 Finally Home Fall Scramble.</p>
           <p>Matthew and Landon will be on the green to witness and measure every birdie.</p>
         </section>
 

--- a/src/UnlockPage.js
+++ b/src/UnlockPage.js
@@ -1,0 +1,153 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Helmet } from "react-helmet-async";
+import "./UnlockPage.css";
+
+const initialForm = {
+  name: "",
+  phone: "",
+  instagramHandle: "",
+  code: "",
+  followedFinallyHomeAgents: false,
+  followedNorthSideGTA: false,
+};
+
+function validate(form) {
+  if (!form.name.trim()) return "Name is required.";
+  if (!form.phone.trim()) return "Phone is required.";
+  if (!form.instagramHandle.trim()) return "Instagram handle is required.";
+  if (!form.code.trim()) return "5-digit code is required.";
+  if (!/^\d{5}$/.test(form.code)) return "Code must be exactly 5 numeric digits.";
+  if (!form.followedFinallyHomeAgents && !form.followedNorthSideGTA) {
+    return "Check at least one follow box to play.";
+  }
+  return "";
+}
+
+export default function UnlockPage() {
+  const [form, setForm] = useState(initialForm);
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState(null);
+  const codeRef = useRef(null);
+
+  useEffect(() => {
+    if (form.name && form.phone && form.instagramHandle && !form.code) {
+      codeRef.current?.focus();
+    }
+  }, [form.name, form.phone, form.instagramHandle, form.code]);
+
+  const update = (key, value) => setForm((current) => ({ ...current, [key]: value }));
+
+  async function onSubmit(event) {
+    event.preventDefault();
+    if (submitting) return;
+
+    const message = validate(form);
+    if (message) {
+      setError(message);
+      return;
+    }
+
+    setError("");
+    setSubmitting(true);
+    try {
+      const response = await fetch("/api/unlock", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ ...form, pageUrl: window.location.href }),
+      });
+      const data = await response.json();
+      setResult(data.unlocked ? "unlocked" : "locked");
+    } catch {
+      setError("We couldn't reach the lockbox. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (result) {
+    const won = result === "unlocked";
+    return (
+      <main className={`unlock-page result-page ${won ? "is-unlocked" : "is-locked"}`}>
+        <Helmet><title>{won ? "Unlocked" : "Still locked"} | Mill Run Member Guest</title></Helmet>
+        <section className="result-card" aria-live="polite">
+          <p className="eyebrow">Mill Run Member Guest</p>
+          <h1>{won ? "Unlocked." : "Still locked."}</h1>
+          <p className="result-copy">
+            {won
+              ? "You won 3 Dozen Callaway Chrome Soft Golf Balls."
+              : "Thanks for playing. Winners announced at dinner."}
+          </p>
+          {won && <p className="handoff">Show this screen to Matthew or Landon.</p>}
+          <button className="ghost-button" type="button" onClick={() => setResult(null)}>Try another code</button>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="unlock-page">
+      <Helmet>
+        <title>Unlock the Prize | Finally Home Agents + NorthSide GTA</title>
+        <meta name="description" content="Enter your Mill Run Member Guest lockbox code for a chance to unlock the prize." />
+      </Helmet>
+      <section className="unlock-shell">
+        <div className="brand-row" aria-label="Event sponsors">
+          <img src="/Images/fha-badge.png" alt="Finally Home Agents" />
+          <span />
+          <img src="/Images/northsidegta-logo.svg" alt="NorthSide GTA" />
+        </div>
+
+        <div className="hero-lockup">
+          <div className="lockbox-visual" aria-hidden="true">
+            <div className="lockbox-shackle" />
+            <div className="lockbox-body">
+              <img src="/Images/fha-badge.png" alt="" />
+              <strong>LOCKBOX</strong>
+              <small>Mill Run</small>
+            </div>
+          </div>
+          <p className="eyebrow">Finally Home Agents × NorthSide GTA</p>
+          <h1>Unlock the Prize</h1>
+          <p className="subheadline">Follow us. Enter your code. Crack the lockbox.</p>
+        </div>
+
+        <div className="prize-card">
+          <span>Prize</span>
+          <strong>3 Dozen Callaway Chrome Soft Golf Balls</strong>
+        </div>
+
+        <ol className="steps-card">
+          <li>Follow @FinallyHomeAgents on Instagram</li>
+          <li>Follow @NorthSideGTA for a bonus chance</li>
+          <li>Enter your 5-digit lockbox code</li>
+          <li>If it unlocks, show Matthew or Landon at the hole</li>
+        </ol>
+
+        <form className="unlock-form" onSubmit={onSubmit} noValidate>
+          <label>Name<input value={form.name} onChange={(e) => update("name", e.target.value)} autoComplete="name" required /></label>
+          <label>Phone<input value={form.phone} onChange={(e) => update("phone", e.target.value)} autoComplete="tel" inputMode="tel" required /></label>
+          <label>Instagram Handle<input value={form.instagramHandle} onChange={(e) => update("instagramHandle", e.target.value)} placeholder="@yourhandle" autoComplete="off" required /></label>
+          <label className="code-label">5-Digit Code<input ref={codeRef} value={form.code} onChange={(e) => update("code", e.target.value.replace(/\D/g, "").slice(0, 5))} inputMode="numeric" pattern="[0-9]*" maxLength="5" placeholder="•••••" required /></label>
+
+          <div className="checks">
+            <label><input type="checkbox" checked={form.followedFinallyHomeAgents} onChange={(e) => update("followedFinallyHomeAgents", e.target.checked)} /> I followed @FinallyHomeAgents</label>
+            <label><input type="checkbox" checked={form.followedNorthSideGTA} onChange={(e) => update("followedNorthSideGTA", e.target.checked)} /> I followed @NorthSideGTA</label>
+          </div>
+
+          {error && <p className="form-error" role="alert">{error}</p>}
+          <button className="unlock-button" type="submit" disabled={submitting}>{submitting ? "Checking…" : "Unlock"}</button>
+        </form>
+
+        <section className="birdie-card">
+          <p className="eyebrow">Bonus contest</p>
+          <h2>Longest Birdie of the Day</h2>
+          <p>The longest made birdie on this hole wins a FREE entry into the 2027 Finally Home Cup.</p>
+          <p>Matthew and Landon will be on the green to witness and measure every birdie.</p>
+        </section>
+
+        <footer>Finally Home Agents | NorthSide GTA<br />Mill Run Member Guest Tournament</footer>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a premium, mobile-first Mill Run Member Guest activation page where golfers can enter a 5-digit lockbox code and experience a branded, high-end interaction.
- Ensure the winning code is never exposed client-side by verifying submissions server-side using a server-only environment variable `LOCKBOX_WINNING_CODE`.
- Capture leads to the existing Formspree pipeline without letting Formspree failures affect whether the lockbox is reported as unlocked.

### Description
- Added a new React route and page at `/unlock` (`src/UnlockPage.js`) and styles in `src/UnlockPage.css` to deliver a luxury dark green/black/gold UI, large lockbox hero, prize card, instructions, and a Longest Birdie section.
- Implemented client-side validation and UX: required `Name`, `Phone`, `Instagram Handle`, exactly 5 numeric `Code` with `inputMode="numeric"` and `pattern`, at least one follow checkbox, autofocus behavior, double-submit prevention, clear error messages, and distinct unlocked/locked result screens.
- Added a secure API endpoint `api/unlock.js` that reads the winning code from `process.env.LOCKBOX_WINNING_CODE`, performs server-side comparison, never returns or logs the winning code, and responds only with `{ unlocked: true }` or `{ unlocked: false }`.
- Lead capture posts a sanitized payload to the configured Formspree endpoint (`FORMSPREE_ENDPOINT`) with a short timeout and non-blocking error handling so the lockbox result is always returned to the user.

### Testing
- Ran `npm test -- --test-reporter=spec`, which passed (81 tests passed).
- Built the production bundle with `npm run build`, which completed successfully (build warnings and rrule source-map warnings were reported but the build finished).
- Performed a Playwright smoke check to fetch `/unlock` and capture a mobile screenshot after installing dependencies, which completed and produced a page screenshot for visual verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45344068ac8324b9e0606aa349c75f)