### PR TITLE
Refine unlock page hero layout

### DIFF
--- a/src/UnlockPage.css
+++ b/src/UnlockPage.css
@@ -1,98 +1,379 @@
 .unlock-page {
   min-height: 100vh;
   background:
-    radial-gradient(circle at 50% -8%, rgba(88, 151, 47, 0.34), transparent 32rem),
+    radial-gradient(
+      circle at 50% -8%,
+      rgba(88, 151, 47, 0.34),
+      transparent 32rem
+    ),
     radial-gradient(circle at 0 20%, rgba(35, 71, 10, 0.58), transparent 25rem),
-    radial-gradient(circle at 100% 55%, rgba(18, 88, 39, 0.28), transparent 24rem),
+    radial-gradient(
+      circle at 100% 55%,
+      rgba(18, 88, 39, 0.28),
+      transparent 24rem
+    ),
     linear-gradient(145deg, #020503 0%, #07180c 44%, #010201 100%);
   color: #fffaf0;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
   padding: 1rem;
 }
 .unlock-page::before {
-  content: "";
+  content: '';
   position: fixed;
   inset: 0;
   pointer-events: none;
-  background-image: linear-gradient(rgba(255,255,255,.025) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.018) 1px, transparent 1px);
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
   background-size: 34px 34px;
-  mask-image: linear-gradient(to bottom, rgba(0,0,0,.7), transparent 78%);
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent 78%);
 }
 .unlock-shell {
   position: relative;
-  width: min(100%, 32rem);
+  width: min(100%, 68rem);
   margin: 0 auto;
-  padding: .9rem 0 2.2rem;
+  padding: 0.75rem 0 1.4rem;
 }
 .brand-row {
   display: grid;
-  grid-template-columns: 3.55rem 1px 3.55rem;
-  gap: .85rem;
+  grid-template-columns: 3.35rem 1px 3.35rem;
+  gap: 0.85rem;
   align-items: center;
   justify-content: center;
-  margin-bottom: 1.15rem;
+  margin-bottom: 0.7rem;
 }
-.brand-row img { width: 3.55rem; height: 3.55rem; object-fit: contain; filter: drop-shadow(0 10px 22px rgba(0,0,0,.42)); }
-.brand-row span { height: 2.25rem; background: linear-gradient(transparent, rgba(216,185,104,.58), transparent); }
-.hero-lockup { text-align: center; padding: .15rem 0 .95rem; }
+.brand-row img {
+  width: 3.35rem;
+  height: 3.35rem;
+  object-fit: contain;
+  filter: drop-shadow(0 10px 22px rgba(0, 0, 0, 0.42));
+}
+.brand-row span {
+  height: 2.25rem;
+  background: linear-gradient(
+    transparent,
+    rgba(216, 185, 104, 0.58),
+    transparent
+  );
+}
+.unlock-hero {
+  display: grid;
+  gap: 0.65rem;
+  align-items: center;
+}
+.lockbox-stage {
+  display: grid;
+  place-items: center;
+  padding: 0.15rem 0 0.35rem;
+}
 .lockbox-photo {
   display: block;
-  width: min(17.5rem, 76vw);
-  max-width: 280px;
+  width: min(22rem, 86vw);
+  max-width: 352px;
   height: auto;
-  margin: 0 auto 1.1rem;
-  filter: drop-shadow(0 28px 48px rgba(0,0,0,.58));
+  filter: drop-shadow(0 24px 18px rgba(0, 0, 0, 0.34));
 }
