### PR TITLE
Use exact June 2026 TRREB market data across snapshots

### DIFF
--- a/scripts/verify-prerendered-seo.js
+++ b/scripts/verify-prerendered-seo.js
@@ -4,7 +4,6 @@ const fs = require("fs");
 const path = require("path");
 const { parse } = require("node-html-parser");
 const { loadPublishedInsights } = require("./utils/publishedInsights");
-const { getMarketTrend } = require("../src/utils/marketTrend");
 
 const rootDir = path.resolve(__dirname, "..");
 const buildDir = path.join(rootDir, "build");
@@ -309,14 +308,14 @@ if (!fs.existsSync(sitemapPath)) {
 }
 
 const homepageText = readRoute("/")?.querySelector("body")?.text.replace(/\s+/g, " ").trim() || "";
-const marketWatch = marketData.datasets.marketWatch;
 [
-  marketData.lastUpdated,
-  marketWatch.source,
-  ...Object.values(marketWatch.towns).flatMap(({ averageSold, daysOnMarket, yearOverYear }) => [
-    averageSold,
-    `${daysOnMarket} days on market`,
-    yearOverYear,
+  marketData.period,
+  marketData.source,
+  marketData.homeType,
+  ...Object.values(marketData.municipalities).flatMap(({ averageSalePrice, salesCount, avgLdom }) => [
+    averageSalePrice,
+    `Sales count ${salesCount}`,
+    `Avg. LDOM ${avgLdom}`,
   ]),
 ].forEach((value) => {
   if (!homepageText.includes(value)) {
@@ -324,26 +323,22 @@ const marketWatch = marketData.datasets.marketWatch;
   }
 });
 
-[
-  ["-7.8%", "down", "↓ -7.8%"],
-  ["+3.0%", "up", "↑ +3.0%"],
-  ["0.0%", "neutral", "0.0%"],
-].forEach(([value, direction, label]) => {
-  const trend = getMarketTrend(value);
-  if (trend.direction !== direction || trend.label !== label) {
-    failures.push(`market trend ${value}: expected ${direction} / "${label}", received ${trend.direction} / "${trend.label}"`);
-  }
-});
-
-const homepageDoc = readRoute("/");
-Object.entries(marketWatch.towns).forEach(([slug, town]) => {
-  const trend = getMarketTrend(town.yearOverYear);
-  const matchingTrend = homepageDoc
-    ?.querySelectorAll(`.market-card__yoy--${trend.direction}`)
-    .find((node) => node.text.replace(/\s+/g, " ").trim() === trend.label);
-  if (!matchingTrend) {
-    failures.push(`/: missing ${slug} market trend class/label ${trend.direction} / "${trend.label}"`);
-  }
+Object.entries(marketData.municipalities).forEach(([slug, town]) => {
+  const route = `/communities/${slug}`;
+  const communityText = readRoute(route)?.querySelector("body")?.text.replace(/\s+/g, " ").trim() || "";
+  [
+    marketData.period,
+    `Source: ${marketData.source}`,
+    town.averageSalePrice,
+    "Sales count",
+    String(town.salesCount),
+    "Avg. LDOM",
+    String(town.avgLdom),
+  ].forEach((value) => {
+    if (!communityText.includes(value)) {
+      failures.push(`${route}: community market snapshot is missing shared value "${value}"`);
+    }
+  });
 });
 
 const robots = fs.readFileSync(path.join(rootDir, "public", "robots.txt"), "utf8");
@@ -411,7 +406,7 @@ console.log(
 console.log("[audit] PASS — 7 community pages: unique H1/title, self canonical, BreadcrumbList");
 console.log("[audit] PASS — 10 static pages: crawlable body content and self canonicals");
 console.log(`[audit] PASS — ${checkedInsights} published insights: body content and Article JSON-LD`);
-console.log("[audit] PASS — homepage: FAQPage, RealEstateAgent, shared market data, sign-aware YoY");
+console.log("[audit] PASS — homepage and community snapshots: exact shared June 2026 market data");
 console.log("[audit] PASS — sitemap: published non-www URLs only; rendered heads: zero www references");
 console.log("[audit] PASS — cache: HTML/fallback revalidate, hashed assets immutable, retired insights 410/no-store");
 console.log("[audit] PASS — AI search: llms.txt, permissive robots, consistent site entity JSON-LD");

--- a/src/AuroraPage.js
+++ b/src/AuroraPage.js
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet-async";
 import HeaderShell from "./components/HeaderShell";
 import MARKET_DATA from "./data/marketData.json";
 
-const TOWN_MARKET = MARKET_DATA.datasets.communityGuide.towns.aurora;
+const TOWN_MARKET = MARKET_DATA.municipalities.aurora;
 const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
@@ -198,10 +198,10 @@ const PAGE_BODY_HTML = `
     <h1>Living in Aurora</h1>
     <p class="hero-sub">Established neighbourhoods, strong schools, heritage streets, GO access, and one of the most complete lifestyles in the NorthSide GTA.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSold}</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSalePrice}</div><div class="hstat-lbl">Avg. sale price</div></div>
       <div class="hstat"><div class="hstat-val">35 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.daysOnMarket}d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.monthsInventory} mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.salesCount}</div><div class="hstat-lbl">Sales</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.avgLdom}d</div><div class="hstat-lbl">Avg. LDOM</div></div>
     </div>
   </div>
 </section>
@@ -399,16 +399,11 @@ const PAGE_BODY_HTML = `
 
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
-        <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">${TOWN_MARKET.averageSold}</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">${TOWN_MARKET.detachedAverage}</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">${TOWN_MARKET.townhouseAverage}</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">${TOWN_MARKET.condoAverage}</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">${TOWN_MARKET.daysOnMarket}d</span></div>
-        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">${TOWN_MARKET.saleToListRatio}</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">${TOWN_MARKET.monthsInventory}</span></div>
-        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">${TOWN_MARKET.marketType}</span></span></div>
-        <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">${MARKET_DATA.datasets.communityGuide.source}. Not an appraisal. Confirm with a registered agent before decisions.</p>
+        <h3>Market snapshot · ${MARKET_DATA.period}</h3>
+        <div class="prow"><span class="pk">Average sale price</span><span class="pv">${TOWN_MARKET.averageSalePrice}</span></div>
+        <div class="prow"><span class="pk">Sales count</span><span class="pv">${TOWN_MARKET.salesCount}</span></div>
+        <div class="prow"><span class="pk">Avg. LDOM</span><span class="pv">${TOWN_MARKET.avgLdom}</span></div>
+        <p style="font-size:10px;color:rgba(255,255,255,0.55);margin-top:10px;line-height:1.6;">Source: ${MARKET_DATA.source}. ${MARKET_DATA.homeType}. Not an appraisal.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->

--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -6,7 +6,6 @@ import { getFormEndpoint } from "./components/contact/contactConfig";
 import { BUYER_FAQS, BUYERS_SCHEMA } from "./components/seo/buyersSchema.mjs";
 import MARKET_DATA from "./data/marketData.json";
 
-const { getMarketTrend } = require("./utils/marketTrend");
 const COMMUNITIES = [
   "Aurora",
   "Newmarket",
@@ -166,14 +165,14 @@ const PHOTO_GRID = [
   },
 ];
 
-const MARKET_WATCH_TOWNS = MARKET_DATA.datasets.marketWatch.towns;
+const MARKET_WATCH_TOWNS = MARKET_DATA.municipalities;
 const MARKET_SNAPSHOT = COMMUNITIES.map((town) => {
   const townMarket = MARKET_WATCH_TOWNS[TOWN_DATA[town].slug];
   return {
     town,
-    price: townMarket.averageSold,
-    days: `${townMarket.daysOnMarket} days avg`,
-    trend: getMarketTrend(townMarket.yearOverYear),
+    price: townMarket.averageSalePrice,
+    sales: `Sales count ${townMarket.salesCount}`,
+    avgLdom: `Avg. LDOM ${townMarket.avgLdom}`,
   };
 });
 
@@ -648,20 +647,20 @@ export default function BuyersPage() {
           <SectionHeader
             eyebrow="03 / Market Context"
             title="A quick read on where budgets are landing"
-            lead={`${MARKET_DATA.lastUpdated} · TRREB Market Watch. Use this as context, then let us apply it to your budget and timing.`}
+            lead={`${MARKET_DATA.period} · ${MARKET_DATA.homeType}. Use this as context, then let us apply it to your budget and timing.`}
           />
           <div className="market-grid">
-            {MARKET_SNAPSHOT.map(({ town, price, days, trend }) => (
+            {MARKET_SNAPSHOT.map(({ town, price, sales, avgLdom }) => (
               <article className="market-card" key={town}>
                 <h3>{town}</h3>
                 <strong>{price}</strong>
-                <span>{days}</span>
-                <em className={`market-change market-change--${trend.direction}`}>{trend.label}</em>
+                <span>{sales}</span>
+                <em className="market-change">{avgLdom}</em>
               </article>
             ))}
           </div>
           <div className="market-followup">
-            <p className="attribution">Source: {MARKET_DATA.datasets.marketWatch.source}. Figures rounded; not a guarantee of value.</p>
+            <p className="attribution">Source: {MARKET_DATA.source}. Exact municipal all-home-types figures; not a guarantee of value.</p>
             <button type="button" onClick={() => scrollToSection("cta-section")}>Book a Strategy Call</button>
           </div>
         </div>

--- a/src/EastGwillimburyPage.js
+++ b/src/EastGwillimburyPage.js
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet-async";
 import HeaderShell from "./components/HeaderShell";
 import MARKET_DATA from "./data/marketData.json";
 
-const TOWN_MARKET = MARKET_DATA.datasets.communityGuide.towns["east-gwillimbury"];
+const TOWN_MARKET = MARKET_DATA.municipalities["east-gwillimbury"];
 const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
@@ -169,7 +169,7 @@ const PAGE_SCHEMA = `{
     },
     {
       "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is East Gwillimbury Ontario like?","acceptedAnswer":{"@type":"Answer","text":"East Gwillimbury is York Region's fastest-growing municipality, spanning Sharon, Queensville, Holland Landing, and Mount Albert. It is known for larger new-construction homes, significant infrastructure investment, and the HALP recreation centre opened in 2025."}},{"@type":"Question","name":"Is East Gwillimbury a good place to buy?","acceptedAnswer":{"@type":"Answer","text":"For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. It is currently a buyer's market with approximately ${TOWN_MARKET.monthsInventory} months of inventory. Daily commuting requires car travel."}},{"@type":"Question","name":"Does East Gwillimbury have GO Train service?","acceptedAnswer":{"@type":"Answer","text":"No — East Gwillimbury does not currently have a GO Train station. The closest stations are in Aurora and Newmarket. Residents primarily commute via Highway 404. The Bradford bypass is improving east-west access."}}]
+      "mainEntity":[{"@type":"Question","name":"What is East Gwillimbury Ontario like?","acceptedAnswer":{"@type":"Answer","text":"East Gwillimbury is York Region's fastest-growing municipality, spanning Sharon, Queensville, Holland Landing, and Mount Albert. It is known for larger new-construction homes, significant infrastructure investment, and the HALP recreation centre opened in 2025."}},{"@type":"Question","name":"Is East Gwillimbury a good place to buy?","acceptedAnswer":{"@type":"Answer","text":"For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. In ${MARKET_DATA.period}, it recorded ${TOWN_MARKET.salesCount} all-home-types sales at an exact average sale price of ${TOWN_MARKET.averageSalePrice} and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}."}},{"@type":"Question","name":"Does East Gwillimbury have GO Train service?","acceptedAnswer":{"@type":"Answer","text":"No — East Gwillimbury does not currently have a GO Train station. The closest stations are in Aurora and Newmarket. Residents primarily commute via Highway 404. The Bradford bypass is improving east-west access."}}]
     },
     {
       "@type":"RealEstateAgent",
@@ -198,10 +198,10 @@ const PAGE_BODY_HTML = `
     <h1>Living in East Gwillimbury</h1>
     <p class="hero-sub">Newer communities, larger lots, family-focused growth, and quick access to Highway 404 across Sharon, Queensville, Holland Landing, and Mount Albert.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSold}</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSalePrice}</div><div class="hstat-lbl">Avg. sale price</div></div>
       <div class="hstat"><div class="hstat-val">50 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.daysOnMarket}d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.monthsInventory} mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.salesCount}</div><div class="hstat-lbl">Sales</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.avgLdom}d</div><div class="hstat-lbl">Avg. LDOM</div></div>
     </div>
   </div>
 </section>
@@ -347,7 +347,7 @@ const PAGE_BODY_HTML = `
       <div class="faq-answer">East Gwillimbury is York Region's fastest-growing municipality, spanning Sharon, Queensville, Holland Landing, and Mount Albert. It is known for larger new-construction homes, significant infrastructure investment, and the HALP recreation centre opened in 2025.</div>
     </details><details class="faq-item">
       <summary class="faq-summary">Is East Gwillimbury a good place to buy? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. It is currently a buyer's market with approximately ${TOWN_MARKET.monthsInventory} months of inventory. Daily commuting requires car travel.</div>
+      <div class="faq-answer">For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. In ${MARKET_DATA.period}, it recorded ${TOWN_MARKET.salesCount} all-home-types sales at an exact average sale price of ${TOWN_MARKET.averageSalePrice} and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}.</div>
     </details><details class="faq-item">
       <summary class="faq-summary">Does East Gwillimbury have GO Train service? <span class="faq-icon">+</span></summary>
       <div class="faq-answer">No — East Gwillimbury does not currently have a GO Train station. The closest stations are in Aurora and Newmarket. Residents primarily commute via Highway 404. The Bradford bypass is improving east-west access.</div>
@@ -389,16 +389,11 @@ const PAGE_BODY_HTML = `
 
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
-        <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">${TOWN_MARKET.averageSold}</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">${TOWN_MARKET.detachedAverage}</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">${TOWN_MARKET.townhouseAverage}</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">${TOWN_MARKET.condoAverage}</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">${TOWN_MARKET.daysOnMarket}d</span></div>
-        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">${TOWN_MARKET.saleToListRatio}</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">${TOWN_MARKET.monthsInventory}</span></div>
-        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">${TOWN_MARKET.marketType}</span></span></div>
-        <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">${MARKET_DATA.datasets.communityGuide.source}. Not an appraisal. Confirm with a registered agent before decisions.</p>
+        <h3>Market snapshot · ${MARKET_DATA.period}</h3>
+        <div class="prow"><span class="pk">Average sale price</span><span class="pv">${TOWN_MARKET.averageSalePrice}</span></div>
+        <div class="prow"><span class="pk">Sales count</span><span class="pv">${TOWN_MARKET.salesCount}</span></div>
+        <div class="prow"><span class="pk">Avg. LDOM</span><span class="pv">${TOWN_MARKET.avgLdom}</span></div>
+        <p style="font-size:10px;color:rgba(255,255,255,0.55);margin-top:10px;line-height:1.6;">Source: ${MARKET_DATA.source}. ${MARKET_DATA.homeType}. Not an appraisal.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->

--- a/src/GeorginaPage.js
+++ b/src/GeorginaPage.js
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet-async";
 import HeaderShell from "./components/HeaderShell";
 import MARKET_DATA from "./data/marketData.json";
 
-const TOWN_MARKET = MARKET_DATA.datasets.communityGuide.towns.georgina;
+const TOWN_MARKET = MARKET_DATA.municipalities.georgina;
 const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
@@ -198,10 +198,10 @@ const PAGE_BODY_HTML = `
     <h1>Living in Georgina</h1>
     <p class="hero-sub">Lake Simcoe, more space, shoreline communities, beaches, marinas, and one of York Region's most accessible price points.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSold}</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSalePrice}</div><div class="hstat-lbl">Avg. sale price</div></div>
       <div class="hstat"><div class="hstat-val">65 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.daysOnMarket}d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.monthsInventory} mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.salesCount}</div><div class="hstat-lbl">Sales</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.avgLdom}d</div><div class="hstat-lbl">Avg. LDOM</div></div>
     </div>
   </div>
 </section>
@@ -221,7 +221,7 @@ const PAGE_BODY_HTML = `
       <!-- INTRO -->
       <div class="sec">
         <div class="sec-eyebrow">About Georgina</div>
-        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Georgina is a strong option for buyers who want more space, waterfront access, or a different pace — and who are comfortable with the commute trade-off. With ${TOWN_MARKET.monthsInventory} months of inventory, it is currently a buyer's market with meaningful negotiating room, particularly on non-waterfront properties.</p>
+        <p style="font-size:14px;color:var(--ink2);line-height:1.8;">Georgina is a strong option for buyers who want more space, waterfront access, or a different pace — and who are comfortable with the commute trade-off. Market conditions and negotiating room vary by neighbourhood, property type, and whether a home is on the waterfront.</p>
         <div style="margin-top:14px;display:flex;gap:6px;flex-wrap:wrap;">
           <a href="#contact" class="btn-primary" style="font-size:13px;padding:10px 20px;">Get local guidance</a>
           <a href="https://northsidegta.ca/neighbourhood-guide" class="btn-secondary" style="font-size:13px;padding:9px 18px;">Compare all towns</a>
@@ -329,7 +329,7 @@ const PAGE_BODY_HTML = `
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
-          <strong>Market note:</strong> Waterfront properties in Georgina have historically held value relative to the broader market. The overall market has ${TOWN_MARKET.monthsInventory} months of inventory, which gives buyers meaningful negotiating room.
+          <strong>Market note:</strong> Waterfront and non-waterfront properties can behave differently, so municipality-wide figures should be paired with a property-specific comparison.
         </div>
       </div>
 
@@ -389,16 +389,11 @@ const PAGE_BODY_HTML = `
 
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
-        <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">${TOWN_MARKET.averageSold}</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">${TOWN_MARKET.detachedAverage}</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">${TOWN_MARKET.townhouseAverage}</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">${TOWN_MARKET.condoAverage}</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">${TOWN_MARKET.daysOnMarket}d</span></div>
-        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">${TOWN_MARKET.saleToListRatio}</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">${TOWN_MARKET.monthsInventory}</span></div>
-        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">${TOWN_MARKET.marketType}</span></span></div>
-        <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">${MARKET_DATA.datasets.communityGuide.source}. Not an appraisal. Confirm with a registered agent before decisions.</p>
+        <h3>Market snapshot · ${MARKET_DATA.period}</h3>
+        <div class="prow"><span class="pk">Average sale price</span><span class="pv">${TOWN_MARKET.averageSalePrice}</span></div>
+        <div class="prow"><span class="pk">Sales count</span><span class="pv">${TOWN_MARKET.salesCount}</span></div>
+        <div class="prow"><span class="pk">Avg. LDOM</span><span class="pv">${TOWN_MARKET.avgLdom}</span></div>
+        <p style="font-size:10px;color:rgba(255,255,255,0.55);margin-top:10px;line-height:1.6;">Source: ${MARKET_DATA.source}. ${MARKET_DATA.homeType}. Not an appraisal.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->

--- a/src/KeswickLowerPricedHomesPage.js
+++ b/src/KeswickLowerPricedHomesPage.js
@@ -7,6 +7,7 @@ import { getStaticRouteMeta } from "./components/seo/staticRouteMetaExports";
 import { getFormEndpoint } from "./components/contact/contactConfig";
 import { trackEvent, trackEventOnce } from "./utils/analytics";
 import { CANONICAL_TESTIMONIALS } from "./data/testimonials";
+import MARKET_DATA from "./data/marketData.json";
 
 const priceBands = [
   { label: "Under $600K", copy: "Smaller homes, condos, townhomes, or properties with trade-offs." },
@@ -24,14 +25,12 @@ const buyerInsights = [
   { title: "The best options move differently", copy: "Some homes sit. Some move quickly. The difference is usually price, condition, presentation, and how well the home matches buyer demand." },
 ];
 
+const georginaMarket = MARKET_DATA.municipalities.georgina;
 const marketStats = {
-  lastUpdated: "May 2026",
-  sources: ["REALTOR.ca", "Zolo", "Property.ca", "Town of Georgina", "TRREB where available"],
   cards: [
-    { label: "Current listing depth", text: "Public portals show meaningful active inventory across Georgina and Keswick, giving buyers more to compare than in tighter markets." },
-    { label: "Lower-price search demand", text: "Buyer searches around homes under $700K and $800K remain highly relevant for Keswick and Georgina." },
-    { label: "More time to compare", text: "Some listings are taking longer to sell, which can create more room for careful review and negotiation." },
-    { label: "Relative affordability", text: "Georgina has been cited by municipal economic development sources as one of York Region’s more approachable detached markets at specific points in time." },
+    { label: "Average sale price", text: georginaMarket.averageSalePrice },
+    { label: "Sales count", text: String(georginaMarket.salesCount) },
+    { label: "Avg. LDOM", text: String(georginaMarket.avgLdom) },
   ],
 };
 
@@ -143,7 +142,7 @@ export default function KeswickLowerPricedHomesPage() {
 
       <section><h2 className="text-3xl font-semibold">What buyers are noticing in Keswick right now</h2><p className="mt-2 text-[#3d4c45]">The opportunity is not that every home is a deal. It is that more buyers are comparing Keswick because the inventory mix can create options that feel harder to find farther south.</p><div className="mt-5 grid gap-4 md:grid-cols-2">{buyerInsights.map((item) => <article key={item.title} className="rounded-2xl border bg-white p-5"><h3 className="font-semibold">{item.title}</h3><p className="mt-2 text-sm text-[#48534e]">{item.copy}</p></article>)}</div><blockquote className="mt-5 rounded-xl border-l-4 border-[#12261c] bg-white p-4 italic">Low price alone is not the strategy. The strategy is knowing which lower-priced homes are actually worth pursuing.</blockquote></section>
 
-      <section><h2 className="text-3xl font-semibold">The market context behind the opportunity</h2><div className="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-4">{marketStats.cards.map((card) => <article key={card.label} className="rounded-2xl border bg-white p-4"><p className="text-xs uppercase tracking-wide text-[#4f6058]">{card.label}</p><p className="mt-2 text-sm">{card.text}</p></article>)}</div><p className="mt-3 text-xs text-gray-600">Market figures and public listing observations are based on sources available at the time of publication, including public listing portals and municipal market references. Confirm current data before relying on it. Last updated: {marketStats.lastUpdated}. Sources: {marketStats.sources.join(", ")}.</p></section>
+      <section><h2 className="text-3xl font-semibold">Georgina market snapshot · {MARKET_DATA.period}</h2><div className="mt-4 grid gap-4 md:grid-cols-3">{marketStats.cards.map((card) => <article key={card.label} className="rounded-2xl border bg-white p-4"><p className="text-xs uppercase tracking-wide text-[#4f6058]">{card.label}</p><p className="mt-2 text-sm">{card.text}</p></article>)}</div><p className="mt-3 text-xs text-gray-600">Source: {MARKET_DATA.source}. {MARKET_DATA.homeType}. Keswick is included within the Georgina municipality figures. Confirm property-specific data before relying on it.</p></section>
 
       <section><h2 className="text-3xl font-semibold">What “lower-priced” really means in Keswick</h2><p className="mt-2 text-[#3d4c45]">A lower asking price can mean opportunity, but it can also mean trade-offs. Some homes need updates. Some have location compromises. Some are smaller than buyers expect. Some are simply priced closer to where today’s buyers are willing to act.</p><div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{lowerPricedMeaning.map((item) => <div key={item} className="rounded-xl border bg-white p-4 text-sm font-medium">{item}</div>)}</div><button onClick={() => jumpToForm("Help me separate opportunity from risk")} className="mt-4 rounded-full border border-[#12261c] px-5 py-2">Help me separate opportunity from risk</button></section>
 

--- a/src/NeighbourhoodGuidePage.js
+++ b/src/NeighbourhoodGuidePage.js
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet-async";
 import HeaderShell from "./components/HeaderShell";
 import MARKET_DATA from "./data/marketData.json";
 
-const GUIDE_MARKET = MARKET_DATA.datasets.communityGuide;
+const GUIDE_MARKET = MARKET_DATA.municipalities;
 const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
@@ -351,10 +351,10 @@ const PAGE_SCHEMA = `{
     {
       "@type":"FAQPage",
       "mainEntity":[
-        {"@type":"Question","name":"What is the average home price in Aurora Ontario 2026?","acceptedAnswer":{"@type":"Answer","text":"The average sold price in Aurora is approximately ${GUIDE_MARKET.towns.aurora.averageSold} across all home types (TRREB MLS Q1 2026). Detached homes average around ${GUIDE_MARKET.towns.aurora.detachedAverage}. It is currently a buyer's market with approximately ${GUIDE_MARKET.towns.aurora.monthsInventory} months of inventory."}},
+        {"@type":"Question","name":"What is the average home price in Aurora Ontario 2026?","acceptedAnswer":{"@type":"Answer","text":"In ${MARKET_DATA.period}, Aurora's exact average sale price across all home types was ${GUIDE_MARKET.aurora.averageSalePrice}, with ${GUIDE_MARKET.aurora.salesCount} sales and an Avg. LDOM of ${GUIDE_MARKET.aurora.avgLdom}. Source: ${MARKET_DATA.source}."}},
         {"@type":"Question","name":"Which towns north of Toronto have GO Train access?","acceptedAnswer":{"@type":"Answer","text":"Aurora and Newmarket are served by the GO Barrie line with service to Union Station. Stouffville is served by the GO Stouffville line. East Gwillimbury, Georgina, Uxbridge, and Scugog are car-dependent for Toronto commuting."}},
         {"@type":"Question","name":"What is Georgina Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Georgina is known for Lake Simcoe waterfront living across communities including Keswick, Sutton, and Jackson's Point. It is one of York Region's most affordable municipalities and is popular with remote workers and buyers seeking waterfront access."}},
-        {"@type":"Question","name":"What is the most affordable town north of Toronto?","acceptedAnswer":{"@type":"Answer","text":"Georgina has the lowest average sold price among the NorthSide GTA communities at approximately ${GUIDE_MARKET.towns.georgina.averageSold} (TRREB 2025–2026). Scugog (${GUIDE_MARKET.towns.scugog.averageSold}) and Uxbridge (${GUIDE_MARKET.towns.uxbridge.averageSold}) are also below the $1M average mark."}},
+        {"@type":"Question","name":"What is the most affordable town north of Toronto?","acceptedAnswer":{"@type":"Answer","text":"For ${MARKET_DATA.period}, Georgina had the lowest exact average sale price among the seven NorthSide GTA municipalities at ${GUIDE_MARKET.georgina.averageSalePrice}. Scugog was ${GUIDE_MARKET.scugog.averageSalePrice}, and Uxbridge was ${GUIDE_MARKET.uxbridge.averageSalePrice}. Source: ${MARKET_DATA.source}."}},
         {"@type":"Question","name":"What is Uxbridge Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge is officially Canada's Trail Capital, with over 300 kilometres of trails on the Oak Ridges Moraine. It is also known for its equestrian community, heritage downtown, Dagmar Ski Resort, and active arts and theatre scene."}}
       ]
     }
@@ -780,7 +780,7 @@ const PAGE_BODY_HTML = `
   <div class="faq-wrap">
     <details class="faq-item">
       <summary class="faq-summary">What is the average home price in Aurora, Ontario in 2026? <span class="faq-icon">+</span></summary>
-      <p class="faq-answer">The average sold price in Aurora is approximately ${GUIDE_MARKET.towns.aurora.averageSold} across all home types (TRREB MLS Q1 2026). Detached homes average around ${GUIDE_MARKET.towns.aurora.detachedAverage} and townhomes around ${GUIDE_MARKET.towns.aurora.townhouseAverage}. It is currently a buyer's market with approximately ${GUIDE_MARKET.towns.aurora.monthsInventory} months of inventory.</p>
+      <p class="faq-answer">In ${MARKET_DATA.period}, Aurora's exact average sale price across all home types was ${GUIDE_MARKET.aurora.averageSalePrice}, with ${GUIDE_MARKET.aurora.salesCount} sales and an Avg. LDOM of ${GUIDE_MARKET.aurora.avgLdom}. Source: ${MARKET_DATA.source}.</p>
     </details>
     <details class="faq-item">
       <summary class="faq-summary">Which towns north of Toronto have GO Train access? <span class="faq-icon">+</span></summary>
@@ -788,7 +788,7 @@ const PAGE_BODY_HTML = `
     </details>
     <details class="faq-item">
       <summary class="faq-summary">Which community north of Toronto is most affordable? <span class="faq-icon">+</span></summary>
-      <p class="faq-answer">Georgina has the lowest average sold price among these seven communities at approximately ${GUIDE_MARKET.towns.georgina.averageSold} (TRREB 2025–2026). Scugog (${GUIDE_MARKET.towns.scugog.averageSold}) and Uxbridge (${GUIDE_MARKET.towns.uxbridge.averageSold}) are also below the $1M average. All three are currently in buyer's market conditions.</p>
+      <p class="faq-answer">For ${MARKET_DATA.period}, Georgina had the lowest exact average sale price among these seven municipalities at ${GUIDE_MARKET.georgina.averageSalePrice}. Scugog was ${GUIDE_MARKET.scugog.averageSalePrice}, and Uxbridge was ${GUIDE_MARKET.uxbridge.averageSalePrice}. Source: ${MARKET_DATA.source}.</p>
     </details>
     <details class="faq-item">
       <summary class="faq-summary">How long is the commute from these communities to Toronto? <span class="faq-icon">+</span></summary>

--- a/src/NewmarketPage.js
+++ b/src/NewmarketPage.js
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet-async";
 import HeaderShell from "./components/HeaderShell";
 import MARKET_DATA from "./data/marketData.json";
 
-const TOWN_MARKET = MARKET_DATA.datasets.communityGuide.towns.newmarket;
+const TOWN_MARKET = MARKET_DATA.municipalities.newmarket;
 const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
@@ -169,7 +169,7 @@ const PAGE_SCHEMA = `{
     },
     {
       "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is Newmarket Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Newmarket is known as one of York Region's most connected and active communities. It has a walkable Main Street, direct GO Train service on the Barrie line, Southlake Regional Health Centre, and Upper Canada Mall. It is York Region's highest-volume real estate market."}},{"@type":"Question","name":"Is Newmarket a good place to buy a home in 2026?","acceptedAnswer":{"@type":"Answer","text":"Newmarket's average days on market sat at ${TOWN_MARKET.daysOnMarket} in early 2026 — the fastest pace in York Region. It offers strong value compared with Aurora while maintaining GO Train access and established neighbourhood stock. Market data from ${MARKET_DATA.datasets.communityGuide.source}."}},{"@type":"Question","name":"What are the best areas in Newmarket?","acceptedAnswer":{"@type":"Answer","text":"Stonehaven-Wyndham is consistently in demand for its school catchment and access to the 404. Armitage and Bristol-London are popular with families. Central Newmarket suits buyers who want walkability and proximity to Main Street amenities."}}]
+      "mainEntity":[{"@type":"Question","name":"What is Newmarket Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Newmarket is known as one of York Region's most connected and active communities. It has a walkable Main Street, direct GO Train service on the Barrie line, Southlake Regional Health Centre, and Upper Canada Mall. It is York Region's highest-volume real estate market."}},{"@type":"Question","name":"Is Newmarket a good place to buy a home in 2026?","acceptedAnswer":{"@type":"Answer","text":"In ${MARKET_DATA.period}, Newmarket recorded ${TOWN_MARKET.salesCount} sales across all home types, an exact average sale price of ${TOWN_MARKET.averageSalePrice}, and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}."}},{"@type":"Question","name":"What are the best areas in Newmarket?","acceptedAnswer":{"@type":"Answer","text":"Stonehaven-Wyndham is consistently in demand for its school catchment and access to the 404. Armitage and Bristol-London are popular with families. Central Newmarket suits buyers who want walkability and proximity to Main Street amenities."}}]
     },
     {
       "@type":"RealEstateAgent",
@@ -198,10 +198,10 @@ const PAGE_BODY_HTML = `
     <h1>Living in Newmarket</h1>
     <p class="hero-sub">A connected NorthSide GTA town with Main Street energy, GO access, established neighbourhoods, shopping, parks, and practical day-to-day convenience.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSold}</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSalePrice}</div><div class="hstat-lbl">Avg. sale price</div></div>
       <div class="hstat"><div class="hstat-val">45 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.daysOnMarket}d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.monthsInventory} mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.salesCount}</div><div class="hstat-lbl">Sales</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.avgLdom}d</div><div class="hstat-lbl">Avg. LDOM</div></div>
     </div>
   </div>
 </section>
@@ -331,7 +331,7 @@ const PAGE_BODY_HTML = `
           </div>
           <div class="fit-item fit-watch">
             <div class="fit-label">Things to weigh up</div>
-            <p>With average days on market at 17, well-priced listings in strong school zones move quickly. Budget preparation matters here.</p>
+            <p>Well-priced listings in strong school zones can move quickly. Budget preparation matters here.</p>
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
@@ -353,7 +353,7 @@ const PAGE_BODY_HTML = `
       <div class="faq-answer">Newmarket is known as one of York Region's most connected and active communities. It has a walkable Main Street, direct GO Train service on the Barrie line, Southlake Regional Health Centre, and Upper Canada Mall. It is York Region's highest-volume real estate market.</div>
     </details><details class="faq-item">
       <summary class="faq-summary">Is Newmarket a good place to buy a home in 2026? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">Newmarket's average days on market sat at ${TOWN_MARKET.daysOnMarket} in early 2026 — the fastest pace in York Region. It offers strong value compared with Aurora while maintaining GO Train access and established neighbourhood stock. Market data from ${MARKET_DATA.datasets.communityGuide.source}.</div>
+      <div class="faq-answer">In ${MARKET_DATA.period}, Newmarket recorded ${TOWN_MARKET.salesCount} sales across all home types, an exact average sale price of ${TOWN_MARKET.averageSalePrice}, and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}.</div>
     </details><details class="faq-item">
       <summary class="faq-summary">What are the best areas in Newmarket? <span class="faq-icon">+</span></summary>
       <div class="faq-answer">Stonehaven-Wyndham is consistently in demand for its school catchment and access to the 404. Armitage and Bristol-London are popular with families. Central Newmarket suits buyers who want walkability and proximity to Main Street amenities.</div>
@@ -395,16 +395,11 @@ const PAGE_BODY_HTML = `
 
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
-        <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">${TOWN_MARKET.averageSold}</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">${TOWN_MARKET.detachedAverage}</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">${TOWN_MARKET.townhouseAverage}</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">${TOWN_MARKET.condoAverage}</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">${TOWN_MARKET.daysOnMarket}d</span></div>
-        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">${TOWN_MARKET.saleToListRatio}</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">${TOWN_MARKET.monthsInventory}</span></div>
-        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">${TOWN_MARKET.marketType}</span></span></div>
-        <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">${MARKET_DATA.datasets.communityGuide.source}. Not an appraisal. Confirm with a registered agent before decisions.</p>
+        <h3>Market snapshot · ${MARKET_DATA.period}</h3>
+        <div class="prow"><span class="pk">Average sale price</span><span class="pv">${TOWN_MARKET.averageSalePrice}</span></div>
+        <div class="prow"><span class="pk">Sales count</span><span class="pv">${TOWN_MARKET.salesCount}</span></div>
+        <div class="prow"><span class="pk">Avg. LDOM</span><span class="pv">${TOWN_MARKET.avgLdom}</span></div>
+        <p style="font-size:10px;color:rgba(255,255,255,0.55);margin-top:10px;line-height:1.6;">Source: ${MARKET_DATA.source}. ${MARKET_DATA.homeType}. Not an appraisal.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->

--- a/src/ScugogPage.js
+++ b/src/ScugogPage.js
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet-async";
 import HeaderShell from "./components/HeaderShell";
 import MARKET_DATA from "./data/marketData.json";
 
-const TOWN_MARKET = MARKET_DATA.datasets.communityGuide.towns.scugog;
+const TOWN_MARKET = MARKET_DATA.municipalities.scugog;
 const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
@@ -198,10 +198,10 @@ const PAGE_BODY_HTML = `
     <h1>Living in Scugog</h1>
     <p class="hero-sub">Port Perry heritage, Lake Scugog waterfront, small-town character, and a slower pace within reach of the GTA.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSold}</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSalePrice}</div><div class="hstat-lbl">Avg. sale price</div></div>
       <div class="hstat"><div class="hstat-val">75 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.daysOnMarket}d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.monthsInventory} mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.salesCount}</div><div class="hstat-lbl">Sales</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.avgLdom}d</div><div class="hstat-lbl">Avg. LDOM</div></div>
     </div>
   </div>
 </section>
@@ -327,7 +327,7 @@ const PAGE_BODY_HTML = `
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
-          <strong>Market note:</strong> Waterfront and heritage properties have historically held value relative to the broader local market. Non-waterfront inventory is soft, with ${TOWN_MARKET.monthsInventory} months available and buyers holding meaningful negotiating room.
+          <strong>Market note:</strong> Waterfront, heritage, and non-waterfront properties can behave differently, so municipality-wide figures should be paired with a property-specific comparison.
         </div>
       </div>
 
@@ -387,16 +387,11 @@ const PAGE_BODY_HTML = `
 
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
-        <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">${TOWN_MARKET.averageSold}</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">${TOWN_MARKET.detachedAverage}</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">${TOWN_MARKET.townhouseAverage}</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">${TOWN_MARKET.condoAverage}</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">${TOWN_MARKET.daysOnMarket}d</span></div>
-        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">${TOWN_MARKET.saleToListRatio}</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">${TOWN_MARKET.monthsInventory}</span></div>
-        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">${TOWN_MARKET.marketType}</span></span></div>
-        <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">${MARKET_DATA.datasets.communityGuide.source}. Not an appraisal. Confirm with a registered agent before decisions.</p>
+        <h3>Market snapshot · ${MARKET_DATA.period}</h3>
+        <div class="prow"><span class="pk">Average sale price</span><span class="pv">${TOWN_MARKET.averageSalePrice}</span></div>
+        <div class="prow"><span class="pk">Sales count</span><span class="pv">${TOWN_MARKET.salesCount}</span></div>
+        <div class="prow"><span class="pk">Avg. LDOM</span><span class="pv">${TOWN_MARKET.avgLdom}</span></div>
+        <p style="font-size:10px;color:rgba(255,255,255,0.55);margin-top:10px;line-height:1.6;">Source: ${MARKET_DATA.source}. ${MARKET_DATA.homeType}. Not an appraisal.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->

--- a/src/StouffvillePage.js
+++ b/src/StouffvillePage.js
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet-async";
 import HeaderShell from "./components/HeaderShell";
 import MARKET_DATA from "./data/marketData.json";
 
-const TOWN_MARKET = MARKET_DATA.datasets.communityGuide.towns.stouffville;
+const TOWN_MARKET = MARKET_DATA.municipalities.stouffville;
 const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
@@ -169,7 +169,7 @@ const PAGE_SCHEMA = `{
     },
     {
       "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"Is Stouffville a good place to live?","acceptedAnswer":{"@type":"Answer","text":"Stouffville combines newer homes, strong schools, GO Train access, and a heritage Main Street in a way that works well for families relocating from the inner GTA. It is one of York Region's fastest-growing communities."}},{"@type":"Question","name":"What is Stouffville Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Stouffville is known for its rapid residential growth, new construction developments, heritage Main Street, Ballantrae Golf & Country Club, and a strong community character. It is a popular destination for families moving from Toronto, Markham, or Richmond Hill."}},{"@type":"Question","name":"What is the housing market like in Stouffville?","acceptedAnswer":{"@type":"Answer","text":"As of early 2026, Stouffville has approximately ${Number(TOWN_MARKET.monthsInventory)} months of inventory — a buyer's market. Average sold price across all property types is approximately ${TOWN_MARKET.averageSold}. Detached homes average around ${TOWN_MARKET.detachedAverage}. Data from ${MARKET_DATA.datasets.communityGuide.source}."}}]
+      "mainEntity":[{"@type":"Question","name":"Is Stouffville a good place to live?","acceptedAnswer":{"@type":"Answer","text":"Stouffville combines newer homes, strong schools, GO Train access, and a heritage Main Street in a way that works well for families relocating from the inner GTA. It is one of York Region's fastest-growing communities."}},{"@type":"Question","name":"What is Stouffville Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Stouffville is known for its rapid residential growth, new construction developments, heritage Main Street, Ballantrae Golf & Country Club, and a strong community character. It is a popular destination for families moving from Toronto, Markham, or Richmond Hill."}},{"@type":"Question","name":"What is the housing market like in Stouffville?","acceptedAnswer":{"@type":"Answer","text":"In ${MARKET_DATA.period}, Whitchurch-Stouffville recorded ${TOWN_MARKET.salesCount} sales across all home types, an exact average sale price of ${TOWN_MARKET.averageSalePrice}, and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}."}}]
     },
     {
       "@type":"RealEstateAgent",
@@ -198,10 +198,10 @@ const PAGE_BODY_HTML = `
     <h1>Living in Stouffville</h1>
     <p class="hero-sub">A fast-growing family town with GO access, newer homes, parks, schools, and a Main Street that still feels local.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSold}</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSalePrice}</div><div class="hstat-lbl">Avg. sale price</div></div>
       <div class="hstat"><div class="hstat-val">40 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.daysOnMarket}d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.monthsInventory} mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.salesCount}</div><div class="hstat-lbl">Sales</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.avgLdom}d</div><div class="hstat-lbl">Avg. LDOM</div></div>
     </div>
   </div>
 </section>
@@ -331,7 +331,7 @@ const PAGE_BODY_HTML = `
           </div>
           <div class="fit-item fit-watch">
             <div class="fit-label">Things to weigh up</div>
-            <p>With ${Number(TOWN_MARKET.monthsInventory)} months of inventory, buyers have real negotiating room. GO Train service to Union is approximately 65 minutes — longer than Aurora or Newmarket.</p>
+            <p>Market conditions vary by property and neighbourhood. GO Train service to Union is approximately 65 minutes — longer than Aurora or Newmarket.</p>
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
@@ -356,7 +356,7 @@ const PAGE_BODY_HTML = `
       <div class="faq-answer">Stouffville is known for its rapid residential growth, new construction developments, heritage Main Street, Ballantrae Golf & Country Club, and a strong community character. It is a popular destination for families moving from Toronto, Markham, or Richmond Hill.</div>
     </details><details class="faq-item">
       <summary class="faq-summary">What is the housing market like in Stouffville? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">As of early 2026, Stouffville has approximately ${Number(TOWN_MARKET.monthsInventory)} months of inventory — a buyer's market. Average sold price across all property types is approximately ${TOWN_MARKET.averageSold}. Detached homes average around ${TOWN_MARKET.detachedAverage}. Data from ${MARKET_DATA.datasets.communityGuide.source}.</div>
+      <div class="faq-answer">In ${MARKET_DATA.period}, Whitchurch-Stouffville recorded ${TOWN_MARKET.salesCount} sales across all home types, an exact average sale price of ${TOWN_MARKET.averageSalePrice}, and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}.</div>
     </details>
       </div>
 
@@ -395,16 +395,11 @@ const PAGE_BODY_HTML = `
 
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
-        <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">${TOWN_MARKET.averageSold}</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">${TOWN_MARKET.detachedAverage}</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">${TOWN_MARKET.townhouseAverage}</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">${TOWN_MARKET.condoAverage}</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">${TOWN_MARKET.daysOnMarket}d</span></div>
-        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">${TOWN_MARKET.saleToListRatio}</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">${TOWN_MARKET.monthsInventory}</span></div>
-        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">${TOWN_MARKET.marketType}</span></span></div>
-        <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">${MARKET_DATA.datasets.communityGuide.source}. Not an appraisal. Confirm with a registered agent before decisions.</p>
+        <h3>Market snapshot · ${MARKET_DATA.period}</h3>
+        <div class="prow"><span class="pk">Average sale price</span><span class="pv">${TOWN_MARKET.averageSalePrice}</span></div>
+        <div class="prow"><span class="pk">Sales count</span><span class="pv">${TOWN_MARKET.salesCount}</span></div>
+        <div class="prow"><span class="pk">Avg. LDOM</span><span class="pv">${TOWN_MARKET.avgLdom}</span></div>
+        <p style="font-size:10px;color:rgba(255,255,255,0.55);margin-top:10px;line-height:1.6;">Source: ${MARKET_DATA.source}. ${MARKET_DATA.homeType}. Not an appraisal.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->

--- a/src/TownPage.js
+++ b/src/TownPage.js
@@ -120,7 +120,7 @@ export default function TownPage() {
   }
 
   const slug = (town.slug || "").toLowerCase();
-  const sharedTownMarket = MARKET_DATA.datasets.communityGuide.towns[slug];
+  const sharedTownMarket = MARKET_DATA.municipalities[slug];
   const lifestyleCopy = getTownLifestyleCopy(slug);
   const isUxbridge = slug === "uxbridge";
 
@@ -183,7 +183,12 @@ export default function TownPage() {
           hero={town.hero}
           snapshot={{
             ...town.snapshot,
-            homePriceRange: sharedTownMarket?.homePriceRange,
+            averageSalePrice: sharedTownMarket?.averageSalePrice,
+            salesCount: sharedTownMarket?.salesCount,
+            avgLdom: sharedTownMarket?.avgLdom,
+            marketPeriod: MARKET_DATA.period,
+            marketSource: MARKET_DATA.source,
+            marketHomeType: MARKET_DATA.homeType,
           }}
           ratings={ratings}
           ratingScaleMax={5}

--- a/src/UxbridgePage.js
+++ b/src/UxbridgePage.js
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet-async";
 import HeaderShell from "./components/HeaderShell";
 import MARKET_DATA from "./data/marketData.json";
 
-const TOWN_MARKET = MARKET_DATA.datasets.communityGuide.towns.uxbridge;
+const TOWN_MARKET = MARKET_DATA.municipalities.uxbridge;
 const PAGE_STYLE = `
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 :root{
@@ -169,7 +169,7 @@ const PAGE_SCHEMA = `{
     },
     {
       "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is Uxbridge Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge holds the official designation of Canada's Trail Capital, with more than 300 km of trails on the Oak Ridges Moraine including the Trans Canada Trail and Durham Forest. The town is also known for its equestrian community, active arts scene, and Theatre Uxbridge."}},{"@type":"Question","name":"Is Uxbridge a good place to live?","acceptedAnswer":{"@type":"Answer","text":"For buyers with remote work flexibility, equestrian interests, or a preference for a quieter lifestyle within reach of the GTA, Uxbridge is a strong option. The main trade-offs are car-dependence and a longer commute. The market is balanced with approximately ${Number(TOWN_MARKET.monthsInventory)} months of inventory."}},{"@type":"Question","name":"What trails are in Uxbridge?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge has more than 300 km of multi-use trails supporting hiking, mountain biking, equestrian use, cross-country skiing, and snowshoeing. Key routes include Durham Forest, Glen Major Forest, the Trans Canada Trail, and the Oak Ridges Moraine Trail."}}]
