### PR TITLE
Polish /unlock contest landing page

### DIFF
--- a/src/UnlockPage.css
+++ b/src/UnlockPage.css
@@ -1,9 +1,10 @@
 .unlock-page {
   min-height: 100vh;
   background:
-    radial-gradient(circle at 50% -10%, rgba(203, 166, 75, 0.22), transparent 34rem),
-    radial-gradient(circle at 0 20%, rgba(42, 89, 57, 0.48), transparent 24rem),
-    linear-gradient(145deg, #020503 0%, #06120c 46%, #010201 100%);
+    radial-gradient(circle at 50% -8%, rgba(88, 151, 47, 0.34), transparent 32rem),
+    radial-gradient(circle at 0 20%, rgba(35, 71, 10, 0.58), transparent 25rem),
+    radial-gradient(circle at 100% 55%, rgba(18, 88, 39, 0.28), transparent 24rem),
+    linear-gradient(145deg, #020503 0%, #07180c 44%, #010201 100%);
   color: #fffaf0;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   padding: 1rem;
@@ -21,57 +22,77 @@
   position: relative;
   width: min(100%, 32rem);
   margin: 0 auto;
-  padding: 1.1rem 0 2.2rem;
+  padding: .9rem 0 2.2rem;
 }
 .brand-row {
   display: grid;
-  grid-template-columns: 4.4rem 1px 4.4rem;
-  gap: 1rem;
+  grid-template-columns: 3.55rem 1px 3.55rem;
+  gap: .85rem;
   align-items: center;
   justify-content: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.15rem;
 }
-.brand-row img { width: 4.4rem; height: 4.4rem; object-fit: contain; filter: drop-shadow(0 12px 26px rgba(0,0,0,.45)); }
-.brand-row span { height: 2.75rem; background: linear-gradient(transparent, rgba(214,180,93,.72), transparent); }
-.hero-lockup { text-align: center; padding: .4rem 0 1rem; }
-.lockbox-visual { width: min(15.5rem, 76vw); height: 15rem; margin: 0 auto 1.2rem; position: relative; display: grid; place-items: end center; }
-.lockbox-shackle { position: absolute; top: .45rem; width: 7.4rem; height: 7.6rem; border: .9rem solid #d7b35f; border-bottom: 0; border-radius: 4.2rem 4.2rem 0 0; box-shadow: inset 0 0 14px rgba(255,255,255,.25), 0 20px 50px rgba(0,0,0,.35); }
-.lockbox-body { position: relative; width: 13rem; height: 10rem; border-radius: 1.65rem; background: linear-gradient(145deg, #f9f4e6, #cba64d 34%, #2a2617 36%, #050705 100%); border: 1px solid rgba(255,237,181,.55); box-shadow: 0 32px 90px rgba(0,0,0,.62), inset 0 1px 0 rgba(255,255,255,.45); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: .3rem; }
-.lockbox-body img { width: 4.8rem; height: 4.8rem; object-fit: contain; border-radius: 999px; background: rgba(255,255,255,.95); padding: .25rem; }
-.lockbox-body strong { letter-spacing: .24em; font-size: .77rem; color: #ffe7a3; }
-.lockbox-body small { color: rgba(255,255,255,.78); text-transform: uppercase; letter-spacing: .18em; }
+.brand-row img { width: 3.55rem; height: 3.55rem; object-fit: contain; filter: drop-shadow(0 10px 22px rgba(0,0,0,.42)); }
+.brand-row span { height: 2.25rem; background: linear-gradient(transparent, rgba(216,185,104,.58), transparent); }
+.hero-lockup { text-align: center; padding: .15rem 0 .95rem; }
+.lockbox-photo {
+  display: block;
+  width: min(17.5rem, 76vw);
+  max-width: 280px;
+  height: auto;
+  margin: 0 auto 1.1rem;
+  filter: drop-shadow(0 28px 48px rgba(0,0,0,.58));
+}
 .eyebrow { margin: 0 0 .6rem; color: #d8b968; text-transform: uppercase; letter-spacing: .18em; font-size: .72rem; font-weight: 800; }
-.hero-lockup h1, .result-card h1 { margin: 0; font-size: clamp(3.15rem, 14vw, 5.6rem); line-height: .88; letter-spacing: -.075em; }
-.subheadline { margin: .95rem auto 0; color: rgba(255,250,240,.76); font-size: 1.08rem; max-width: 19rem; line-height: 1.45; }
-.prize-card, .steps-card, .unlock-form, .birdie-card, .result-card { border: 1px solid rgba(214,180,93,.28); background: rgba(255,255,255,.075); box-shadow: 0 24px 80px rgba(0,0,0,.32); backdrop-filter: blur(18px); }
+.hero-lockup h1 { margin: 0; font-size: clamp(3rem, 13vw, 5.35rem); line-height: .9; letter-spacing: -.075em; }
+.hero-lockup h1 span { color: #d8b968; }
+.prize-card, .steps-card, .unlock-form, .result-card {
+  border: 1px solid rgba(108, 165, 74, .34);
+  background: rgba(255,255,255,.075);
+  box-shadow: 0 24px 80px rgba(0,0,0,.32);
+  backdrop-filter: blur(18px);
+}
 .prize-card { border-radius: 1.5rem; padding: 1.15rem; margin: 1.1rem 0; }
 .prize-card span { display:block; color:#d8b968; text-transform:uppercase; letter-spacing:.16em; font-size:.72rem; font-weight:800; margin-bottom:.3rem; }
 .prize-card strong { font-size: 1.35rem; line-height: 1.2; }
-.steps-card { margin: 0 0 1rem; padding: 1.1rem 1.1rem 1.1rem 2.35rem; border-radius: 1.35rem; color: rgba(255,250,240,.82); line-height: 1.55; }
+.steps-card { margin: 0 0 1rem; padding: 1.1rem 1.1rem 1.1rem 2.35rem; border-radius: 1.35rem; color: rgba(255,250,240,.84); line-height: 1.55; }
+.steps-card li::marker { color: #a6d36c; font-weight: 900; }
 .unlock-form { border-radius: 1.7rem; padding: 1rem; display: grid; gap: .85rem; }
-.unlock-form label { display: grid; gap: .35rem; color: rgba(255,250,240,.82); font-size: .88rem; font-weight: 750; }
+.unlock-form label, .code-label { display: grid; gap: .35rem; color: rgba(255,250,240,.84); font-size: .88rem; font-weight: 750; }
 .unlock-form input { width: 100%; box-sizing: border-box; border: 1px solid rgba(255,255,255,.16); background: rgba(0,0,0,.35); color: #fffaf0; border-radius: 1rem; padding: .95rem 1rem; font: inherit; outline: none; }
-.unlock-form input:focus { border-color: #d8b968; box-shadow: 0 0 0 4px rgba(216,185,104,.13); }
-.code-label input { font-size: 2rem; letter-spacing: .34em; text-align: center; font-weight: 900; padding: 1.05rem 1rem; }
+.unlock-form input:focus { border-color: #a6d36c; box-shadow: 0 0 0 4px rgba(80,151,42,.2); }
+.code-label { border: 0; margin: 0; padding: 0; }
+.code-label legend { padding: 0; margin-bottom: .35rem; }
+.code-boxes { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: .5rem; }
+.code-boxes input { min-height: 56px; padding: .3rem; text-align: center; font-size: 1.85rem; line-height: 1; font-weight: 950; }
 .checks { display: grid; gap: .65rem; padding: .25rem 0; }
 .checks label { grid-template-columns: 1.1rem 1fr; align-items: center; font-weight: 700; }
-.checks input { width: 1.1rem; height: 1.1rem; accent-color: #d8b968; padding: 0; }
+.checks input { width: 1.1rem; height: 1.1rem; accent-color: #5f9f36; padding: 0; }
 .form-error { margin: 0; border: 1px solid rgba(255,120,120,.4); background: rgba(120,0,0,.25); color: #ffd7d7; border-radius: .9rem; padding: .8rem .9rem; font-weight: 750; }
-.unlock-button, .ghost-button { border: 0; border-radius: 999px; min-height: 3.5rem; background: linear-gradient(135deg, #fff2b8, #d1a33f 48%, #8d6418); color: #0a0e09; font-weight: 950; letter-spacing: .04em; text-transform: uppercase; box-shadow: 0 18px 42px rgba(210,163,63,.24); cursor: pointer; }
+.unlock-button, .ghost-button { border: 0; border-radius: 999px; min-height: 3.5rem; background: linear-gradient(135deg, #6fb83e, #23470a 58%, #142d07); color: #fffaf0; font-weight: 950; letter-spacing: .04em; text-transform: uppercase; box-shadow: 0 18px 42px rgba(35,71,10,.32); cursor: pointer; }
 .unlock-button:disabled { opacity: .68; cursor: wait; }
-.birdie-card { margin: 1rem 0 1.2rem; border-radius: 1.5rem; padding: 1.2rem; }
-.birdie-card h2 { margin: 0 0 .6rem; font-size: 1.65rem; letter-spacing: -.04em; }
-.birdie-card p:not(.eyebrow) { color: rgba(255,250,240,.78); line-height: 1.5; margin: .45rem 0 0; }
+.birdie-card { margin: 1rem 0 1.2rem; border-radius: 1.2rem; padding: 1rem; border: 1px solid rgba(255,255,255,.14); background: rgba(255,255,255,.045); box-shadow: none; backdrop-filter: blur(12px); }
+.birdie-card .eyebrow { color: rgba(216,185,104,.82); font-size: .66rem; }
+.birdie-card h2 { margin: 0 0 .5rem; font-size: 1.28rem; letter-spacing: -.035em; }
+.birdie-card p:not(.eyebrow) { color: rgba(255,250,240,.72); line-height: 1.5; margin: .4rem 0 0; font-size: .95rem; }
 .unlock-shell footer { text-align: center; color: rgba(255,250,240,.62); font-size: .86rem; line-height: 1.5; padding: .7rem 0 0; }
-.result-page { display: grid; place-items: center; padding: 1rem; }
-.result-card { width: min(100%, 31rem); border-radius: 2rem; padding: 2rem 1.25rem; text-align: center; }
-.result-copy { font-size: 1.35rem; line-height: 1.32; color: rgba(255,250,240,.86); margin: 1.2rem auto 0; }
-.handoff { color: #ffe7a3; font-weight: 900; font-size: 1.1rem; }
+.result-card { position: relative; overflow: hidden; border-radius: 2rem; padding: 2rem 1.25rem; text-align: center; }
+.result-win { border-color: rgba(216,185,104,.68); box-shadow: 0 24px 90px rgba(216,185,104,.16), 0 24px 80px rgba(0,0,0,.36); }
+.result-win::before { content: ""; position: absolute; inset: -30%; background: radial-gradient(circle, rgba(216,185,104,.25) 0 2px, transparent 3px); background-size: 34px 34px; transform: rotate(18deg); opacity: .42; }
+.result-card > * { position: relative; }
+.result-icon { width: 4.25rem; height: 4.25rem; display: grid; place-items: center; margin: 0 auto .9rem; border-radius: 999px; background: linear-gradient(135deg, #fff2b8, #d1a33f 48%, #8d6418); color: #07180c; font-size: 2.3rem; font-weight: 950; }
+.result-locked .result-icon { background: rgba(166,211,108,.16); color: #a6d36c; border: 1px solid rgba(166,211,108,.32); }
+.result-card h2 { margin: 0; font-size: clamp(2.7rem, 12vw, 4.8rem); line-height: .92; letter-spacing: -.065em; }
+.result-copy { font-size: 1.24rem; line-height: 1.35; color: rgba(255,250,240,.86); margin: 1.1rem auto 0; }
+.handoff { color: #ffe7a3; font-weight: 900; font-size: 1.05rem; }
 .ghost-button { margin-top: 1rem; padding: 0 1.5rem; background: transparent; color: #fffaf0; border: 1px solid rgba(255,255,255,.25); box-shadow: none; }
-.is-unlocked { background: radial-gradient(circle at 50% 22%, rgba(216,185,104,.38), transparent 22rem), linear-gradient(145deg, #07170e, #010201); }
+.is-unlocked { background: radial-gradient(circle at 50% 22%, rgba(216,185,104,.34), transparent 22rem), linear-gradient(145deg, #07170e, #010201); }
 @media (min-width: 720px) {
   .unlock-page { padding: 2rem; }
   .unlock-shell { width: min(100%, 39rem); }
+  .lockbox-photo { width: min(26.25rem, 72vw); max-width: 420px; }
   .unlock-form { grid-template-columns: 1fr 1fr; padding: 1.2rem; }
   .unlock-form label:nth-child(3), .code-label, .checks, .form-error, .unlock-button { grid-column: 1 / -1; }
+  .code-boxes { gap: .65rem; }
+  .code-boxes input { min-height: 64px; font-size: 2rem; }
 }

--- a/src/UnlockPage.js
+++ b/src/UnlockPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import "./UnlockPage.css";
 
@@ -10,6 +10,9 @@ const initialForm = {
   followedFinallyHomeAgents: false,
   followedNorthSideGTA: false,
 };
+
+const codeDigits = Array.from({ length: 5 });
+const lockboxHeroPath = "/assets/unlock/lockbox-hero.jpg";
 
 function validate(form) {
   if (!form.name.trim()) return "Name is required.";
@@ -28,7 +31,38 @@ export default function UnlockPage() {
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState(null);
+  const [codeValues, setCodeValues] = useState(Array(5).fill(""));
+  const digitRefs = useRef([]);
   const update = (key, value) => setForm((current) => ({ ...current, [key]: value }));
+
+  function setCodeDigits(nextDigits) {
+    setCodeValues(nextDigits);
+    update("code", nextDigits.join(""));
+  }
+
+  function updateCodeDigit(index, value) {
+    const numeric = value.replace(/\D/g, "");
+    const nextDigits = [...codeValues];
+
+    if (numeric.length > 1) {
+      numeric.slice(0, 5 - index).split("").forEach((digit, offset) => {
+        nextDigits[index + offset] = digit;
+      });
+      setCodeDigits(nextDigits);
+      digitRefs.current[Math.min(index + numeric.length, 4)]?.focus();
+      return;
+    }
+
+    nextDigits[index] = numeric;
+    setCodeDigits(nextDigits);
+    if (numeric && index < 4) digitRefs.current[index + 1]?.focus();
+  }
+
+  function onCodeKeyDown(index, event) {
+    if (event.key === "Backspace" && !codeValues[index] && index > 0) {
+      digitRefs.current[index - 1]?.focus();
+    }
+  }
 
   async function onSubmit(event) {
     event.preventDefault();
@@ -61,30 +95,12 @@ export default function UnlockPage() {
     }
   }
 
-  if (result) {
-    const won = result === "unlocked";
-    return (
-      <main className={`unlock-page result-page ${won ? "is-unlocked" : "is-locked"}`}>
-        <Helmet><title>{won ? "Unlocked" : "Still locked"} | Mill Run Member Guest</title></Helmet>
-        <section className="result-card" aria-live="polite">
-          <p className="eyebrow">Mill Run Member Guest</p>
-          <h1>{won ? "Unlocked." : "Still locked."}</h1>
-          <p className="result-copy">
-            {won
-              ? "You won an entry into the 2026 Finally Home Fall Scramble."
-              : "Thanks for playing. Winners announced at dinner."}
-          </p>
-          {won && <p className="handoff">We’ll be in contact with you.</p>}
-          <button className="ghost-button" type="button" onClick={() => setResult(null)}>Try another code</button>
-        </section>
-      </main>
-    );
-  }
+  const won = result === "unlocked";
 
   return (
-    <main className="unlock-page">
+    <main className={`unlock-page ${result ? `has-result ${won ? "is-unlocked" : "is-locked"}` : ""}`}>
       <Helmet>
-        <title>Unlock the Prize | Finally Home Agents + NorthSide GTA</title>
+        <title>{result ? (won ? "Unlocked" : "Still locked") : "Unlock the Prize"} | Finally Home Agents + NorthSide GTA</title>
         <meta name="description" content="Enter your Mill Run Member Guest lockbox code for a chance to unlock the prize." />
       </Helmet>
       <section className="unlock-shell">
@@ -95,17 +111,9 @@ export default function UnlockPage() {
         </div>
 
         <div className="hero-lockup">
-          <div className="lockbox-visual" aria-hidden="true">
-            <div className="lockbox-shackle" />
-            <div className="lockbox-body">
-              <img src="/Images/fha-badge.png" alt="" />
-              <strong>LOCKBOX</strong>
-              <small>Mill Run</small>
-            </div>
-          </div>
+          <img className="lockbox-photo" src={lockboxHeroPath} alt="Finally Home Agents lockbox" />
           <p className="eyebrow">Finally Home Agents × NorthSide GTA</p>
-          <h1>Unlock the Prize</h1>
-          <p className="subheadline">Follow us. Enter your code. Crack the lockbox.</p>
+          <h1>Unlock the <span>Prize</span></h1>
         </div>
 
         <div className="prize-card">
@@ -120,20 +128,53 @@ export default function UnlockPage() {
           <li>If it unlocks, show Matthew or Landon at the hole</li>
         </ol>
 
-        <form className="unlock-form" onSubmit={onSubmit} noValidate>
-          <label>Name<input value={form.name} onChange={(e) => update("name", e.target.value)} autoComplete="name" required /></label>
-          <label>Phone<input value={form.phone} onChange={(e) => update("phone", e.target.value)} autoComplete="tel" inputMode="tel" required /></label>
-          <label>Instagram Handle<input value={form.instagramHandle} onChange={(e) => update("instagramHandle", e.target.value)} placeholder="@yourhandle" autoComplete="off" required /></label>
-          <label className="code-label">5-Digit Code<input value={form.code} onChange={(e) => update("code", e.target.value.replace(/\D/g, "").slice(0, 5))} inputMode="numeric" pattern="[0-9]*" maxLength="5" placeholder="•••••" required /></label>
+        {result ? (
+          <section className={`result-card ${won ? "result-win" : "result-locked"}`} aria-live="polite">
+            <div className="result-icon" aria-hidden="true">{won ? "✓" : "↻"}</div>
+            <p className="eyebrow">Mill Run Member Guest</p>
+            <h2>{won ? "You're In!" : "Not this time"}</h2>
+            <p className="result-copy">
+              {won
+                ? "You won an entry into the 2026 Finally Home Fall Scramble. Find Matthew or Landon at the hole to confirm."
+                : "Good luck on the Bonus Contest below."}
+            </p>
+            {won && <p className="handoff">Show this screen to Matthew or Landon.</p>}
+            <button className="ghost-button" type="button" onClick={() => setResult(null)}>Try another code</button>
+          </section>
+        ) : (
+          <form className="unlock-form" onSubmit={onSubmit} noValidate>
+            <label>Name<input value={form.name} onChange={(e) => update("name", e.target.value)} autoComplete="name" required /></label>
+            <label>Phone<input value={form.phone} onChange={(e) => update("phone", e.target.value)} autoComplete="tel" inputMode="tel" required /></label>
+            <label>Instagram Handle<input value={form.instagramHandle} onChange={(e) => update("instagramHandle", e.target.value)} placeholder="@yourhandle" autoComplete="off" required /></label>
+            <fieldset className="code-label">
+              <legend>5-Digit Code</legend>
+              <div className="code-boxes">
+                {codeDigits.map((_, index) => (
+                  <input
+                    key={index}
+                    ref={(node) => { digitRefs.current[index] = node; }}
+                    value={codeValues[index]}
+                    onChange={(e) => updateCodeDigit(index, e.target.value)}
+                    onKeyDown={(e) => onCodeKeyDown(index, e)}
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    maxLength="1"
+                    aria-label={`Code digit ${index + 1}`}
+                    required
+                  />
+                ))}
+              </div>
+            </fieldset>
 
-          <div className="checks">
-            <label><input type="checkbox" checked={form.followedFinallyHomeAgents} onChange={(e) => update("followedFinallyHomeAgents", e.target.checked)} /> I followed @FinallyHomeAgents</label>
-            <label><input type="checkbox" checked={form.followedNorthSideGTA} onChange={(e) => update("followedNorthSideGTA", e.target.checked)} /> I followed @NorthSideGTA</label>
-          </div>
+            <div className="checks">
+              <label><input type="checkbox" checked={form.followedFinallyHomeAgents} onChange={(e) => update("followedFinallyHomeAgents", e.target.checked)} /> I followed @FinallyHomeAgents</label>
+              <label><input type="checkbox" checked={form.followedNorthSideGTA} onChange={(e) => update("followedNorthSideGTA", e.target.checked)} /> I followed @NorthSideGTA</label>
+            </div>
 
-          {error && <p className="form-error" role="alert">{error}</p>}
-          <button className="unlock-button" type="submit" disabled={submitting}>{submitting ? "Checking…" : "Unlock"}</button>
-        </form>
+            {error && <p className="form-error" role="alert">{error}</p>}
+            <button className="unlock-button" type="submit" disabled={submitting}>{submitting ? "Checking…" : "Unlock"}</button>
+          </form>
+        )}
 
         <section className="birdie-card">
           <p className="eyebrow">Bonus contest</p>


### PR DESCRIPTION
### Motivation
- Convert the existing unlock page into a compact, in-person contest landing experience with clearer visuals and lower friction for golfers. 
- Replace the illustrative padlock with the real branded lockbox photo and simplify the header to a centered sponsor lockup so the page reads as a single-purpose contest card. 
- Improve legibility and reduce friction by switching to visible digit entry and by reserving gold only for the winning state. 
- Provide immediate in-place win/locked feedback so entrants can screenshot or show the result at the hole without a page reload.

### Description
- Replaced the illustrated lockbox lockup with a photo element wired to `"/assets/unlock/lockbox-hero.jpg"` and tightened its responsive sizing and drop-shadow in `src/UnlockPage.css` and `src/UnlockPage.js`.
- Simplified the hero/header to the centered Finally Home Agents + NorthSide GTA badge lockup and removed the duplicated subhead, keeping a single numbered `ol.steps-card` instruction list above the form in `src/UnlockPage.js`.
- Replaced the single masked code input with five visible single-digit inputs (`inputMode="numeric"`, `pattern="[0-9]*"`, auto-advance and backspace behaviour) while preserving the concatenated `code` value sent to `/api/unlock` in the form payload in `src/UnlockPage.js`.
- Added in-place result states (gold-accented win: `.result-win`, and a softer locked state `.result-locked`) that replace the form without navigation, and visually demoted the Bonus Contest card; moved the primary palette toward the site dark-green and made the resting `Unlock` button green in `src/UnlockPage.css`.
- Files changed: `src/UnlockPage.js`, `src/UnlockPage.css`; asset path for the hero image is `public/assets/unlock/lockbox-hero.jpg` (awaiting upload).
- Preserved all backend wiring: the `fetch` to `/api/unlock`, Formspree payload structure, and prize/bonus copy and win-condition logic were not altered.

### Testing
- Ran `npm test`, which completed successfully (all tests passed: 81/81).
- Ran `npm run build`, which completed successfully; the build emits existing warnings about missing `rrule` source maps and outdated Browserslist data but finished and produced the build artifacts.
- Committed changes and verified `git diff --check` produced no problems prior to the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a454a1d192883249fb7b2ea0be34ef2)