### PR TITLE
Fix homepage NorthSide map clipping

### DIFF
--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -421,8 +421,8 @@ main { padding-top: 0; }
   font-weight: 500;
   color: #16a34a;
 }
-.hero__map-frame { position: relative; flex: 1; overflow: visible; }
-.northside-map { width: 100%; height: 100%; object-fit: cover; overflow: visible; }
+.hero__map-frame { position: relative; flex: 0 0 auto; overflow: visible; }
+.northside-map { width: 100%; height: auto; object-fit: contain; overflow: visible; }
 .map-legend {
   position: absolute;
   left: 14px;
@@ -1196,8 +1196,9 @@ main { padding-top: 0; }
 .hero__map-frame svg.northside-map--inline {
   display: block;
   width: 100%;
-  height: 100%;
-  min-height: 360px;
+  height: auto;
+  min-height: 0;
+  overflow: visible;
 }
 .northside-map--inline .map-town {
   cursor: pointer;
@@ -1703,9 +1704,7 @@ main { padding-top: 0; }
 
 @media (min-width: 1024px) {
   .hero__grid {
-    height: calc(100vh - 81px - 48px);
     min-height: 480px;
-    max-height: 680px;
   }
 
   .hero__copy,
@@ -1716,7 +1715,7 @@ main { padding-top: 0; }
 
   .hero__map-frame {
     min-height: 0;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .focus-community-rail__track {

--- a/src/HomePage.css
+++ b/src/HomePage.css
@@ -306,6 +306,10 @@ main { padding-top: 0; }
 .hero__grid {
   display: grid;
   grid-template-columns: 1fr;
+  height: auto;
+  min-height: unset;
+  max-height: none;
+  overflow: visible;
 }
 @media (min-width: 1024px) {
   .hero__grid { grid-template-columns: 44% 56%; }
@@ -1588,9 +1592,10 @@ main { padding-top: 0; }
 @media (min-width: 1024px) {
   .hero__grid {
     grid-template-columns: 50% 50%;
-    height: calc(100vh - 80px - 45px - 137px);
-    min-height: 480px;
-    max-height: 680px;
+    height: auto;
+    min-height: unset;
+    max-height: none;
+    overflow: visible;
   }
 }
 
@@ -1676,7 +1681,7 @@ main { padding-top: 0; }
 
 /* Production hero bug fixes: isolate media layers and keep logo rail clean/visible. */
 .hero__grid {
-  overflow: hidden;
+  overflow: visible;
 }
 
 .hero__copy {
@@ -1704,7 +1709,10 @@ main { padding-top: 0; }
 
 @media (min-width: 1024px) {
   .hero__grid {
-    min-height: 480px;
+    height: auto;
+    min-height: unset;
+    max-height: none;
+    overflow: visible;
   }
 
   .hero__copy,


### PR DESCRIPTION
### Motivation
- The homepage NorthSide interactive map was being visually cropped at the bottom due to fixed container heights and SVG/styling that stretched the artwork, hiding the lower row of nearby communities and bottom boundary.
- The goal is to let the SVG render at its intrinsic aspect ratio (`width:100%`, `height:auto`) and avoid cropping while preserving the existing layout, legend, and responsive behavior.

### Description
- Adjusted map wrapper and SVG sizing in `src/HomePage.css` so the map uses `height: auto`, `width: 100%`, `object-fit: contain`, and `overflow: visible` instead of forcing `height: 100%`/`object-fit: cover`.
- Updated the inline SVG rule `.hero__map-frame svg.northside-map--inline` to `height: auto`, `min-height: 0`, and `overflow: visible` so the full artwork displays at any viewport.
- Removed the strict desktop hero grid height/max-height constraint and changed the desktop `.hero__map-frame` overflow from `hidden` to `visible` so lower labels/icons are not clipped.
- All changes are confined to `src/HomePage.css` and preserve the map legend, logo rail, and responsive layout.

### Testing
- Ran `git diff --check` to validate whitespace and patch hygiene (no issues found).
- Executed `npm test -- --test-name-pattern=static-buyers-shell`, which completed successfully but the test run skipped matched cases due to the pattern (no failures from this run).
- Built the production bundle with `npm run build`, which completed successfully; build emitted existing warnings about stale Browserslist data and `rrule` source-map files but the build finished.
- Started the dev server with `BROWSER=none npm start` and confirmed compilation (existing `rrule` warnings only).
- Verified the visual fix with automated Playwright navigation and screenshots of `#northside-map-container` on desktop and mobile viewports, confirming the SVG container and map artwork render without bottom clipping.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bf79bed8483249a05d8dff0e60126)