-.eyebrow { margin: 0 0 .6rem; color: #d8b968; text-transform: uppercase; letter-spacing: .18em; font-size: .72rem; font-weight: 800; }
-.hero-lockup h1 { margin: 0; font-size: clamp(3rem, 13vw, 5.35rem); line-height: .9; letter-spacing: -.075em; }
-.hero-lockup h1 span { color: #d8b968; }
-.prize-card, .steps-card, .unlock-form, .result-card {
-  border: 1px solid rgba(108, 165, 74, .34);
-  background: rgba(255,255,255,.075);
-  box-shadow: 0 24px 80px rgba(0,0,0,.32);
+.hero-content {
+  display: grid;
+  gap: 0.65rem;
+}
+.hero-lockup {
+  text-align: center;
+}
+.eyebrow {
+  margin: 0 0 0.6rem;
+  color: #d8b968;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+.hero-lockup h1 {
+  margin: 0;
+  font-size: clamp(3rem, 13vw, 5.35rem);
+  line-height: 0.9;
+  letter-spacing: -0.075em;
+}
+.hero-lockup h1 span {
+  color: #d8b968;
+}
+.prize-line {
+  margin: 1.15rem auto 0;
+  color: rgba(255, 250, 240, 0.94);
+  font-size: clamp(1.1rem, 4vw, 1.55rem);
+  font-weight: 850;
+  line-height: 1.25;
+  max-width: 34rem;
+}
+.steps-card,
+.unlock-form,
+.result-card {
+  border: 1px solid rgba(166, 211, 108, 0.2);
+  background: rgba(255, 255, 255, 0.065);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
   backdrop-filter: blur(18px);
 }
-.prize-card { border-radius: 1.5rem; padding: 1.15rem; margin: 1.1rem 0; }
-.prize-card span { display:block; color:#d8b968; text-transform:uppercase; letter-spacing:.16em; font-size:.72rem; font-weight:800; margin-bottom:.3rem; }
-.prize-card strong { font-size: 1.35rem; line-height: 1.2; }
-.steps-card { margin: 0 0 1rem; padding: 1.1rem 1.1rem 1.1rem 2.35rem; border-radius: 1.35rem; color: rgba(255,250,240,.84); line-height: 1.55; }
-.steps-card li::marker { color: #a6d36c; font-weight: 900; }
-.unlock-form { border-radius: 1.7rem; padding: 1rem; display: grid; gap: .85rem; }
-.unlock-form label, .code-label { display: grid; gap: .35rem; color: rgba(255,250,240,.84); font-size: .88rem; font-weight: 750; }
-.unlock-form input { width: 100%; box-sizing: border-box; border: 1px solid rgba(255,255,255,.16); background: rgba(0,0,0,.35); color: #fffaf0; border-radius: 1rem; padding: .95rem 1rem; font: inherit; outline: none; }
-.unlock-form input:focus { border-color: #a6d36c; box-shadow: 0 0 0 4px rgba(80,151,42,.2); }
-.code-label { border: 0; margin: 0; padding: 0; }
-.code-label legend { padding: 0; margin-bottom: .35rem; }
-.code-boxes { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: .5rem; }
-.code-boxes input { min-height: 56px; padding: .3rem; text-align: center; font-size: 1.85rem; line-height: 1; font-weight: 950; }
-.checks { display: grid; gap: .65rem; padding: .25rem 0; }
-.checks label { grid-template-columns: 1.1rem 1fr; align-items: center; font-weight: 700; }
-.checks input { width: 1.1rem; height: 1.1rem; accent-color: #5f9f36; padding: 0; }
-.form-error { margin: 0; border: 1px solid rgba(255,120,120,.4); background: rgba(120,0,0,.25); color: #ffd7d7; border-radius: .9rem; padding: .8rem .9rem; font-weight: 750; }
-.unlock-button, .ghost-button { border: 0; border-radius: 999px; min-height: 3.5rem; background: linear-gradient(135deg, #6fb83e, #23470a 58%, #142d07); color: #fffaf0; font-weight: 950; letter-spacing: .04em; text-transform: uppercase; box-shadow: 0 18px 42px rgba(35,71,10,.32); cursor: pointer; }
-.unlock-button:disabled { opacity: .68; cursor: wait; }
-.birdie-card { margin: 1rem 0 1.2rem; border-radius: 1.2rem; padding: 1rem; border: 1px solid rgba(255,255,255,.14); background: rgba(255,255,255,.045); box-shadow: none; backdrop-filter: blur(12px); }
-.birdie-card .eyebrow { color: rgba(216,185,104,.82); font-size: .66rem; }
-.birdie-card h2 { margin: 0 0 .5rem; font-size: 1.28rem; letter-spacing: -.035em; }
-.birdie-card p:not(.eyebrow) { color: rgba(255,250,240,.72); line-height: 1.5; margin: .4rem 0 0; font-size: .95rem; }
-.unlock-shell footer { text-align: center; color: rgba(255,250,240,.62); font-size: .86rem; line-height: 1.5; padding: .7rem 0 0; }
-.result-card { position: relative; overflow: hidden; border-radius: 2rem; padding: 2rem 1.25rem; text-align: center; }
-.result-win { border-color: rgba(216,185,104,.68); box-shadow: 0 24px 90px rgba(216,185,104,.16), 0 24px 80px rgba(0,0,0,.36); }
-.result-win::before { content: ""; position: absolute; inset: -30%; background: radial-gradient(circle, rgba(216,185,104,.25) 0 2px, transparent 3px); background-size: 34px 34px; transform: rotate(18deg); opacity: .42; }
-.result-card > * { position: relative; }
-.result-icon { width: 4.25rem; height: 4.25rem; display: grid; place-items: center; margin: 0 auto .9rem; border-radius: 999px; background: linear-gradient(135deg, #fff2b8, #d1a33f 48%, #8d6418); color: #07180c; font-size: 2.3rem; font-weight: 950; }
-.result-locked .result-icon { background: rgba(166,211,108,.16); color: #a6d36c; border: 1px solid rgba(166,211,108,.32); }
-.result-card h2 { margin: 0; font-size: clamp(2.7rem, 12vw, 4.8rem); line-height: .92; letter-spacing: -.065em; }
-.result-copy { font-size: 1.24rem; line-height: 1.35; color: rgba(255,250,240,.86); margin: 1.1rem auto 0; }
-.handoff { color: #ffe7a3; font-weight: 900; font-size: 1.05rem; }
-.ghost-button { margin-top: 1rem; padding: 0 1.5rem; background: transparent; color: #fffaf0; border: 1px solid rgba(255,255,255,.25); box-shadow: none; }
-.is-unlocked { background: radial-gradient(circle at 50% 22%, rgba(216,185,104,.34), transparent 22rem), linear-gradient(145deg, #07170e, #010201); }
+.steps-card {
+  margin: 0;
+  padding: 0.9rem 1rem 0.9rem 1.1rem;
+  border-radius: 1.35rem;
+  color: rgba(255, 250, 240, 0.84);
+  line-height: 1.46;
+}
+.steps-card h2 {
+  margin: 0 0 0.45rem;
+  color: #d8b968;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+}
+.steps-card ol {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+.steps-card li {
+  padding-left: 0.15rem;
+}
+.steps-card li::marker {
+  color: #a6d36c;
+  font-weight: 900;
+}
+.unlock-form {
+  border-radius: 2rem;
+  padding: 1.15rem;
+  display: grid;
+  gap: 0.85rem;
+}
+.unlock-form label,
+.code-label {
+  display: grid;
+  gap: 0.35rem;
+  color: rgba(255, 250, 240, 0.84);
+  font-size: 0.88rem;
+  font-weight: 750;
+}
+.unlock-form input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  background: rgba(0, 0, 0, 0.33);
+  color: #fffaf0;
+  border-radius: 1rem;
+  padding: 0.95rem 1rem;
+  font: inherit;
+  outline: none;
+}
+.unlock-form input:focus {
+  border-color: #a6d36c;
+  box-shadow: 0 0 0 4px rgba(80, 151, 42, 0.2);
+}
+.code-label {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+.code-label legend {
+  padding: 0;
+  margin-bottom: 0.35rem;
+}
+.code-boxes {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+.code-boxes input {
+  min-height: 56px;
+  padding: 0.3rem;
+  text-align: center;
+  font-size: 1.85rem;
+  line-height: 1;
+  font-weight: 950;
+}
+.checks {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.25rem 0;
+}
+.checks label {
+  grid-template-columns: 1.1rem 1fr;
+  align-items: center;
+  font-weight: 700;
+}
+.checks input {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #5f9f36;
+  padding: 0;
+}
+.form-error {
+  margin: 0;
+  border: 1px solid rgba(255, 120, 120, 0.4);
+  background: rgba(120, 0, 0, 0.25);
+  color: #ffd7d7;
+  border-radius: 0.9rem;
+  padding: 0.8rem 0.9rem;
+  font-weight: 750;
+}
+.unlock-button,
+.ghost-button {
+  border: 0;
+  border-radius: 999px;
+  min-height: 3.5rem;
+  background: linear-gradient(135deg, #6fb83e, #23470a 58%, #142d07);
+  color: #fffaf0;
+  font-weight: 950;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  box-shadow: 0 18px 42px rgba(35, 71, 10, 0.32);
+  cursor: pointer;
+}
+.unlock-button:disabled {
+  opacity: 0.68;
+  cursor: wait;
+}
+.result-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 2rem;
+  padding: 2rem 1.25rem;
+  text-align: center;
+}
+.result-win {
+  border-color: rgba(216, 185, 104, 0.68);
+  box-shadow:
+    0 24px 90px rgba(216, 185, 104, 0.16),
+    0 24px 80px rgba(0, 0, 0, 0.36);
+}
+.result-win::before {
+  content: '';
+  position: absolute;
+  inset: -30%;
+  background: radial-gradient(
+    circle,
+    rgba(216, 185, 104, 0.25) 0 2px,
+    transparent 3px
+  );
+  background-size: 34px 34px;
+  transform: rotate(18deg);
+  opacity: 0.42;
+}
+.result-card > * {
+  position: relative;
+}
+.result-icon {
+  width: 4.25rem;
+  height: 4.25rem;
+  display: grid;
+  place-items: center;
+  margin: 0 auto 0.9rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #fff2b8, #d1a33f 48%, #8d6418);
+  color: #07180c;
+  font-size: 2.3rem;
+  font-weight: 950;
+}
+.result-locked .result-icon {
+  background: rgba(166, 211, 108, 0.16);
+  color: #a6d36c;
+  border: 1px solid rgba(166, 211, 108, 0.32);
+}
+.result-card h2 {
+  margin: 0;
+  font-size: clamp(2.7rem, 12vw, 4.8rem);
+  line-height: 0.92;
+  letter-spacing: -0.065em;
+}
+.result-copy {
+  font-size: 1.16rem;
+  line-height: 1.35;
+  color: rgba(255, 250, 240, 0.86);
+  margin: 1.1rem auto 0;
+}
+.handoff {
+  color: #ffe7a3;
+  font-weight: 900;
+  font-size: 1.05rem;
+}
+.ghost-button {
+  margin-top: 1rem;
+  padding: 0 1.5rem;
+  background: transparent;
+  color: #fffaf0;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: none;
+}
+.is-unlocked {
+  background:
+    radial-gradient(
+      circle at 50% 22%,
+      rgba(216, 185, 104, 0.34),
+      transparent 22rem
+    ),
+    linear-gradient(145deg, #07170e, #010201);
+}
 @media (min-width: 720px) {
-  .unlock-page { padding: 2rem; }
-  .unlock-shell { width: min(100%, 39rem); }
-  .lockbox-photo { width: min(26.25rem, 72vw); max-width: 420px; }
-  .unlock-form { grid-template-columns: 1fr 1fr; padding: 1.2rem; }
-  .unlock-form label:nth-child(3), .code-label, .checks, .form-error, .unlock-button { grid-column: 1 / -1; }
-  .code-boxes { gap: .65rem; }
-  .code-boxes input { min-height: 64px; font-size: 2rem; }
+  .unlock-page {
+    padding: 1.35rem 2rem;
+  }
+  .unlock-shell {
+    padding-top: 0.45rem;
+  }
+  .brand-row {
+    margin-bottom: 0.35rem;
+  }
+  .unlock-hero {
+    grid-template-columns: minmax(19rem, 0.95fr) minmax(25rem, 1.05fr);
+    gap: clamp(1.2rem, 4vw, 3rem);
+    min-height: calc(100vh - 8.2rem);
+  }
+  .lockbox-stage {
+    align-self: center;
+    padding: 0;
+  }
+  .lockbox-photo {
+    width: min(36vw, 34rem);
+    max-width: 540px;
+  }
+  .hero-lockup {
+    text-align: left;
+  }
+  .hero-lockup h1 {
+    font-size: clamp(4.2rem, 7vw, 6.25rem);
+  }
+  .prize-line {
+    margin: 1.45rem 0 0;
+  }
+  .unlock-form {
+    grid-template-columns: 1fr 1fr;
+    padding: 1.35rem;
+  }
+  .unlock-form label:nth-child(3),
+  .code-label,
+  .checks,
+  .form-error,
+  .unlock-button {
+    grid-column: 1 / -1;
+  }
+  .code-boxes {
+    gap: 0.65rem;
+  }
+  .code-boxes input {
+    min-height: 64px;
+    font-size: 2rem;
+  }
+}
+@media (min-width: 980px) {
+  .hero-content {
+    gap: 0.75rem;
+  }
+  .steps-card {
+    padding: 1rem 1.15rem 1rem 1.25rem;
+  }
 }

--- a/src/UnlockPage.js
+++ b/src/UnlockPage.js
@@ -1,107 +1,123 @@
-import React, { useRef, useState } from "react";
-import { Helmet } from "react-helmet-async";
-import "./UnlockPage.css";
+import React, { useRef, useState } from 'react'
+import { Helmet } from 'react-helmet-async'
+import './UnlockPage.css'
 
 const initialForm = {
-  name: "",
-  phone: "",
-  instagramHandle: "",
-  code: "",
+  name: '',
+  phone: '',
+  instagramHandle: '',
+  code: '',
   followedFinallyHomeAgents: false,
   followedNorthSideGTA: false,
-};
+}
 
-const codeDigits = Array.from({ length: 5 });
-const lockboxHeroPath = "/assets/unlock/lockbox-hero.jpg";
+const codeDigits = Array.from({ length: 5 })
+const lockboxHeroPath = '/assets/unlock/lockbox-hero.png'
 
 function validate(form) {
-  if (!form.name.trim()) return "Name is required.";
-  if (!form.phone.trim()) return "Phone is required.";
-  if (!form.instagramHandle.trim()) return "Instagram handle is required.";
-  if (!form.code.trim()) return "5-digit code is required.";
-  if (!/^\d{5}$/.test(form.code)) return "Code must be exactly 5 numeric digits.";
+  if (!form.name.trim()) return 'Name is required.'
+  if (!form.phone.trim()) return 'Phone is required.'
+  if (!form.instagramHandle.trim()) return 'Instagram handle is required.'
+  if (!form.code.trim()) return '5-digit code is required.'
+  if (!/^\d{5}$/.test(form.code))
+    return 'Code must be exactly 5 numeric digits.'
   if (!form.followedFinallyHomeAgents && !form.followedNorthSideGTA) {
-    return "Check at least one follow box to play.";
+    return 'Check at least one follow box to play.'
   }
-  return "";
+  return ''
 }
 
 export default function UnlockPage() {
-  const [form, setForm] = useState(initialForm);
-  const [error, setError] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [result, setResult] = useState(null);
-  const [codeValues, setCodeValues] = useState(Array(5).fill(""));
-  const digitRefs = useRef([]);
-  const update = (key, value) => setForm((current) => ({ ...current, [key]: value }));
+  const [form, setForm] = useState(initialForm)
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState(null)
+  const [codeValues, setCodeValues] = useState(Array(5).fill(''))
+  const digitRefs = useRef([])
+  const update = (key, value) =>
+    setForm((current) => ({ ...current, [key]: value }))
 
   function setCodeDigits(nextDigits) {
-    setCodeValues(nextDigits);
-    update("code", nextDigits.join(""));
+    setCodeValues(nextDigits)
+    update('code', nextDigits.join(''))
   }
 
   function updateCodeDigit(index, value) {
-    const numeric = value.replace(/\D/g, "");
-    const nextDigits = [...codeValues];
+    const numeric = value.replace(/\D/g, '')
+    const nextDigits = [...codeValues]
 
     if (numeric.length > 1) {
-      numeric.slice(0, 5 - index).split("").forEach((digit, offset) => {
-        nextDigits[index + offset] = digit;
-      });
-      setCodeDigits(nextDigits);
-      digitRefs.current[Math.min(index + numeric.length, 4)]?.focus();
-      return;
+      numeric
+        .slice(0, 5 - index)
+        .split('')
+        .forEach((digit, offset) => {
+          nextDigits[index + offset] = digit
+        })
+      setCodeDigits(nextDigits)
+      digitRefs.current[Math.min(index + numeric.length, 4)]?.focus()
+      return
     }
 
-    nextDigits[index] = numeric;
-    setCodeDigits(nextDigits);
-    if (numeric && index < 4) digitRefs.current[index + 1]?.focus();
+    nextDigits[index] = numeric
+    setCodeDigits(nextDigits)
+    if (numeric && index < 4) digitRefs.current[index + 1]?.focus()
   }
 
   function onCodeKeyDown(index, event) {
-    if (event.key === "Backspace" && !codeValues[index] && index > 0) {
-      digitRefs.current[index - 1]?.focus();
+    if (event.key === 'Backspace' && !codeValues[index] && index > 0) {
+      digitRefs.current[index - 1]?.focus()
     }
   }
 
   async function onSubmit(event) {
-    event.preventDefault();
-    if (submitting) return;
+    event.preventDefault()
+    if (submitting) return
 
-    const message = validate(form);
+    const message = validate(form)
     if (message) {
-      setError(message);
-      return;
+      setError(message)
+      return
     }
 
-    setError("");
-    setSubmitting(true);
+    setError('')
+    setSubmitting(true)
     try {
-      const response = await fetch("/api/unlock", {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Accept: "application/json" },
+      const response = await fetch('/api/unlock', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
         body: JSON.stringify({ ...form, pageUrl: window.location.href }),
-      });
-      const data = await response.json();
+      })
+      const data = await response.json()
       if (response.status === 429) {
-        setError(data.error || "Too many attempts. Please try again later.");
-        return;
+        setError(data.error || 'Too many attempts. Please try again later.')
+        return
       }
-      setResult(data.unlocked ? "unlocked" : "locked");
+      setResult(data.unlocked ? 'unlocked' : 'locked')
     } catch {
-      setError("We couldn't reach the lockbox. Please try again.");
+      setError("We couldn't reach the lockbox. Please try again.")
     } finally {
-      setSubmitting(false);
+      setSubmitting(false)
     }
   }
 
-  const won = result === "unlocked";
+  const won = result === 'unlocked'
 
   return (
-    <main className={`unlock-page ${result ? `has-result ${won ? "is-unlocked" : "is-locked"}` : ""}`}>
+    <main
+      className={`unlock-page ${result ? `has-result ${won ? 'is-unlocked' : 'is-locked'}` : ''}`}
+    >
       <Helmet>
-        <title>{result ? (won ? "Unlocked" : "Still locked") : "Unlock the Prize"} | Finally Home Agents + NorthSide GTA</title>
-        <meta name="description" content="Enter your Mill Run Member Guest lockbox code for a chance to unlock the prize." />
+        <title>
+          {result ? (won ? 'Unlocked' : 'Still locked') : 'Unlock the Prize'} |
+          Finally Home Agents + NorthSide GTA
+        </title>
+        <meta
+          name="description"
+          content="Enter your Mill Run Member Guest lockbox code for a chance to unlock the prize."
+        />
       </Helmet>
       <section className="unlock-shell">
         <div className="brand-row" aria-label="Event sponsors">
@@ -110,81 +126,156 @@ export default function UnlockPage() {
           <img src="/Images/northsidegta-logo.svg" alt="NorthSide GTA" />
         </div>
 
-        <div className="hero-lockup">
-          <img className="lockbox-photo" src={lockboxHeroPath} alt="Finally Home Agents lockbox" />
-          <p className="eyebrow">Finally Home Agents × NorthSide GTA</p>
-          <h1>Unlock the <span>Prize</span></h1>
-        </div>
+        <div className="unlock-hero">
+          <div className="lockbox-stage" aria-hidden="true">
+            <img className="lockbox-photo" src={lockboxHeroPath} alt="" />
+          </div>
 
-        <div className="prize-card">
-          <span>Prize</span>
-          <strong>Entry into the 2026 Finally Home Fall Scramble</strong>
-        </div>
-
-        <ol className="steps-card">
-          <li>Follow @FinallyHomeAgents on Instagram</li>
-          <li>Follow @NorthSideGTA for a bonus chance</li>
-          <li>Enter your 5-digit lockbox code</li>
-          <li>If it unlocks, show Matthew or Landon at the hole</li>
-        </ol>
-
-        {result ? (
-          <section className={`result-card ${won ? "result-win" : "result-locked"}`} aria-live="polite">
-            <div className="result-icon" aria-hidden="true">{won ? "✓" : "↻"}</div>
-            <p className="eyebrow">Mill Run Member Guest</p>
-            <h2>{won ? "You're In!" : "Not this time"}</h2>
-            <p className="result-copy">
-              {won
-                ? "You won an entry into the 2026 Finally Home Fall Scramble. Find Matthew or Landon at the hole to confirm."
-                : "Good luck on the Bonus Contest below."}
-            </p>
-            {won && <p className="handoff">Show this screen to Matthew or Landon.</p>}
-            <button className="ghost-button" type="button" onClick={() => setResult(null)}>Try another code</button>
-          </section>
-        ) : (
-          <form className="unlock-form" onSubmit={onSubmit} noValidate>
-            <label>Name<input value={form.name} onChange={(e) => update("name", e.target.value)} autoComplete="name" required /></label>
-            <label>Phone<input value={form.phone} onChange={(e) => update("phone", e.target.value)} autoComplete="tel" inputMode="tel" required /></label>
-            <label>Instagram Handle<input value={form.instagramHandle} onChange={(e) => update("instagramHandle", e.target.value)} placeholder="@yourhandle" autoComplete="off" required /></label>
-            <fieldset className="code-label">
-              <legend>5-Digit Code</legend>
-              <div className="code-boxes">
-                {codeDigits.map((_, index) => (
-                  <input
-                    key={index}
-                    ref={(node) => { digitRefs.current[index] = node; }}
-                    value={codeValues[index]}
-                    onChange={(e) => updateCodeDigit(index, e.target.value)}
-                    onKeyDown={(e) => onCodeKeyDown(index, e)}
-                    inputMode="numeric"
-                    pattern="[0-9]*"
-                    maxLength="1"
-                    aria-label={`Code digit ${index + 1}`}
-                    required
-                  />
-                ))}
-              </div>
-            </fieldset>
-
-            <div className="checks">
-              <label><input type="checkbox" checked={form.followedFinallyHomeAgents} onChange={(e) => update("followedFinallyHomeAgents", e.target.checked)} /> I followed @FinallyHomeAgents</label>
-              <label><input type="checkbox" checked={form.followedNorthSideGTA} onChange={(e) => update("followedNorthSideGTA", e.target.checked)} /> I followed @NorthSideGTA</label>
+          <div className="hero-content">
+            <div className="hero-lockup">
+              <p className="eyebrow">Finally Home Agents × NorthSide GTA</p>
+              <h1>
+                Unlock the <span>Prize</span>
+              </h1>
+              <p className="prize-line">
+                🏆 Win Entry into the 2026 Finally Home Fall Scramble
+              </p>
             </div>
 
-            {error && <p className="form-error" role="alert">{error}</p>}
-            <button className="unlock-button" type="submit" disabled={submitting}>{submitting ? "Checking…" : "Unlock"}</button>
-          </form>
-        )}
+            <section
+              className="steps-card"
+              aria-labelledby="how-it-works-heading"
+            >
+              <h2 id="how-it-works-heading">How it Works</h2>
+              <ol>
+                <li>Follow @FinallyHomeAgents on Instagram</li>
+                <li>Follow @NorthSideGTA for a bonus chance</li>
+                <li>Enter your 5-digit lockbox code</li>
+                <li>If it unlocks, show Matthew or Landon at the hole</li>
+              </ol>
+            </section>
 
-        <section className="birdie-card">
-          <p className="eyebrow">Bonus contest</p>
-          <h2>Longest Birdie of the Day</h2>
-          <p>The longest made birdie on this hole wins an entry into the 2026 Finally Home Fall Scramble.</p>
-          <p>Matthew and Landon will be on the green to witness and measure every birdie.</p>
-        </section>
+            {result ? (
+              <section
+                className={`result-card ${won ? 'result-win' : 'result-locked'}`}
+                aria-live="polite"
+              >
+                <div className="result-icon" aria-hidden="true">
+                  {won ? '✓' : '↻'}
+                </div>
+                <p className="eyebrow">Mill Run Member Guest</p>
+                <h2>{won ? "You're In!" : 'Not this time'}</h2>
+                <p className="result-copy">
+                  {won
+                    ? 'You won an entry into the 2026 Finally Home Fall Scramble. Find Matthew or Landon at the hole to confirm.'
+                    : 'The box is still locked. You can try another code if you have one.'}
+                </p>
+                {won && (
+                  <p className="handoff">
+                    Show this screen to Matthew or Landon.
+                  </p>
+                )}
+                <button
+                  className="ghost-button"
+                  type="button"
+                  onClick={() => setResult(null)}
+                >
+                  Try another code
+                </button>
+              </section>
+            ) : (
+              <form className="unlock-form" onSubmit={onSubmit} noValidate>
+                <label>
+                  Name
+                  <input
+                    value={form.name}
+                    onChange={(e) => update('name', e.target.value)}
+                    autoComplete="name"
+                    required
+                  />
+                </label>
+                <label>
+                  Phone
+                  <input
+                    value={form.phone}
+                    onChange={(e) => update('phone', e.target.value)}
+                    autoComplete="tel"
+                    inputMode="tel"
+                    required
+                  />
+                </label>
+                <label>
+                  Instagram Handle
+                  <input
+                    value={form.instagramHandle}
+                    onChange={(e) => update('instagramHandle', e.target.value)}
+                    placeholder="@yourhandle"
+                    autoComplete="off"
+                    required
+                  />
+                </label>
+                <fieldset className="code-label">
+                  <legend>5-Digit Code</legend>
+                  <div className="code-boxes">
+                    {codeDigits.map((_, index) => (
+                      <input
+                        key={index}
+                        ref={(node) => {
+                          digitRefs.current[index] = node
+                        }}
+                        value={codeValues[index]}
+                        onChange={(e) => updateCodeDigit(index, e.target.value)}
+                        onKeyDown={(e) => onCodeKeyDown(index, e)}
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        maxLength="1"
+                        aria-label={`Code digit ${index + 1}`}
+                        required
+                      />
+                    ))}
+                  </div>
+                </fieldset>
 
-        <footer>Finally Home Agents | NorthSide GTA<br />Mill Run Member Guest Tournament</footer>
+                <div className="checks">
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={form.followedFinallyHomeAgents}
+                      onChange={(e) =>
+                        update('followedFinallyHomeAgents', e.target.checked)
+                      }
+                    />{' '}
+                    I followed @FinallyHomeAgents
+                  </label>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={form.followedNorthSideGTA}
+                      onChange={(e) =>
+                        update('followedNorthSideGTA', e.target.checked)
+                      }
+                    />{' '}
+                    I followed @NorthSideGTA
+                  </label>
+                </div>
+
+                {error && (
+                  <p className="form-error" role="alert">
+                    {error}
+                  </p>
+                )}
+                <button
+                  className="unlock-button"
+                  type="submit"
+                  disabled={submitting}
+                >
+                  {submitting ? 'Checking…' : 'Unlock'}
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
       </section>
     </main>
-  );
+  )
 }


### PR DESCRIPTION
### Motivation
- Move the lockbox art to the transparent PNG and reshape the hero so the lockbox sits naturally on the page and becomes the visual focal point.
- Replace the stacked lockbox/header/prize layout with a responsive two-column hero so the page fits above the fold on desktop while remaining stacked-first on mobile.
- Shorten and simplify the content by folding the prize into the headline area and keeping only sponsor lockup, heading, prize, instructions, and the entry form.
- Make the form feel more premium and adjust spacing so instructions and form feel like a single unified component.

### Description
- Swapped the hero asset reference from `"/assets/unlock/lockbox-hero.jpg"` to `"/assets/unlock/lockbox-hero.png"` in `src/UnlockPage.js` and updated the component markup to a single `unlock-hero` container with `lockbox-stage` and `hero-content` columns.
- Removed the separate prize card and added a compact `prize-line` under the `Unlock the Prize` heading, and moved the steps into a compact `steps-card` section in the hero content.
- Reworked the layout and sizing in `src/UnlockPage.css` to implement a responsive two-column grid at desktop/tablet breakpoints, increase the lockbox render size (≈20–30%), vertically center the image on desktop, and add a subtle drop shadow beneath the lockbox.
- Updated form styling (larger border radius, softer border color, slightly increased padding) and tightened spacing between headline, prize line, steps, and form so they read as a single premium unit.

### Testing
- Ran `npm test` with the project test suite and all tests passed (81/81).
- Ran `npm run build` and the project built successfully; build emitted existing dependency/source-map warnings but completed without errors.
- Applied formatting with `npx prettier --write src/UnlockPage.js src/UnlockPage.css` and confirmed files were formatted.
- Started the dev server and produced a Playwright screenshot of `/unlock` to validate the responsive hero layout and visual changes (screenshot created successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45510d4c188324983dd54be197a2ef)