+      "mainEntity":[{"@type":"Question","name":"What is Uxbridge Ontario known for?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge holds the official designation of Canada's Trail Capital, with more than 300 km of trails on the Oak Ridges Moraine including the Trans Canada Trail and Durham Forest. The town is also known for its equestrian community, active arts scene, and Theatre Uxbridge."}},{"@type":"Question","name":"Is Uxbridge a good place to live?","acceptedAnswer":{"@type":"Answer","text":"For buyers with remote work flexibility, equestrian interests, or a preference for a quieter lifestyle within reach of the GTA, Uxbridge is a strong option. In ${MARKET_DATA.period}, it recorded ${TOWN_MARKET.salesCount} all-home-types sales at an exact average sale price of ${TOWN_MARKET.averageSalePrice} and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}."}},{"@type":"Question","name":"What trails are in Uxbridge?","acceptedAnswer":{"@type":"Answer","text":"Uxbridge has more than 300 km of multi-use trails supporting hiking, mountain biking, equestrian use, cross-country skiing, and snowshoeing. Key routes include Durham Forest, Glen Major Forest, the Trans Canada Trail, and the Oak Ridges Moraine Trail."}}]
     },
     {
       "@type":"RealEstateAgent",
@@ -198,10 +198,10 @@ const PAGE_BODY_HTML = `
     <h1>Living in Uxbridge</h1>
     <p class="hero-sub">Trail networks, rolling countryside, heritage streets, local shops, and a quieter NorthSide GTA lifestyle with room to breathe.</p>
     <div class="hero-stats">
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSold}</div><div class="hstat-lbl">Avg. sold</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.averageSalePrice}</div><div class="hstat-lbl">Avg. sale price</div></div>
       <div class="hstat"><div class="hstat-val">60 min</div><div class="hstat-lbl">Off-peak to DVP</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.daysOnMarket}d</div><div class="hstat-lbl">Avg. on mkt</div></div>
-      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.monthsInventory} mo</div><div class="hstat-lbl">Inventory</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.salesCount}</div><div class="hstat-lbl">Sales</div></div>
+      <div class="hstat"><div class="hstat-val">${TOWN_MARKET.avgLdom}d</div><div class="hstat-lbl">Avg. LDOM</div></div>
     </div>
   </div>
 </section>
@@ -327,7 +327,7 @@ const PAGE_BODY_HTML = `
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
-          <strong>Market note:</strong> A stable, balanced market with approximately ${Number(TOWN_MARKET.monthsInventory)} months of inventory and an 85% homeownership rate. Buyers are not competing against speculative pressure. Value is driven by the lifestyle rather than speculative demand.
+          <strong>Market note:</strong> Uxbridge properties span in-town homes, acreages, and equestrian properties, so municipality-wide figures should be paired with a property-specific comparison.
         </div>
       </div>
 
@@ -345,7 +345,7 @@ const PAGE_BODY_HTML = `
       <div class="faq-answer">Uxbridge holds the official designation of Canada's Trail Capital, with more than 300 km of trails on the Oak Ridges Moraine including the Trans Canada Trail and Durham Forest. The town is also known for its equestrian community, active arts scene, and Theatre Uxbridge.</div>
     </details><details class="faq-item">
       <summary class="faq-summary">Is Uxbridge a good place to live? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">For buyers with remote work flexibility, equestrian interests, or a preference for a quieter lifestyle within reach of the GTA, Uxbridge is a strong option. The main trade-offs are car-dependence and a longer commute. The market is balanced with approximately ${Number(TOWN_MARKET.monthsInventory)} months of inventory.</div>
+      <div class="faq-answer">For buyers with remote work flexibility, equestrian interests, or a preference for a quieter lifestyle within reach of the GTA, Uxbridge is a strong option. In ${MARKET_DATA.period}, it recorded ${TOWN_MARKET.salesCount} all-home-types sales at an exact average sale price of ${TOWN_MARKET.averageSalePrice} and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}.</div>
     </details><details class="faq-item">
       <summary class="faq-summary">What trails are in Uxbridge? <span class="faq-icon">+</span></summary>
       <div class="faq-answer">Uxbridge has more than 300 km of multi-use trails supporting hiking, mountain biking, equestrian use, cross-country skiing, and snowshoeing. Key routes include Durham Forest, Glen Major Forest, the Trans Canada Trail, and the Oak Ridges Moraine Trail.</div>
@@ -387,16 +387,11 @@ const PAGE_BODY_HTML = `
 
       <!-- PRICE SNAPSHOT -->
       <div class="price-card">
-        <h3>Market snapshot</h3>
-        <div class="prow"><span class="pk">All types avg.</span><span class="pv">${TOWN_MARKET.averageSold}</span></div>
-        <div class="prow"><span class="pk">Detached avg.</span><span class="pv">${TOWN_MARKET.detachedAverage}</span></div>
-        <div class="prow"><span class="pk">Townhouse avg.</span><span class="pv">${TOWN_MARKET.townhouseAverage}</span></div>
-        <div class="prow"><span class="pk">Condo / apt avg.</span><span class="pv">${TOWN_MARKET.condoAverage}</span></div>
-        <div class="prow"><span class="pk">Days on market</span><span class="pv">${TOWN_MARKET.daysOnMarket}d</span></div>
-        <div class="prow"><span class="pk">Sale / list ratio</span><span class="pv">${TOWN_MARKET.saleToListRatio}</span></div>
-        <div class="prow"><span class="pk">Months inventory</span><span class="pv">${TOWN_MARKET.monthsInventory}</span></div>
-        <div class="prow"><span class="pk">Market type</span><span class="pv"><span class="mkt-pill">${TOWN_MARKET.marketType}</span></span></div>
-        <p style="font-size:10px;color:rgba(255,255,255,0.35);margin-top:10px;line-height:1.6;">${MARKET_DATA.datasets.communityGuide.source}. Not an appraisal. Confirm with a registered agent before decisions.</p>
+        <h3>Market snapshot · ${MARKET_DATA.period}</h3>
+        <div class="prow"><span class="pk">Average sale price</span><span class="pv">${TOWN_MARKET.averageSalePrice}</span></div>
+        <div class="prow"><span class="pk">Sales count</span><span class="pv">${TOWN_MARKET.salesCount}</span></div>
+        <div class="prow"><span class="pk">Avg. LDOM</span><span class="pv">${TOWN_MARKET.avgLdom}</span></div>
+        <p style="font-size:10px;color:rgba(255,255,255,0.55);margin-top:10px;line-height:1.6;">Source: ${MARKET_DATA.source}. ${MARKET_DATA.homeType}. Not an appraisal.</p>
       </div>
 
       <!-- WHAT $1M BUYS -->

--- a/src/components/towns/TownPageLayout.js
+++ b/src/components/towns/TownPageLayout.js
@@ -344,7 +344,9 @@ export default function TownPageLayout({
     { key: "population", label: "Population" },
     { key: "driveToToronto", label: driveLabel },
     { key: "goTrainTime", label: goTrainLabel },
-    { key: "homePriceRange", label: "Typical Home Price" },
+    { key: "averageSalePrice", label: "Average Sale Price" },
+    { key: "salesCount", label: "Sales Count" },
+    { key: "avgLdom", label: "Avg. LDOM" },
     { key: "highways", label: "Highways" },
     { key: "transitSummary", label: "Transit" },
   ];
@@ -439,6 +441,11 @@ export default function TownPageLayout({
                 </a>
               )}
             </div>
+            {snapshot?.marketPeriod && snapshot?.marketSource && (
+              <p className="mt-2 text-xs text-gray-500">
+                {snapshot.marketPeriod} · {snapshot.marketHomeType}. Source: {snapshot.marketSource}.
+              </p>
+            )}
             <div className="mt-6 grid gap-3 sm:grid-cols-2">
               {snapshotFields.map((field) => (
                 <SnapshotRow key={field.key} label={field.label} value={snapshot?.[field.key]} />

--- a/src/data/marketData.json
+++ b/src/data/marketData.json
@@ -1,127 +1,49 @@
 {
-  "lastUpdated": "April 2026",
-  "datasets": {
-    "marketWatch": {
-      "source": "TRREB Market Watch",
-      "towns": {
-        "aurora": {
-          "averageSold": "$1,153,153",
-          "daysOnMarket": "26",
-          "yearOverYear": "-12.3%"
-        },
-        "newmarket": {
-          "averageSold": "$998,202",
-          "daysOnMarket": "24",
-          "yearOverYear": "-9.2%"
-        },
-        "stouffville": {
-          "averageSold": "$1,186,821",
-          "daysOnMarket": "27",
-          "yearOverYear": "-10.2%"
-        },
-        "uxbridge": {
-          "averageSold": "$1,023,606",
-          "daysOnMarket": "37",
-          "yearOverYear": "-7.3%"
-        },
-        "georgina": {
-          "averageSold": "$767,732",
-          "daysOnMarket": "24",
-          "yearOverYear": "-7.8%"
-        },
-        "east-gwillimbury": {
-          "averageSold": "$1,038,275",
-          "daysOnMarket": "31",
-          "yearOverYear": "-4.4%"
-        },
-        "scugog": {
-          "averageSold": "$865,895",
-          "daysOnMarket": "37",
-          "yearOverYear": "-6.4%"
-        }
-      }
+  "period": "June 2026",
+  "source": "TRREB Market Watch, June 2026",
+  "homeType": "All Home Types",
+  "municipalities": {
+    "aurora": {
+      "name": "Aurora",
+      "averageSalePrice": "$1,239,892",
+      "salesCount": 76,
+      "avgLdom": 46
     },
-    "communityGuide": {
-      "source": "TRREB MLS® 2025–2026",
-      "towns": {
-        "aurora": {
-          "homePriceRange": "~$1.1M–$1.6M",
-          "averageSold": "$1,122,000",
-          "detachedAverage": "$1,561,000",
-          "townhouseAverage": "$918,000",
-          "condoAverage": "$720,000",
-          "daysOnMarket": "24",
-          "saleToListRatio": "97%",
-          "monthsInventory": "4.2",
-          "marketType": "Buyer's market"
-        },
-        "newmarket": {
-          "homePriceRange": "~$750K–$1.1M",
-          "averageSold": "$1,048,000",
-          "detachedAverage": "$1,142,000",
-          "townhouseAverage": "$820,000",
-          "condoAverage": "$544,000",
-          "daysOnMarket": "17",
-          "saleToListRatio": "98%",
-          "monthsInventory": "1.6",
-          "marketType": "Balanced market"
-        },
-        "stouffville": {
-          "homePriceRange": "~$1.0M–$1.4M",
-          "averageSold": "$1,114,000",
-          "detachedAverage": "$1,280,000",
-          "townhouseAverage": "$890,000",
-          "condoAverage": "$680,000",
-          "daysOnMarket": "28",
-          "saleToListRatio": "99%",
-          "monthsInventory": "6.0",
-          "marketType": "Buyer's market"
-        },
-        "east-gwillimbury": {
-          "homePriceRange": "~$1.1M–$1.4M",
-          "averageSold": "$1,150,000",
-          "detachedAverage": "$1,550,000",
-          "townhouseAverage": "$890,000",
-          "condoAverage": "$680,000",
-          "daysOnMarket": "30",
-          "saleToListRatio": "98%",
-          "monthsInventory": "4.5",
-          "marketType": "Buyer's market"
-        },
-        "georgina": {
-          "homePriceRange": "~$800K–$950K",
-          "averageSold": "$875,000",
-          "detachedAverage": "$910,000",
-          "townhouseAverage": "$815,000",
-          "condoAverage": "$590,000",
-          "daysOnMarket": "38",
-          "saleToListRatio": "97%",
-          "monthsInventory": "7.5",
-          "marketType": "Buyer's market"
-        },
-        "uxbridge": {
-          "homePriceRange": "~$1.0M–$1.4M",
-          "averageSold": "$990,000",
-          "detachedAverage": "$1,200,000",
-          "townhouseAverage": "$750,000",
-          "condoAverage": "$527,000",
-          "daysOnMarket": "34",
-          "saleToListRatio": "97%",
-          "monthsInventory": "4.0",
-          "marketType": "Balanced market"
-        },
-        "scugog": {
-          "homePriceRange": "~$800K–$1.0M",
-          "averageSold": "$960,000",
-          "detachedAverage": "$1,099,000",
-          "townhouseAverage": "$762,000",
-          "condoAverage": "$800,000",
-          "daysOnMarket": "36",
-          "saleToListRatio": "98%",
-          "monthsInventory": "5.5",
-          "marketType": "Buyer's market"
-        }
-      }
+    "newmarket": {
+      "name": "Newmarket",
+      "averageSalePrice": "$1,018,511",
+      "salesCount": 88,
+      "avgLdom": 38
+    },
+    "stouffville": {
+      "name": "Whitchurch-Stouffville",
+      "averageSalePrice": "$1,329,155",
+      "salesCount": 54,
+      "avgLdom": 41
+    },
+    "east-gwillimbury": {
+      "name": "East Gwillimbury",
+      "averageSalePrice": "$1,062,808",
+      "salesCount": 39,
+      "avgLdom": 57
+    },
+    "georgina": {
+      "name": "Georgina",
+      "averageSalePrice": "$794,410",
+      "salesCount": 85,
+      "avgLdom": 52
+    },
+    "uxbridge": {
+      "name": "Uxbridge",
+      "averageSalePrice": "$1,140,111",
+      "salesCount": 33,
+      "avgLdom": 47
+    },
+    "scugog": {
+      "name": "Scugog",
+      "averageSalePrice": "$990,492",
+      "salesCount": 31,
+      "avgLdom": 55
     }
   }
 }

--- a/src/homepageMarkup.js
+++ b/src/homepageMarkup.js
@@ -1,10 +1,6 @@
 import MARKET_DATA from "./data/marketData.json";
 
-const { getMarketTrend } = require("./utils/marketTrend");
-const MARKET_WATCH = MARKET_DATA.datasets.marketWatch;
-const MARKET_TRENDS = Object.fromEntries(
-  Object.entries(MARKET_WATCH.towns).map(([slug, town]) => [slug, getMarketTrend(town.yearOverYear)])
-);
+const MARKET_TOWNS = MARKET_DATA.municipalities;
 
 export const HOMEPAGE_MARKUP = String.raw`
 <main>
@@ -657,8 +653,8 @@ export const HOMEPAGE_MARKUP = String.raw`
               </ul>
               <div class="community-card__footer">
                 <div>
-                  <span class="community-card__price-label">Avg. price · Apr 2026</span>
-                  <span class="community-card__price">${MARKET_WATCH.towns.georgina.averageSold}</span>
+                  <span class="community-card__price-label">Avg. sale price · ${MARKET_DATA.period}</span>
+                  <span class="community-card__price">${MARKET_TOWNS.georgina.averageSalePrice}</span>
                 </div>
                 <span class="community-card__cta">Explore Georgina Real Estate →</span>
               </div>
@@ -679,8 +675,8 @@ export const HOMEPAGE_MARKUP = String.raw`
               </ul>
               <div class="community-card__footer">
                 <div>
-                  <span class="community-card__price-label">Avg. price · Apr 2026</span>
-                  <span class="community-card__price">${MARKET_WATCH.towns["east-gwillimbury"].averageSold}</span>
+                  <span class="community-card__price-label">Avg. sale price · ${MARKET_DATA.period}</span>
+                  <span class="community-card__price">${MARKET_TOWNS["east-gwillimbury"].averageSalePrice}</span>
                 </div>
                 <span class="community-card__cta">Explore East Gwillimbury Real Estate →</span>
               </div>
@@ -701,8 +697,8 @@ export const HOMEPAGE_MARKUP = String.raw`
               </ul>
               <div class="community-card__footer">
                 <div>
-                  <span class="community-card__price-label">Avg. price · Apr 2026</span>
-                  <span class="community-card__price">${MARKET_WATCH.towns.newmarket.averageSold}</span>
+                  <span class="community-card__price-label">Avg. sale price · ${MARKET_DATA.period}</span>
+                  <span class="community-card__price">${MARKET_TOWNS.newmarket.averageSalePrice}</span>
                 </div>
                 <span class="community-card__cta">Explore Newmarket Real Estate →</span>
               </div>
@@ -723,8 +719,8 @@ export const HOMEPAGE_MARKUP = String.raw`
               </ul>
               <div class="community-card__footer">
                 <div>
-                  <span class="community-card__price-label">Avg. price · Apr 2026</span>
-                  <span class="community-card__price">${MARKET_WATCH.towns.aurora.averageSold}</span>
+                  <span class="community-card__price-label">Avg. sale price · ${MARKET_DATA.period}</span>
+                  <span class="community-card__price">${MARKET_TOWNS.aurora.averageSalePrice}</span>
                 </div>
                 <span class="community-card__cta">Explore Aurora Real Estate →</span>
               </div>
@@ -745,8 +741,8 @@ export const HOMEPAGE_MARKUP = String.raw`
               </ul>
               <div class="community-card__footer">
                 <div>
-                  <span class="community-card__price-label">Avg. price · Apr 2026</span>
-                  <span class="community-card__price">${MARKET_WATCH.towns.stouffville.averageSold}</span>
+                  <span class="community-card__price-label">Avg. sale price · ${MARKET_DATA.period}</span>
+                  <span class="community-card__price">${MARKET_TOWNS.stouffville.averageSalePrice}</span>
                 </div>
                 <span class="community-card__cta">Explore Stouffville Real Estate →</span>
               </div>
@@ -767,8 +763,8 @@ export const HOMEPAGE_MARKUP = String.raw`
               </ul>
               <div class="community-card__footer">
                 <div>
-                  <span class="community-card__price-label">Avg. price · Apr 2026</span>
-                  <span class="community-card__price">${MARKET_WATCH.towns.uxbridge.averageSold}</span>
+                  <span class="community-card__price-label">Avg. sale price · ${MARKET_DATA.period}</span>
+                  <span class="community-card__price">${MARKET_TOWNS.uxbridge.averageSalePrice}</span>
                 </div>
                 <span class="community-card__cta">Explore Uxbridge Real Estate →</span>
               </div>
@@ -789,8 +785,8 @@ export const HOMEPAGE_MARKUP = String.raw`
               </ul>
               <div class="community-card__footer">
                 <div>
-                  <span class="community-card__price-label">Avg. price · Apr 2026</span>
-                  <span class="community-card__price">${MARKET_WATCH.towns.scugog.averageSold}</span>
+                  <span class="community-card__price-label">Avg. sale price · ${MARKET_DATA.period}</span>
+                  <span class="community-card__price">${MARKET_TOWNS.scugog.averageSalePrice}</span>
                 </div>
                 <span class="community-card__cta">Explore Scugog Real Estate →</span>
               </div>
@@ -808,56 +804,56 @@ export const HOMEPAGE_MARKUP = String.raw`
       <div class="market-snapshot__header">
         <div>
           <h2 class="market-snapshot__heading" id="market-heading">NorthSide GTA Market Snapshot</h2>
-          <p class="market-snapshot__date">Last updated: ${MARKET_DATA.lastUpdated} · Updated monthly</p>
+          <p class="market-snapshot__date">${MARKET_DATA.period} · ${MARKET_DATA.homeType}</p>
         </div>
-        <span class="market-snapshot__source">Source: ${MARKET_WATCH.source}, ${MARKET_DATA.lastUpdated}</span>
+        <span class="market-snapshot__source">Source: ${MARKET_DATA.source}</span>
       </div>
 
       <p class="market-context">
-        Prices across the NorthSide GTA are down year-over-year — giving buyers more room to negotiate and more time to decide than at any point in the last three years.
+        A consistent all-home-types view of average sale price, sales, and average listing days on market across all seven municipalities.
       </p>
 
       <div class="market-cards" role="list" aria-label="Market data by community">
         
         <div class="market-card" role="listitem">
-          <div class="market-card__top"><span class="market-card__name">Georgina</span><span class="market-card__yoy market-card__yoy--${MARKET_TRENDS.georgina.direction}">${MARKET_TRENDS.georgina.label}</span></div>
-          <span class="market-card__price">${MARKET_WATCH.towns.georgina.averageSold}</span>
-          <span class="market-card__meta">Avg · ${MARKET_WATCH.towns.georgina.daysOnMarket} days on market · YoY</span>
+          <div class="market-card__top"><span class="market-card__name">Georgina</span></div>
+          <span class="market-card__price">${MARKET_TOWNS.georgina.averageSalePrice}</span>
+          <span class="market-card__meta">Sales count ${MARKET_TOWNS.georgina.salesCount} · Avg. LDOM ${MARKET_TOWNS.georgina.avgLdom}</span>
         </div>
         <div class="market-card" role="listitem">
-          <div class="market-card__top"><span class="market-card__name">East Gwillimbury</span><span class="market-card__yoy market-card__yoy--${MARKET_TRENDS["east-gwillimbury"].direction}">${MARKET_TRENDS["east-gwillimbury"].label}</span></div>
-          <span class="market-card__price">${MARKET_WATCH.towns["east-gwillimbury"].averageSold}</span>
-          <span class="market-card__meta">Avg · ${MARKET_WATCH.towns["east-gwillimbury"].daysOnMarket} days on market · YoY</span>
+          <div class="market-card__top"><span class="market-card__name">East Gwillimbury</span></div>
+          <span class="market-card__price">${MARKET_TOWNS["east-gwillimbury"].averageSalePrice}</span>
+          <span class="market-card__meta">Sales count ${MARKET_TOWNS["east-gwillimbury"].salesCount} · Avg. LDOM ${MARKET_TOWNS["east-gwillimbury"].avgLdom}</span>
         </div>
         <div class="market-card" role="listitem">
-          <div class="market-card__top"><span class="market-card__name">Newmarket</span><span class="market-card__yoy market-card__yoy--${MARKET_TRENDS.newmarket.direction}">${MARKET_TRENDS.newmarket.label}</span></div>
-          <span class="market-card__price">${MARKET_WATCH.towns.newmarket.averageSold}</span>
-          <span class="market-card__meta">Avg · ${MARKET_WATCH.towns.newmarket.daysOnMarket} days on market · YoY</span>
+          <div class="market-card__top"><span class="market-card__name">Newmarket</span></div>
+          <span class="market-card__price">${MARKET_TOWNS.newmarket.averageSalePrice}</span>
+          <span class="market-card__meta">Sales count ${MARKET_TOWNS.newmarket.salesCount} · Avg. LDOM ${MARKET_TOWNS.newmarket.avgLdom}</span>
         </div>
         <div class="market-card" role="listitem">
-          <div class="market-card__top"><span class="market-card__name">Aurora</span><span class="market-card__yoy market-card__yoy--${MARKET_TRENDS.aurora.direction}">${MARKET_TRENDS.aurora.label}</span></div>
-          <span class="market-card__price">${MARKET_WATCH.towns.aurora.averageSold}</span>
-          <span class="market-card__meta">Avg · ${MARKET_WATCH.towns.aurora.daysOnMarket} days on market · YoY</span>
+          <div class="market-card__top"><span class="market-card__name">Aurora</span></div>
+          <span class="market-card__price">${MARKET_TOWNS.aurora.averageSalePrice}</span>
+          <span class="market-card__meta">Sales count ${MARKET_TOWNS.aurora.salesCount} · Avg. LDOM ${MARKET_TOWNS.aurora.avgLdom}</span>
         </div>
         <div class="market-card" role="listitem">
-          <div class="market-card__top"><span class="market-card__name">Whitchurch-Stouffville</span><span class="market-card__yoy market-card__yoy--${MARKET_TRENDS.stouffville.direction}">${MARKET_TRENDS.stouffville.label}</span></div>
-          <span class="market-card__price">${MARKET_WATCH.towns.stouffville.averageSold}</span>
-          <span class="market-card__meta">Avg · ${MARKET_WATCH.towns.stouffville.daysOnMarket} days on market · YoY</span>
+          <div class="market-card__top"><span class="market-card__name">Whitchurch-Stouffville</span></div>
+          <span class="market-card__price">${MARKET_TOWNS.stouffville.averageSalePrice}</span>
+          <span class="market-card__meta">Sales count ${MARKET_TOWNS.stouffville.salesCount} · Avg. LDOM ${MARKET_TOWNS.stouffville.avgLdom}</span>
         </div>
         <div class="market-card" role="listitem">
-          <div class="market-card__top"><span class="market-card__name">Uxbridge</span><span class="market-card__yoy market-card__yoy--${MARKET_TRENDS.uxbridge.direction}">${MARKET_TRENDS.uxbridge.label}</span></div>
-          <span class="market-card__price">${MARKET_WATCH.towns.uxbridge.averageSold}</span>
-          <span class="market-card__meta">Avg · ${MARKET_WATCH.towns.uxbridge.daysOnMarket} days on market · YoY</span>
+          <div class="market-card__top"><span class="market-card__name">Uxbridge</span></div>
+          <span class="market-card__price">${MARKET_TOWNS.uxbridge.averageSalePrice}</span>
+          <span class="market-card__meta">Sales count ${MARKET_TOWNS.uxbridge.salesCount} · Avg. LDOM ${MARKET_TOWNS.uxbridge.avgLdom}</span>
         </div>
         <div class="market-card" role="listitem">
-          <div class="market-card__top"><span class="market-card__name">Scugog</span><span class="market-card__yoy market-card__yoy--${MARKET_TRENDS.scugog.direction}">${MARKET_TRENDS.scugog.label}</span></div>
-          <span class="market-card__price">${MARKET_WATCH.towns.scugog.averageSold}</span>
-          <span class="market-card__meta">Avg · ${MARKET_WATCH.towns.scugog.daysOnMarket} days on market · YoY</span>
+          <div class="market-card__top"><span class="market-card__name">Scugog</span></div>
+          <span class="market-card__price">${MARKET_TOWNS.scugog.averageSalePrice}</span>
+          <span class="market-card__meta">Sales count ${MARKET_TOWNS.scugog.salesCount} · Avg. LDOM ${MARKET_TOWNS.scugog.avgLdom}</span>
         </div>
       </div>
 
       <p class="market-snapshot__disclaimer">
-        Source: ${MARKET_WATCH.source}, ${MARKET_DATA.lastUpdated}. Figures are rounded and may vary by property type, location, and condition.
+        Source: ${MARKET_DATA.source}. ${MARKET_DATA.homeType}.
       </p>
       <p class="market-snapshot__legal">
         Not a guarantee of value. Not intended to solicit clients already under contract with a brokerage.


### PR DESCRIPTION
## What changed

- Replace the previous `marketWatch` and `communityGuide` datasets with one authoritative June 2026 municipal dataset in `src/data/marketData.json`.
- Store the exact TRREB Market Watch June 2026 All Home Types average sale price, sales count, and Avg. LDOM for Aurora, Newmarket, Whitchurch-Stouffville, East Gwillimbury, Georgina, Uxbridge, and Scugog.
- Update homepage, buyer, neighbourhood-guide, Keswick/Georgina, generic town, and all seven community snapshots to read the same shared fields.
- Show `June 2026`, `All Home Types`, and `Source: TRREB Market Watch, June 2026` on every market snapshot.
- Remove the old rounded property-type averages, inventory figures, sale/list ratios, market labels, and YoY snapshot values.
- Extend the prerendered-route audit to verify every municipality’s exact shared values and source attribution.

## Why

The site had two competing market datasets and several rounded or page-specific figures. That allowed the homepage and community pages to show different numbers for the same municipality and made monthly updates prone to drift.

## Impact

All market snapshots now use one consistent TRREB reporting period and expose the exact three requested municipal metrics. Future updates can be made once in `marketData.json` and flow through every consuming page.

## Source

TRREB Market Watch, June 2026 — All Home Types:
https://trreb.ca/wp-content/files/market-stats/market-watch/mw2606.pdf

## Validation

- Production build completed successfully ✅
- 31 prerendered route checks and 13 published insight checks passed ✅
- Exact-value check passed for all seven municipalities ✅
- `git diff --check` passed ✅
- Full test suite: 85/86 passed; the existing unrelated ICS recurrence timezone assertion remains failing (`10:00–12:00` expected vs `06:00–08:00` actual) ⚠️

The unrelated untracked insight JSON files in the working tree were not included.