### PR TITLE
Add the Moving to Georgina from Toronto guide

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -12,6 +12,11 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://northsidegta.ca/moving-to-georgina-from-toronto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://northsidegta.ca/sellers</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -95,6 +95,7 @@ function main() {
   const staticRoutes = [
     { path: '/', changefreq: 'weekly', priority: '1.0' },
     { path: '/buyers', changefreq: 'weekly', priority: '0.9' },
+    { path: '/moving-to-georgina-from-toronto', changefreq: 'monthly', priority: '0.8' },
     { path: '/sellers', changefreq: 'weekly', priority: '0.9' },
     { path: '/homeanalysis', changefreq: 'monthly', priority: '0.7' },
     { path: '/communities', changefreq: 'monthly', priority: '0.8' },

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -25,6 +25,7 @@ const buildDir = path.join(rootDir, "build");
 const routeModules = {
   "/about": "../src/AboutPage",
   "/buyers": "../src/BuyersPage",
+  "/moving-to-georgina-from-toronto": "../src/MovingToGeorginaFromTorontoPage",
   "/sellers": "../src/SellersPage",
   "/homeanalysis": "../src/HomeAnalysisPage",
   "/media": "../src/MediaPage",

--- a/scripts/verify-prerendered-seo.js
+++ b/scripts/verify-prerendered-seo.js
@@ -35,6 +35,13 @@ const townNames = {
 const staticChecks = [
   { route: "/about", h1: "About Finally Home Agents", body: "Matthew and Landon" },
   { route: "/buyers", h1: "You don't have to leave the city", body: "Town strategy" },
+  {
+    route: "/moving-to-georgina-from-toronto",
+    h1: "Moving to Georgina from Toronto: The Honest 2026 Guide",
+    body: "What your Toronto money buys in Georgina",
+    title: "Moving to Georgina from Toronto (2026 Guide) | Finally Home Agents",
+    schema: ["Article", "FAQPage", "BreadcrumbList"],
+  },
   { route: "/sellers", h1: "A Better Sale Starts Before the Listing Goes Live", body: "seller" },
   { route: "/homeanalysis", h1: "What’s Your Home Worth", body: "NorthSide GTA Market" },
   { route: "/contact", h1: "Glad you found us", body: "Matthew" },
@@ -340,6 +347,46 @@ Object.entries(marketData.municipalities).forEach(([slug, town]) => {
     }
   });
 });
+
+const movingGuideRoute = "/moving-to-georgina-from-toronto";
+const movingGuideDoc = readRoute(movingGuideRoute);
+const movingGuideText = movingGuideDoc?.querySelector("body")?.text.replace(/\s+/g, " ").trim() || "";
+const movingGuideHtml = movingGuideDoc?.toString() || "";
+[
+  marketData.period,
+  `Source: ${marketData.source}`,
+  marketData.homeType,
+  ...["georgina", "newmarket", "aurora"].flatMap((slug) => {
+    const town = marketData.municipalities[slug];
+    return [
+      town.averageSalePrice,
+      String(town.salesCount),
+      String(town.avgLdom),
+      town.yearOverYear,
+    ];
+  }),
+].forEach((value) => {
+  if (!movingGuideText.includes(value)) {
+    failures.push(`${movingGuideRoute}: moving guide is missing shared market value "${value}"`);
+  }
+});
+
+[
+  'href="/communities/georgina"',
+  'href="/tastehub?town=georgina"',
+  'href="/neighbourhood-guide"',
+  'href="/buyers#town-match"',
+  'href="/contact"',
+  'href="https://wa.me/16476684646"',
+].forEach((value) => {
+  if (!movingGuideHtml.includes(value)) {
+    failures.push(`${movingGuideRoute}: missing outbound link ${value}`);
+  }
+});
+
+if (marketData.toronto?.condoAverage == null && /The average Toronto condo now sells for/.test(movingGuideText)) {
+  failures.push(`${movingGuideRoute}: Toronto comparison must be hidden while placeholder values are null`);
+}
 
 const robots = fs.readFileSync(path.join(rootDir, "public", "robots.txt"), "utf8");
 if (

--- a/src/App.js
+++ b/src/App.js
@@ -50,6 +50,7 @@ import CoffeePage, { BookCoffeeAliasPage } from "./CoffeePage";
 import PowerOfSaleSupportPage from "./PowerOfSaleSupportPage";
 import KeswickLowerPricedHomesPage from "./KeswickLowerPricedHomesPage";
 import UnlockPage from "./UnlockPage";
+import MovingToGeorginaFromTorontoPage from "./MovingToGeorginaFromTorontoPage";
 
 import AuroraPage from "./AuroraPage";
 import NewmarketPage from "./NewmarketPage";
@@ -109,6 +110,7 @@ function App() {
           <Route path="/listings/33-st-augustine-drive-brooklin" element={<StAugustineDriveListingPage />} />
           <Route path="/about"        element={<AboutPage />} />
           <Route path="/buyers"       element={<BuyersPage />} />
+          <Route path="/moving-to-georgina-from-toronto" element={<MovingToGeorginaFromTorontoPage />} />
           <Route path="/sellers"      element={<SellersPage />} />
           <Route path="/community"    element={<CommunityPage />} />
           <Route path="/communities"  element={<CommunitiesPage />} />

--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -16,6 +16,16 @@ const COMMUNITIES = [
   "Scugog",
 ];
 
+const MOVING_FROM_TORONTO_GUIDES = [
+  { town: "Georgina", href: "/moving-to-georgina-from-toronto" },
+  { town: "East Gwillimbury" },
+  { town: "Uxbridge" },
+  { town: "Newmarket" },
+  { town: "Aurora" },
+  { town: "Stouffville" },
+  { town: "Scugog" },
+];
+
 const TOWN_DATA = {
   Aurora: {
     slug: "aurora",
@@ -610,6 +620,30 @@ export default function BuyersPage() {
         </div>
       </section>
 
+      <section className="moving-guides-strip" aria-labelledby="moving-guides-heading">
+        <div className="buyers-container moving-guides-strip__inner">
+          <div>
+            <p className="buyers-eyebrow">Moving from Toronto?</p>
+            <h2 id="moving-guides-heading">Start with an honest town guide.</h2>
+            <p>
+              Read the live Georgina guide now. Six more Toronto-to-town guides are coming next,
+              and this list is ready to grow with them.
+            </p>
+          </div>
+          <ul>
+            {MOVING_FROM_TORONTO_GUIDES.map(({ town, href }) => (
+              <li key={town}>
+                {href ? (
+                  <a href={href}>Moving to {town} from Toronto →</a>
+                ) : (
+                  <span>Moving to {town} from Toronto <em>Coming soon</em></span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
       <section className="buyers-section white-section" id="town-match">
         <div className="buyers-container split-section">
           <SectionHeader
@@ -780,6 +814,14 @@ const BUYERS_STYLES = `
   .community-tags { display: flex; flex-wrap: wrap; gap: 6px; }
   .community-tags span { border: 1px solid #e2ddd5; border-radius: 999px; background: #fff; padding: 4px 9px; color: var(--primary); font-size: 11.5px; font-weight: 600; }
   .community-strip p { flex-basis: 100%; margin: 2px 0 0; color: var(--muted); font-size: 11.5px; }
+  .moving-guides-strip { border-bottom: 1px solid #e8e4db; background: #eef3e6; padding: 30px 32px; }
+  .moving-guides-strip__inner { display: grid; grid-template-columns: minmax(0, 0.8fr) minmax(420px, 1.2fr); gap: 34px; align-items: center; }
+  .moving-guides-strip h2 { margin: 0; color: var(--primary); font-family: "Playfair Display", Georgia, serif; font-size: 27px; line-height: 1.14; }
+  .moving-guides-strip p:not(.buyers-eyebrow) { margin: 10px 0 0; color: var(--muted); font-size: 13px; line-height: 1.65; }
+  .moving-guides-strip ul { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 0; padding: 0; list-style: none; }
+  .moving-guides-strip li a, .moving-guides-strip li span { display: flex; min-height: 43px; align-items: center; justify-content: space-between; gap: 8px; border: 1px solid #d8dfcf; border-radius: 4px; background: #fff; padding: 9px 12px; color: var(--primary); font-size: 12px; font-weight: 650; text-decoration: none; }
+  .moving-guides-strip li span { color: var(--muted); font-weight: 500; }
+  .moving-guides-strip li em { flex: 0 0 auto; color: #8a7450; font-size: 9px; font-style: normal; letter-spacing: 0.08em; text-transform: uppercase; }
 
   .split-section { display: grid; grid-template-columns: minmax(0, 0.82fr) minmax(340px, 600px); gap: 34px; align-items: start; }
   .quiz-card { width: 100%; max-width: 600px; background: #fff; border: 1px solid var(--border); border-radius: 6px; padding: 26px; box-shadow: 0 22px 70px rgba(26,26,26,0.07); }
@@ -887,7 +929,7 @@ const BUYERS_STYLES = `
   .mobile-cta-bar { display: none; }
 
   @media (max-width: 900px) {
-    .split-section, .cta-grid { grid-template-columns: 1fr; }
+    .split-section, .cta-grid, .moving-guides-strip__inner { grid-template-columns: 1fr; }
     .market-grid, .process-grid, .reviews-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   }
 
@@ -900,13 +942,14 @@ const BUYERS_STYLES = `
   }
 
   @media (max-width: 640px) {
-    .buyers-hero, .buyers-section, .community-strip { padding-left: 20px; padding-right: 20px; }
+    .buyers-hero, .buyers-section, .community-strip, .moving-guides-strip { padding-left: 20px; padding-right: 20px; }
     .buyers-section { padding-top: 34px; padding-bottom: 34px; }
     .dark-section { padding-bottom: 104px; }
     .buyers-hero { padding-top: 58px; }
     .buyers-hero h1 { font-size: 32px; }
     .buyers-section-header h2 { font-size: 29px; }
     .trust-strip, .photo-grid, .market-grid, .process-grid, .reviews-grid, .also-grid, .form-two-col { grid-template-columns: 1fr; }
+    .moving-guides-strip ul { grid-template-columns: 1fr; }
     .quiz-card, .consultation-card { padding: 22px; }
     .buyers-faq-item summary { align-items: flex-start; padding: 16px; font-size: 17px; }
     .buyers-faq-item p { padding: 14px 16px 17px; font-size: 13.5px; }

--- a/src/GeorginaPage.js
+++ b/src/GeorginaPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef } from "react";
 import { Helmet } from "react-helmet-async";
 import HeaderShell from "./components/HeaderShell";
+import CommunityComplianceFooter from "./components/CommunityComplianceFooter";
 import MARKET_DATA from "./data/marketData.json";
 
 const TOWN_MARKET = MARKET_DATA.municipalities.georgina;
@@ -49,6 +50,10 @@ img{max-width:100%;display:block;}
 .breadcrumb{font-size:12px;color:var(--ink4);padding:16px 0 0;}
 .breadcrumb a{color:var(--green);}
 .breadcrumb span{margin:0 5px;}
+.moving-guide-banner{display:flex;align-items:center;justify-content:space-between;gap:18px;margin:20px 0 0;padding:17px 20px;border:1px solid var(--gborder);border-radius:var(--rl);background:linear-gradient(135deg,var(--gpale),#fff);box-shadow:var(--sh);}
+.moving-guide-banner strong{display:block;color:var(--green);font-family:var(--fd);font-size:17px;}
+.moving-guide-banner span{display:block;margin-top:3px;color:var(--ink3);font-size:12px;}
+.moving-guide-banner a{flex:0 0 auto;border-radius:24px;background:var(--green);padding:10px 17px;color:#fff;font-size:12px;font-weight:600;text-decoration:none;}
 .page-grid{display:grid;grid-template-columns:1fr 300px;gap:32px;align-items:start;padding:28px 0 60px;}
 .sec{background:var(--paper);border-radius:var(--rxl);border:1px solid var(--border);padding:24px;margin-bottom:20px;box-shadow:var(--sh);}
 .sec h2{font-family:var(--fd);font-size:20px;font-weight:700;color:var(--ink);margin-bottom:14px;letter-spacing:-0.01em;}
@@ -148,7 +153,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-watch{background:#fffbeb;border-color:#fde68a;}
 .fit-watch .fit-label{font-weight:600;color:#78350f;font-size:11px;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:6px;}
 .fit-item p{color:var(--ink2);line-height:1.6;}
-@media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
+@media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}.moving-guide-banner{align-items:flex-start;flex-direction:column;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
 `;
 const PAGE_SCHEMA = `{
@@ -213,6 +218,13 @@ const PAGE_BODY_HTML = `
     <a href="https://northsidegta.ca/neighbourhood-guide">Neighbourhood guide</a><span>&rsaquo;</span>
     <span>Georgina</span>
   </nav>
+  <aside class="moving-guide-banner" aria-label="Moving to Georgina guide">
+    <div>
+      <strong>Moving from Toronto?</strong>
+      <span>Prices, commute, communities, and the trade-offs to know before you move.</span>
+    </div>
+    <a href="/moving-to-georgina-from-toronto">Read the Honest 2026 Guide &rarr;</a>
+  </aside>
   <div class="page-grid">
 
     <!-- MAIN COLUMN -->
@@ -440,13 +452,6 @@ const PAGE_BODY_HTML = `
   </div><!-- /grid -->
 </div><!-- /container -->
 
-<footer class="compliance" role="contentinfo">
-  <div class="compliance-inner">
-    <p><strong>Market data disclaimer:</strong> Market information is provided for general guidance only and may change. Buyers should confirm current pricing, availability, school boundaries, commute times, and property details before making decisions. Average sold prices sourced from TRREB MLS® data and regional market reports (Q3 2025–Q2 2026). Drive times are off-peak estimates via Hwy 404 to the DVP/401 interchange. <strong>TasteHub disclaimer:</strong> TasteHub results are community-powered and are not paid rankings or endorsements. <strong>Restaurant disclaimer:</strong> Local favourites are included for community context only and are not ranked by Finally Home Agents unless clearly identified as community voting results. <strong>School disclaimer:</strong> School ratings from Fraser Institute 2024/2025. School ratings and boundaries can change. Buyers should verify directly with the relevant school board before purchasing. <strong>Registrant information (TRESA):</strong> <strong>Matthew Mulhall</strong> and <strong>Landon Mulhall</strong>, Sales Representatives, Finally Home Agents Team, <strong>HomeLife Optimum Realty, Brokerage</strong>, regulated by the <strong>Real Estate Council of Ontario (RECO)</strong> under the <em>Trust in Real Estate Services Act, 2002 (TRESA)</em>. MLS® is a registered trademark of CREA. © 2026 Finally Home Agents Team | HomeLife Optimum Realty, Brokerage | <a href="https://northsidegta.ca">northsidegta.ca</a></p>
-  </div>
-</footer>
-
-
 `;
 
 
@@ -502,5 +507,5 @@ export default function GeorginaPage() {
       <meta property="og:image" content="https://northsidegta.ca/Images/georgina-banner.jpg" />
       <link rel="canonical" href="https://northsidegta.ca/communities/georgina" />
       <script type="application/ld+json">{JSON.stringify(schemaObject)}</script>
-    </Helmet><HeaderShell /><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /></>);
+    </Helmet><HeaderShell /><style>{PAGE_STYLE}</style><div ref={containerRef} dangerouslySetInnerHTML={{ __html: PAGE_BODY_HTML }} /><CommunityComplianceFooter /></>);
 }

--- a/src/MovingToGeorginaFromTorontoPage.js
+++ b/src/MovingToGeorginaFromTorontoPage.js
@@ -1,0 +1,14 @@
+import React from "react";
+import MovingFromTorontoPage from "./components/movingFromToronto/MovingFromTorontoPage";
+import georginaMovingGuideModule from "./content/movingFromToronto/georgina";
+
+const { georginaMovingGuide, buildMovingGuideSchema } = georginaMovingGuideModule;
+
+export default function MovingToGeorginaFromTorontoPage() {
+  return (
+    <MovingFromTorontoPage
+      content={georginaMovingGuide}
+      buildSchema={buildMovingGuideSchema}
+    />
+  );
+}

--- a/src/NeighbourhoodGuidePage.js
+++ b/src/NeighbourhoodGuidePage.js
@@ -633,6 +633,7 @@ const PAGE_BODY_HTML = `
       <div class="omc-price">At $1,000,000</div>
       <p class="omc-desc">A newer or updated 4-bed detached in communities like Keswick (including Simcoe Landing), often with a nice lot and modern family layout. Waterfront and triple-garage homes are typically above this budget.</p>
       <a href="/communities/georgina" class="omc-link">View Georgina guide &rarr;</a>
+      <a href="/moving-to-georgina-from-toronto" class="omc-link" style="display:block;margin-top:7px;">Moving from Toronto? Read the Honest 2026 Guide &rarr;</a>
     </div>
     <div class="omc" style="--omc-c:#2a3a1a;">
       <div class="omc-header">

--- a/src/components/CommunityComplianceFooter.js
+++ b/src/components/CommunityComplianceFooter.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+export default function CommunityComplianceFooter() {
+  return (
+    <footer className="compliance" role="contentinfo">
+      <div className="compliance-inner">
+        <p>
+          <strong>Market data disclaimer:</strong> Market information is provided for general guidance only and may change. Buyers should confirm current pricing, availability, school boundaries, commute times, and property details before making decisions. Average sold prices sourced from TRREB MLS® data and regional market reports (Q3 2025–Q2 2026). Drive times are off-peak estimates via Hwy 404 to the DVP/401 interchange.{" "}
+          <strong>TasteHub disclaimer:</strong> TasteHub results are community-powered and are not paid rankings or endorsements.{" "}
+          <strong>Restaurant disclaimer:</strong> Local favourites are included for community context only and are not ranked by Finally Home Agents unless clearly identified as community voting results.{" "}
+          <strong>School disclaimer:</strong> School ratings from Fraser Institute 2024/2025. School ratings and boundaries can change. Buyers should verify directly with the relevant school board before purchasing.{" "}
+          <strong>Registrant information (TRESA):</strong>{" "}
+          <strong>Matthew Mulhall</strong> and <strong>Landon Mulhall</strong>, Sales Representatives, Finally Home Agents Team,{" "}
+          <strong>HomeLife Optimum Realty, Brokerage</strong>, regulated by the{" "}
+          <strong>Real Estate Council of Ontario (RECO)</strong> under the{" "}
+          <em>Trust in Real Estate Services Act, 2002 (TRESA)</em>. MLS® is a registered trademark of CREA. © 2026 Finally Home Agents Team | HomeLife Optimum Realty, Brokerage |{" "}
+          <a href="https://northsidegta.ca">northsidegta.ca</a>
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/movingFromToronto/MovingFromTorontoPage.css
+++ b/src/components/movingFromToronto/MovingFromTorontoPage.css
@@ -1,0 +1,708 @@
+.moving-guide {
+  --mg-green: #23470a;
+  --mg-green-deep: #142d08;
+  --mg-green-soft: #3f7020;
+  --mg-cream: #f8f6ef;
+  --mg-paper: #fff;
+  --mg-ink: #1a2116;
+  --mg-muted: #5e6859;
+  --mg-gold: #d9b44a;
+  --mg-line: #dfddd4;
+  background: var(--mg-cream);
+  color: var(--mg-ink);
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.moving-guide *,
+.moving-guide *::before,
+.moving-guide *::after {
+  box-sizing: border-box;
+}
+
+.moving-guide__container {
+  width: min(100% - 40px, 1080px);
+  margin-inline: auto;
+}
+
+.moving-guide__hero {
+  position: relative;
+  min-height: 660px;
+  overflow: hidden;
+  color: #fff;
+}
+
+.moving-guide__hero-image,
+.moving-guide__hero-shade {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.moving-guide__hero-image {
+  object-fit: cover;
+  object-position: center 52%;
+}
+
+.moving-guide__hero-shade {
+  background:
+    linear-gradient(90deg, rgba(10, 27, 5, 0.92) 0%, rgba(10, 27, 5, 0.76) 48%, rgba(10, 27, 5, 0.3) 100%),
+    linear-gradient(0deg, rgba(10, 27, 5, 0.74), transparent 55%);
+}
+
+.moving-guide__hero-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-height: 660px;
+  flex-direction: column;
+  justify-content: center;
+  padding-block: 48px 52px;
+}
+
+.moving-guide__breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 46px;
+  color: rgba(255, 255, 255, 0.74);
+  font-size: 12px;
+}
+
+.moving-guide__breadcrumbs a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.moving-guide__hero-badge {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+}
+
+.moving-guide__hero-badge img {
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-radius: 50%;
+}
+
+.moving-guide__hero-badge p,
+.moving-guide__eyebrow {
+  margin: 0;
+  color: var(--mg-gold);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.moving-guide__hero h1,
+.moving-guide h2,
+.moving-guide h3,
+.moving-guide__review blockquote {
+  font-family: "Playfair Display", Georgia, serif;
+}
+
+.moving-guide__hero h1 {
+  max-width: 820px;
+  margin: 18px 0 0;
+  font-size: clamp(40px, 6vw, 66px);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.04;
+}
+
+.moving-guide__hero-intro {
+  max-width: 710px;
+  margin: 20px 0 0;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: clamp(16px, 2vw, 19px);
+  line-height: 1.7;
+}
+
+.moving-guide__byline {
+  margin: 22px 0 0;
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 12px;
+}
+
+.moving-guide__hero-actions,
+.moving-guide__cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 11px;
+  margin-top: 27px;
+}
+
+.moving-guide__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  padding: 12px 19px;
+  font-size: 13px;
+  font-weight: 750;
+  line-height: 1.2;
+  text-decoration: none;
+  transition: transform 160ms ease, filter 160ms ease;
+}
+
+.moving-guide__button:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.04);
+}
+
+.moving-guide__button--gold {
+  background: var(--mg-gold);
+  color: var(--mg-green-deep);
+}
+
+.moving-guide__button--light {
+  border: 1px solid rgba(255, 255, 255, 0.48);
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.moving-guide__source {
+  margin: 12px 0 24px;
+  color: var(--mg-muted);
+  font-size: 11px;
+}
+
+.moving-guide__source--hero {
+  margin: 15px 0 0;
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.moving-guide__body {
+  padding-block: 32px 88px;
+}
+
+.moving-guide__section {
+  padding-block: 64px 8px;
+}
+
+.moving-guide__section h2,
+.moving-guide__cta h2 {
+  max-width: 780px;
+  margin: 9px 0 18px;
+  color: var(--mg-green);
+  font-size: clamp(31px, 4.2vw, 48px);
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.08;
+}
+
+.moving-guide__section > p:not(.moving-guide__eyebrow):not(.moving-guide__source):not(.moving-guide__aside-copy):not(.moving-guide__lifestyle-link) {
+  max-width: 790px;
+  font-size: 16px;
+  line-height: 1.78;
+}
+
+.moving-guide__stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.moving-guide__stat {
+  min-height: 116px;
+  border: 1px solid var(--mg-line);
+  border-radius: 8px;
+  background: var(--mg-paper);
+  padding: 22px 18px;
+  box-shadow: 0 16px 44px rgba(35, 71, 10, 0.05);
+}
+
+.moving-guide__stat strong {
+  display: block;
+  color: var(--mg-green);
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: clamp(21px, 2.5vw, 29px);
+}
+
+.moving-guide__stat span {
+  display: block;
+  margin-top: 8px;
+  color: var(--mg-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.moving-guide__stat--down strong,
+.moving-guide__trend--down {
+  color: #a63a3a;
+}
+
+.moving-guide__stat--up strong,
+.moving-guide__trend--up {
+  color: #2d782d;
+}
+
+.moving-guide__budget-card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 24px;
+  margin-top: 30px;
+  border: 1px solid rgba(35, 71, 10, 0.2);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(35, 71, 10, 0.1), rgba(35, 71, 10, 0.03));
+  padding: 26px 28px;
+}
+
+.moving-guide__budget-card h3 {
+  margin: 7px 0 8px;
+  color: var(--mg-green);
+  font-size: 23px;
+}
+
+.moving-guide__budget-card p:last-child {
+  max-width: 750px;
+  margin: 0;
+  color: #394235;
+  font-size: 14px;
+  line-height: 1.72;
+}
+
+.moving-guide__budget-card img {
+  border-radius: 50%;
+  box-shadow: 0 14px 30px rgba(35, 71, 10, 0.14);
+}
+
+.moving-guide__callout {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 18px;
+  margin: 56px 0 8px;
+  border-left: 4px solid var(--mg-gold);
+  border-radius: 0 10px 10px 0;
+  background: #eaf1df;
+  padding: 23px 26px;
+}
+
+.moving-guide__callout-mark {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--mg-green);
+  color: var(--mg-gold);
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.moving-guide__callout p {
+  margin: 0;
+  line-height: 1.72;
+}
+
+.moving-guide__callout strong {
+  color: var(--mg-green);
+}
+
+.moving-guide__feature-image {
+  overflow: hidden;
+  margin: 28px 0 18px;
+  border-radius: 12px;
+}
+
+.moving-guide__feature-image img {
+  display: block;
+  width: 100%;
+  height: clamp(260px, 43vw, 430px);
+  object-fit: cover;
+}
+
+.moving-guide__town-grid,
+.moving-guide__family-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.moving-guide__town-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.moving-guide__town-card,
+.moving-guide__family-card,
+.moving-guide__commute-grid article {
+  border: 1px solid var(--mg-line);
+  border-radius: 8px;
+  background: var(--mg-paper);
+  padding: 22px;
+}
+
+.moving-guide__town-card {
+  border-top: 4px solid var(--mg-green-soft);
+}
+
+.moving-guide__town-card h3,
+.moving-guide__family-card h3,
+.moving-guide__commute-grid h3 {
+  margin: 0 0 10px;
+  color: var(--mg-green);
+  font-size: 20px;
+  line-height: 1.25;
+}
+
+.moving-guide__town-card p,
+.moving-guide__family-card p,
+.moving-guide__commute-grid p {
+  margin: 0;
+  color: #475043;
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.moving-guide__aside-copy {
+  margin: 14px 0 0;
+  color: var(--mg-muted);
+  font-size: 13px;
+}
+
+.moving-guide__mini-cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-top: 25px;
+  border: 1px solid var(--mg-line);
+  border-radius: 8px;
+  background: var(--mg-paper);
+  padding: 20px 22px;
+}
+
+.moving-guide__mini-cta p {
+  max-width: 710px;
+  margin: 0;
+  font-size: 14px;
+}
+
+.moving-guide__mini-cta a,
+.moving-guide__section-heading-row a,
+.moving-guide__lifestyle-link a {
+  color: var(--mg-green);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.moving-guide__mini-cta a {
+  flex: 0 0 auto;
+  border-radius: 3px;
+  background: var(--mg-green);
+  padding: 10px 16px;
+  color: #fff;
+  font-size: 12px;
+}
+
+.moving-guide__family-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 24px;
+}
+
+.moving-guide__family-card {
+  position: relative;
+  padding-top: 52px;
+}
+
+.moving-guide__family-icon {
+  position: absolute;
+  top: 16px;
+  left: 20px;
+  font-size: 22px;
+}
+
+.moving-guide__lifestyle-link {
+  margin: 20px 0 0;
+  font-size: 14px;
+}
+
+.moving-guide__commute-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 24px;
+}
+
+.moving-guide__callout--inside {
+  margin-top: 18px;
+  grid-template-columns: 1fr;
+}
+
+.moving-guide__section-heading-row {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.moving-guide__section-heading-row a {
+  margin-bottom: 23px;
+  font-size: 13px;
+}
+
+.moving-guide__table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--mg-line);
+  border-radius: 8px;
+  background: var(--mg-paper);
+}
+
+.moving-guide__table-wrap table {
+  width: 100%;
+  min-width: 680px;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.moving-guide__table-wrap caption {
+  padding: 14px 16px;
+  color: var(--mg-muted);
+  font-size: 11px;
+  text-align: left;
+}
+
+.moving-guide__table-wrap th,
+.moving-guide__table-wrap td {
+  border-top: 1px solid var(--mg-line);
+  padding: 15px 17px;
+}
+
+.moving-guide__table-wrap thead th {
+  border-top: 0;
+  background: var(--mg-green);
+  color: #fff;
+  font-size: 13px;
+}
+
+.moving-guide__table-wrap tbody th {
+  color: var(--mg-green);
+  font-size: 13px;
+}
+
+.moving-guide__table-wrap td {
+  font-size: 14px;
+}
+
+.moving-guide__review {
+  margin: 72px 0 0;
+  border: 1px solid var(--mg-line);
+  border-radius: 12px;
+  background: var(--mg-paper);
+  padding: 34px 38px;
+  text-align: center;
+}
+
+.moving-guide__stars {
+  color: var(--mg-gold);
+  letter-spacing: 0.16em;
+}
+
+.moving-guide__review blockquote {
+  max-width: 790px;
+  margin: 15px auto 14px;
+  color: var(--mg-green);
+  font-size: clamp(21px, 3vw, 29px);
+  line-height: 1.48;
+}
+
+.moving-guide__review p {
+  margin: 0;
+  color: var(--mg-muted);
+  font-size: 12px;
+}
+
+.moving-guide__cta {
+  margin: 72px 0 12px;
+  border-radius: 14px;
+  background:
+    radial-gradient(circle at 85% 15%, rgba(217, 180, 74, 0.18), transparent 34%),
+    var(--mg-green-deep);
+  padding: 48px;
+  color: #fff;
+}
+
+.moving-guide__cta h2 {
+  color: #fff;
+}
+
+.moving-guide__cta > p:not(.moving-guide__eyebrow):not(.moving-guide__cta-note) {
+  max-width: 720px;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.72;
+}
+
+.moving-guide__button--whatsapp {
+  background: #25d366;
+  color: #0d301a;
+}
+
+.moving-guide__button--outline {
+  border: 1px solid rgba(255, 255, 255, 0.44);
+  color: #fff;
+}
+
+.moving-guide__cta-note {
+  margin: 17px 0 0;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 11px;
+}
+
+.moving-guide__faq-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 26px;
+}
+
+.moving-guide__faq details {
+  overflow: hidden;
+  border: 1px solid var(--mg-line);
+  border-radius: 8px;
+  background: var(--mg-paper);
+}
+
+.moving-guide__faq summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 20px;
+  color: var(--mg-green);
+  font-family: "Playfair Display", Georgia, serif;
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+
+.moving-guide__faq summary::-webkit-details-marker {
+  display: none;
+}
+
+.moving-guide__faq summary::after {
+  content: "+";
+  display: grid;
+  flex: 0 0 auto;
+  width: 27px;
+  height: 27px;
+  place-items: center;
+  border: 1px solid var(--mg-line);
+  border-radius: 50%;
+  color: var(--mg-gold);
+  font-family: Inter, sans-serif;
+}
+
+.moving-guide__faq details[open] summary::after {
+  content: "−";
+  border-color: var(--mg-green);
+  background: var(--mg-green);
+  color: #fff;
+}
+
+.moving-guide__faq details p {
+  margin: 0;
+  border-top: 1px solid var(--mg-line);
+  padding: 17px 20px 20px;
+  color: var(--mg-muted);
+  font-size: 14px;
+  line-height: 1.75;
+}
+
+.compliance {
+  border-top: 1px solid #dfddd4;
+  background: #f0ede8;
+  padding: 24px;
+  color: #77776f;
+  font-size: 11px;
+  line-height: 1.8;
+}
+
+.compliance strong {
+  color: #3d3d38;
+}
+
+.compliance a {
+  color: #23470a;
+}
+
+.compliance-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+@media (max-width: 900px) {
+  .moving-guide__stats,
+  .moving-guide__family-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .moving-guide__town-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .moving-guide__container {
+    width: min(100% - 32px, 1080px);
+  }
+
+  .moving-guide__hero,
+  .moving-guide__hero-content {
+    min-height: 620px;
+  }
+
+  .moving-guide__breadcrumbs {
+    margin-bottom: 34px;
+  }
+
+  .moving-guide__hero h1 {
+    font-size: clamp(36px, 10vw, 48px);
+  }
+
+  .moving-guide__stats,
+  .moving-guide__family-grid,
+  .moving-guide__commute-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .moving-guide__stat {
+    min-height: auto;
+  }
+
+  .moving-guide__budget-card {
+    grid-template-columns: 1fr;
+  }
+
+  .moving-guide__budget-card img {
+    display: none;
+  }
+
+  .moving-guide__callout {
+    grid-template-columns: 1fr;
+  }
+
+  .moving-guide__mini-cta,
+  .moving-guide__section-heading-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .moving-guide__section-heading-row a {
+    margin: -6px 0 4px;
+  }
+
+  .moving-guide__review {
+    padding: 28px 22px;
+  }
+
+  .moving-guide__cta {
+    padding: 38px 24px;
+  }
+
+}

--- a/src/components/movingFromToronto/MovingFromTorontoPage.js
+++ b/src/components/movingFromToronto/MovingFromTorontoPage.js
@@ -1,0 +1,403 @@
+import React, { useMemo } from "react";
+import { Helmet } from "react-helmet-async";
+import HeaderShell from "../HeaderShell";
+import CommunityComplianceFooter from "../CommunityComplianceFooter";
+import MARKET_DATA from "../../data/marketData.json";
+import "./MovingFromTorontoPage.css";
+
+const { getMarketTrend } = require("../../utils/marketTrend");
+
+const QUIZ_URL = "/buyers#town-match";
+const WHATSAPP_URL = "https://wa.me/16476684646";
+
+function marketValue(value) {
+  if (typeof value === "number") {
+    return new Intl.NumberFormat("en-CA", {
+      style: "currency",
+      currency: "CAD",
+      maximumFractionDigits: 0,
+    }).format(value);
+  }
+  return value;
+}
+
+function MarketStat({ label, value, marketKey, className = "" }) {
+  return (
+    <article className={`moving-guide__stat ${className}`.trim()}>
+      <strong data-market={marketKey}>{value}</strong>
+      <span>{label}</span>
+    </article>
+  );
+}
+
+function BudgetBuyCard({ content }) {
+  return (
+    <aside className="moving-guide__budget-card" aria-labelledby="moving-guide-budget-heading">
+      <div>
+        <p className="moving-guide__eyebrow">The $800K comparison</p>
+        <h3 id="moving-guide-budget-heading">{content.heading}</h3>
+        <p>{content.body}</p>
+      </div>
+      <img
+        src="/assets/town-logos/georgina.webp"
+        alt=""
+        aria-hidden="true"
+        width="108"
+        height="108"
+        loading="lazy"
+      />
+    </aside>
+  );
+}
+
+export default function MovingFromTorontoPage({ content, buildSchema }) {
+  const schema = useMemo(() => buildSchema(content), [buildSchema, content]);
+  const canonical = `https://northsidegta.ca${content.route}`;
+  const markets = MARKET_DATA.municipalities;
+  const georgina = markets.georgina;
+  const comparisonTowns = ["georgina", "newmarket", "aurora"];
+  const toronto = MARKET_DATA.toronto || {};
+  const showTorontoComparison =
+    toronto.condoAverage != null && toronto.detachedAverage != null;
+  const georginaTrend = getMarketTrend(georgina.yearOverYear);
+
+  return (
+    <>
+      <Helmet>
+        <title>{content.title}</title>
+        <meta name="description" content={content.description} />
+        <meta name="author" content="Matthew Mulhall" />
+        <meta name="publisher" content="Finally Home Agents" />
+        <link rel="canonical" href={canonical} />
+        <meta property="og:title" content={content.title} />
+        <meta property="og:description" content={content.description} />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={canonical} />
+        <meta property="og:image" content={`https://northsidegta.ca${content.heroImage}`} />
+        <meta property="og:image:alt" content={content.heroImageAlt} />
+        <meta property="og:locale" content="en_CA" />
+        <meta property="og:site_name" content="NorthSide GTA" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={content.title} />
+        <meta name="twitter:description" content={content.description} />
+        <meta name="twitter:image" content={`https://northsidegta.ca${content.heroImage}`} />
+        <script type="application/ld+json">{JSON.stringify(schema)}</script>
+      </Helmet>
+
+      <HeaderShell />
+
+      <main className="moving-guide">
+        <header className="moving-guide__hero">
+          <img
+            className="moving-guide__hero-image"
+            src={content.heroImage}
+            alt={content.heroImageAlt}
+            loading="eager"
+          />
+          <div className="moving-guide__hero-shade" aria-hidden="true" />
+          <div className="moving-guide__container moving-guide__hero-content">
+            <nav className="moving-guide__breadcrumbs" aria-label="Breadcrumb">
+              <a href="/">Home</a>
+              <span aria-hidden="true">›</span>
+              <a href="/buyers">Moving North</a>
+              <span aria-hidden="true">›</span>
+              <span>{content.town}</span>
+            </nav>
+            <div className="moving-guide__hero-badge">
+              <img
+                src={content.badgeImage}
+                alt={content.badgeImageAlt}
+                width="58"
+                height="58"
+              />
+              <p>{content.kicker}</p>
+            </div>
+            <h1>{content.heading}</h1>
+            <p className="moving-guide__hero-intro">{content.intro}</p>
+            <p className="moving-guide__byline">
+              By Matthew Mulhall, Finally Home Agents · Updated{" "}
+              <span data-market="lastUpdated">{MARKET_DATA.period}</span>
+            </p>
+            <div className="moving-guide__hero-actions">
+              <a className="moving-guide__button moving-guide__button--gold" href={QUIZ_URL}>
+                Take the Town Match Quiz
+              </a>
+              <a className="moving-guide__button moving-guide__button--light" href="/communities/georgina">
+                Full Georgina community profile
+              </a>
+            </div>
+            <p className="moving-guide__source moving-guide__source--hero">
+              Source: {MARKET_DATA.source} · {MARKET_DATA.homeType}
+            </p>
+          </div>
+        </header>
+
+        <div className="moving-guide__container moving-guide__body">
+          <section className="moving-guide__section" aria-labelledby="moving-guide-money-heading">
+            <p className="moving-guide__eyebrow">Toronto budget, Georgina space</p>
+            <h2 id="moving-guide-money-heading">What your Toronto money buys in Georgina</h2>
+            <div className="moving-guide__stats" aria-label={`${MARKET_DATA.period} Georgina market snapshot`}>
+              <MarketStat
+                label="Average sale price"
+                value={georgina.averageSalePrice}
+                marketKey="georgina.averageSold"
+              />
+              <MarketStat
+                label="Sales count"
+                value={georgina.salesCount}
+                marketKey="georgina.salesCount"
+              />
+              <MarketStat
+                label="Avg. LDOM"
+                value={`${georgina.avgLdom} days`}
+                marketKey="georgina.daysOnMarket"
+              />
+              <MarketStat
+                label="Year over year"
+                value={georginaTrend.label}
+                marketKey="georgina.yearOverYear"
+                className={`moving-guide__stat--${georginaTrend.direction}`}
+              />
+            </div>
+            <p className="moving-guide__source">
+              {MARKET_DATA.period} · Source: {MARKET_DATA.source} · {MARKET_DATA.homeType}
+            </p>
+            {showTorontoComparison ? (
+              <p data-market="toronto.comparison">
+                The average Toronto condo now sells for {marketValue(toronto.condoAverage)}, and a
+                detached averages {marketValue(toronto.detachedAverage)} (TRREB).
+              </p>
+            ) : null}
+            <p>
+              In practical terms, the price of a modest Toronto condo puts a detached house with a
+              yard within reach in Keswick — and waterfront-area living within reach for less than
+              a Toronto semi.
+            </p>
+            <BudgetBuyCard content={content.budgetCard} />
+          </section>
+
+          <aside className="moving-guide__callout" aria-label="Toronto land transfer tax comparison">
+            <div className="moving-guide__callout-mark" aria-hidden="true">$</div>
+            <p>
+              <strong>The number Toronto buyers forget:</strong> leaving Toronto means no municipal
+              land transfer tax. On a $770,000 purchase, that's roughly{" "}
+              <strong>$11,500 staying in your pocket</strong> — Toronto is the only municipality in
+              Ontario that charges a second land transfer tax on top of the provincial one.
+            </p>
+          </aside>
+
+          <section className="moving-guide__section" aria-labelledby="moving-guide-communities-heading">
+            <p className="moving-guide__eyebrow">Choose your corner of the lake</p>
+            <h2 id="moving-guide-communities-heading">Keswick, Sutton, or Jackson's Point?</h2>
+            <p>Georgina isn't one place — choosing your corner of it is the real decision.</p>
+            <figure className="moving-guide__feature-image">
+              <img
+                src={content.communityImage}
+                alt={content.communityImageAlt}
+                loading="lazy"
+              />
+            </figure>
+            <div className="moving-guide__town-grid">
+              {content.communities.map(({ heading, body }) => (
+                <article className="moving-guide__town-card" key={heading}>
+                  <h3>{heading}</h3>
+                  <p>{body}</p>
+                </article>
+              ))}
+            </div>
+            <p className="moving-guide__aside-copy">
+              Also worth knowing: Pefferlaw and Udora for rural properties and acreage.
+            </p>
+            <div className="moving-guide__mini-cta">
+              <p>
+                <strong>Not sure which corner fits you?</strong> Tell us your budget and lifestyle
+                — we'll tell you where to look (and where not to).
+              </p>
+              <a href={WHATSAPP_URL} target="_blank" rel="noopener noreferrer">
+                Ask us on WhatsApp →
+              </a>
+            </div>
+          </section>
+
+          <section className="moving-guide__section" aria-labelledby="moving-guide-family-heading">
+            <p className="moving-guide__eyebrow">Life beyond the listing</p>
+            <h2 id="moving-guide-family-heading">Raising kids in Georgina</h2>
+            <p>This is the question behind most moves north, so here's the real picture.</p>
+            <div className="moving-guide__family-grid">
+              {content.familyCards.map(({ icon, heading, body }) => (
+                <article className="moving-guide__family-card" key={heading}>
+                  <span className="moving-guide__family-icon" aria-hidden="true">{icon}</span>
+                  <h3>{heading}</h3>
+                  <p>{body}</p>
+                </article>
+              ))}
+            </div>
+            <p className="moving-guide__lifestyle-link">
+              Looking for the places locals actually eat?{" "}
+              <a href="/tastehub?town=georgina">Explore Georgina on TasteHub →</a>
+            </p>
+          </section>
+
+          <section className="moving-guide__section moving-guide__commute" aria-labelledby="moving-guide-commute-heading">
+            <p className="moving-guide__eyebrow">The trade-off to pressure-test</p>
+            <h2 id="moving-guide-commute-heading">The honest commute</h2>
+            <p>We won't sugar-coat this — Georgina is a commitment if you work downtown daily.</p>
+            <div className="moving-guide__commute-grid">
+              <article>
+                <h3>Driving</h3>
+                <p>
+                  Highway 404 now reaches the edge of Keswick, making it highway nearly
+                  door-to-door. Plan on roughly an hour to north Toronto in normal traffic, more
+                  to the downtown core at peak.
+                </p>
+              </article>
+              <article>
+                <h3>GO Transit</h3>
+                <p>
+                  No train station in Georgina itself. The GO 67 Keswick–North York bus runs down
+                  the 404 corridor, and the nearest train stations are East Gwillimbury GO and
+                  Newmarket GO — about 20–25 minutes' drive from Keswick, with all-day service to
+                  Union.
+                </p>
+              </article>
+            </div>
+            <div className="moving-guide__callout moving-guide__callout--inside">
+              <p>
+                <strong>The honest read:</strong> Georgina works best for hybrid workers, people
+                working anywhere in York Region or north Toronto, and anyone whose office days are
+                2–3 per week. Downtown five days a week? Let's talk honestly about whether East
+                Gwillimbury or Newmarket fits better — that conversation is literally what we do.
+              </p>
+            </div>
+          </section>
+
+          <section className="moving-guide__section" aria-labelledby="moving-guide-market-heading">
+            <p className="moving-guide__eyebrow">Three-town comparison</p>
+            <div className="moving-guide__section-heading-row">
+              <h2 id="moving-guide-market-heading">Georgina market snapshot</h2>
+              <a href="/neighbourhood-guide">Compare all seven towns →</a>
+            </div>
+            <div className="moving-guide__table-wrap">
+              <table>
+                <caption>
+                  {MARKET_DATA.period} {MARKET_DATA.homeType} market snapshot
+                </caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Metric</th>
+                    {comparisonTowns.map((slug) => (
+                      <th scope="col" key={slug}>{markets[slug].name}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Average sale price</th>
+                    {comparisonTowns.map((slug) => (
+                      <td data-market={`${slug}.averageSold`} key={slug}>
+                        {markets[slug].averageSalePrice}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr>
+                    <th scope="row">Sales count</th>
+                    {comparisonTowns.map((slug) => (
+                      <td data-market={`${slug}.salesCount`} key={slug}>
+                        {markets[slug].salesCount}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr>
+                    <th scope="row">Avg. LDOM</th>
+                    {comparisonTowns.map((slug) => (
+                      <td data-market={`${slug}.daysOnMarket`} key={slug}>
+                        {markets[slug].avgLdom}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr>
+                    <th scope="row">Change YoY</th>
+                    {comparisonTowns.map((slug) => {
+                      const trend = getMarketTrend(markets[slug].yearOverYear);
+                      return (
+                        <td
+                          className={`moving-guide__trend moving-guide__trend--${trend.direction}`}
+                          data-market={`${slug}.yearOverYear`}
+                          key={slug}
+                        >
+                          {trend.label}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="moving-guide__source">
+              <span data-market="lastUpdated">{MARKET_DATA.period}</span> · Source:{" "}
+              {MARKET_DATA.source} · {MARKET_DATA.homeType}
+            </p>
+            <p>
+              Georgina is the lowest-priced town in the NorthSide GTA — the affordability gap
+              versus Newmarket and Aurora is why so many Toronto movers start their search here.
+            </p>
+          </section>
+
+          <aside className="moving-guide__review" aria-label="Client review">
+            <div className="moving-guide__stars" aria-label="5 out of 5 stars">★★★★★</div>
+            <blockquote>
+              “What really stood out was that Matt understood our priorities as a family and
+              ensured that these priorities were held in high regard throughout the whole process.”
+            </blockquote>
+            <p>Larissa Halko · Buyer &amp; Seller · Google Reviews (5.0 rating)</p>
+          </aside>
+
+          <section className="moving-guide__cta" aria-labelledby="moving-guide-cta-heading">
+            <p className="moving-guide__eyebrow">Two minutes, no pressure</p>
+            <h2 id="moving-guide-cta-heading">Is Georgina right for you?</h2>
+            <p>
+              Not sure whether Georgina, East Gwillimbury, or somewhere else north fits your family
+              best? That's exactly what our Town Match Quiz figures out — two minutes, no contact
+              info required to see your result.
+            </p>
+            <div className="moving-guide__cta-actions">
+              <a className="moving-guide__button moving-guide__button--gold" href={QUIZ_URL}>
+                Take the Town Match Quiz →
+              </a>
+              <a
+                className="moving-guide__button moving-guide__button--whatsapp"
+                href={WHATSAPP_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                WhatsApp Matthew &amp; Landon
+              </a>
+              <a className="moving-guide__button moving-guide__button--outline" href="/contact">
+                Contact Finally Home Agents
+              </a>
+            </div>
+            <p className="moving-guide__cta-note">
+              No spam. No pressure. Regulated by RECO · HomeLife Optimum Realty, Brokerage.
+            </p>
+          </section>
+
+          <section className="moving-guide__section moving-guide__faq" aria-labelledby="moving-guide-faq-heading">
+            <p className="moving-guide__eyebrow">Straight answers</p>
+            <h2 id="moving-guide-faq-heading">Frequently asked questions</h2>
+            <div className="moving-guide__faq-list">
+              {content.faqs.map(({ question, answer }, index) => (
+                <details key={question} open={index === 0 ? true : undefined}>
+                  <summary>{question}</summary>
+                  <p>{answer}</p>
+                </details>
+              ))}
+            </div>
+          </section>
+        </div>
+
+      </main>
+
+      <CommunityComplianceFooter />
+    </>
+  );
+}

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -1,7 +1,9 @@
 import { BUYERS_SCHEMA } from "./buyersSchema.mjs";
 import sellersSchemaModule from "../../lib/structuredData/sellersPage.js";
+import movingGuideContentModule from "../../content/movingFromToronto/georgina.js";
 
 const { buildSellersPageSchema, SELLERS_PAGE_TITLE, SELLERS_PAGE_DESCRIPTION } = sellersSchemaModule;
+const { georginaMovingGuide, buildMovingGuideSchema } = movingGuideContentModule;
 
 const DEFAULT_GLOBAL_META_CONFIG = {
   route: "/",
@@ -568,6 +570,18 @@ const TOWN_REMEDIATION = [
 const SEO_REMEDIATION_ROUTE_META_CONFIGS = [
   { route: "/", meta: routeMeta({ route: "/", title: "NorthSide GTA Real Estate | Finally Home Agents", description: "Buy or sell north of Toronto with Finally Home Agents. Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.", image: HOME_IMAGE, pageType: "WebSite" }) },
   { route: "/buyers", meta: routeMeta({ route: "/buyers", title: "Buying a Home North of Toronto | Finally Home Agents", description: "Buying north of Toronto? Compare Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog with local buyer guidance.", image: `${SITE_URL}/uploads/buyers-page-seo.jpg`, schema: BUYERS_SCHEMA }) },
+  {
+    route: georginaMovingGuide.route,
+    meta: routeMeta({
+      route: georginaMovingGuide.route,
+      title: georginaMovingGuide.title,
+      description: georginaMovingGuide.description,
+      image: `${SITE_URL}${georginaMovingGuide.heroImage}`,
+      imageAlt: georginaMovingGuide.heroImageAlt,
+      pageType: "Article",
+      schema: buildMovingGuideSchema(georginaMovingGuide),
+    }),
+  },
   { route: "/sellers", meta: routeMeta({ route: "/sellers", title: SELLERS_PAGE_TITLE, description: SELLERS_PAGE_DESCRIPTION, image: SELLERS_IMAGE, imageAlt: SELLERS_IMAGE_ALT, schema: buildSellersPageSchema(), serviceType: "Seller representation" }) },
   { route: "/communities", meta: routeMeta({ route: "/communities", title: "NorthSide GTA Communities | Compare Towns North of Toronto", description: "Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog with Finally Home Agents.", image: COMMUNITY_IMAGE, pageType: "CollectionPage", collectionItems: COMMUNITY_ITEMS }) },
   { route: "/contact", meta: routeMeta({ route: "/contact", title: "Contact Finally Home Agents | NorthSide GTA Real Estate", description: "Contact Matthew and Landon Mulhall for buying, selling, and local real estate guidance across Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.", image: `${SITE_URL}/uploads/og-contact-northsidegta.jpg`, pageType: "ContactPage" }) },

--- a/src/content/movingFromToronto/georgina.js
+++ b/src/content/movingFromToronto/georgina.js
@@ -1,0 +1,197 @@
+const SITE_URL = "https://northsidegta.ca";
+
+const georginaMovingGuide = {
+  town: "Georgina",
+  slug: "georgina",
+  route: "/moving-to-georgina-from-toronto",
+  title: "Moving to Georgina from Toronto (2026 Guide) | Finally Home Agents",
+  description:
+    "Thinking of moving to Georgina from Toronto? Keswick, Sutton & Jackson's Point compared — real prices, the honest commute, and what your Toronto money buys on Lake Simcoe.",
+  heroImage: "/Images/georgina-banner.jpg",
+  heroImageAlt: "Lake Simcoe shoreline at Jackson's Point, Georgina",
+  badgeImage: "/assets/town-logos/georgina.webp",
+  badgeImageAlt: "Georgina NorthSide GTA town badge",
+  communityImage: "/uploads/insights/georgina-keswick-lakefront-aerial-2026.jpg",
+  communityImageAlt: "Aerial view of Keswick homes along the Lake Simcoe shoreline in Georgina",
+  kicker: "Relocation Guide · Georgina",
+  heading: "Moving to Georgina from Toronto: The Honest 2026 Guide",
+  intro:
+    "Sell a Toronto condo, buy a detached house on the Lake Simcoe side of the GTA — that's the trade more Toronto families are making every year. Here's what that move actually looks like: the good, the trade-offs, and the numbers.",
+  budgetCard: {
+    heading: "What does $800K buy in Georgina?",
+    body:
+      "A detached 3–4 bed family home in Keswick with a garage and real backyard — or a renovated bungalow near the lake in Sutton or Jackson's Point. In Toronto, $800K is a two-bed condo with maintenance fees.",
+  },
+  communities: [
+    {
+      heading: "Keswick — the practical choice",
+      body:
+        "The largest community, closest to Highway 404, with the most amenities, newer subdivisions, and the widest selection of family homes. Home to the MURC and the ROC. If you're commuting or want the easiest transition from city life, start here.",
+    },
+    {
+      heading: "Sutton — small-town Ontario",
+      body:
+        "A historic main street, slower pace, and quick access to Sibbald Point Provincial Park. More house and lot for your money than Keswick, a few minutes further from the highway.",
+    },
+    {
+      heading: "Jackson's Point — the lake life",
+      body:
+        "Steps to Lake Simcoe, marinas, beaches, and cottage-country character in a year-round community. Waterfront living here is still attainable in a way that stopped being true in most of Ontario years ago.",
+    },
+  ],
+  familyCards: [
+    {
+      icon: "🏊",
+      heading: "The MURC (opened 2024)",
+      body:
+        "Keswick's new Multi-Use Recreation Complex: six-lane 25-metre pool, leisure and therapy pools, swim lessons, drop-in programs, and fitness classes — the kind of facility Toronto families assume they're giving up by leaving.",
+    },
+    {
+      icon: "⚽",
+      heading: "The ROC",
+      body:
+        "A year-round outdoor campus: 10 sports fields for soccer, lacrosse and field hockey, six free pickleball courts, plus winter tubing and skiing on the hill. Town-run camps and child/youth programs cover preschool through age 14.",
+    },
+    {
+      icon: "🏫",
+      heading: "Schools",
+      body:
+        "York Region public and Catholic boards. Keswick High School, Sutton District High, and elementary options in every community — school catchment is one of the first things we map for families.",
+    },
+    {
+      icon: "🏒",
+      heading: "Small-town sports culture",
+      body:
+        "Minor hockey, soccer leagues, and lake life: swimming and beach days all summer, ice fishing and tubing in winter. Kids here grow up outside.",
+    },
+    {
+      icon: "🏥",
+      heading: "Healthcare",
+      body:
+        "Southlake Regional Health Centre in Newmarket is about 20–25 minutes away; family clinics and pharmacies operate in Keswick and Sutton.",
+    },
+    {
+      icon: "🛒",
+      heading: "The honest trade-off",
+      body:
+        "Fewer restaurants and big-box stores than Newmarket or Aurora — you'll drive 20 minutes for some errands. Most families call it a fair trade for the mortgage payment and the lake.",
+    },
+  ],
+  faqs: [
+    {
+      question: "Is Georgina a good place to live?",
+      answer:
+        "Georgina offers the most affordable homeownership in the GTA's northern communities, with Lake Simcoe beaches, ice fishing, trails, and new recreation facilities like the MURC. It suits families wanting space and lake access, and hybrid workers who don't commute downtown daily.",
+    },
+    {
+      question: "Is Georgina a good place to raise kids?",
+      answer:
+        "Yes, for families who value outdoor life and space. The MURC (opened 2024) offers swim lessons and youth programs, the ROC has 10 sports fields plus winter tubing, town-run camps cover preschool to age 14, and schools fall under York Region's public and Catholic boards. The trade-off is fewer urban amenities than Newmarket or Aurora.",
+    },
+    {
+      question: "How far is Georgina from Toronto?",
+      answer:
+        "About 60–80 km depending on your end of town. Driving takes roughly an hour via Highway 404. The GO 67 bus serves the corridor, and East Gwillimbury GO station is about 20–25 minutes away by car.",
+    },
+    {
+      question: "Is Georgina cheaper than Toronto?",
+      answer:
+        "Significantly. Detached-house money in Georgina is condo money in Toronto, and buyers leaving Toronto also avoid Toronto's municipal land transfer tax — roughly $11,000+ saved on a typical purchase.",
+    },
+    {
+      question: "What's the difference between Keswick, Sutton, and Jackson's Point?",
+      answer:
+        "Keswick is the largest and most convenient, with the MURC and ROC. Sutton offers small-town character and more property for the money. Jackson's Point is the lakeside community with beaches and marinas. Pefferlaw and Udora offer rural properties.",
+    },
+    {
+      question: "Does Georgina have a GO train station?",
+      answer:
+        "No. The nearest GO train stations are East Gwillimbury GO and Newmarket GO on the Barrie line, about 20–25 minutes' drive from Keswick. GO's route 67 bus connects the Keswick area toward North York via Highway 404.",
+    },
+    {
+      question: "Who can help me buy a home in Georgina?",
+      answer:
+        "Finally Home Agents (Matthew and Landon Mulhall, HomeLife Optimum Realty, Brokerage) live and work in the NorthSide GTA and guide Toronto buyers through Georgina town-by-town — starting with whether it's the right town for you at all.",
+    },
+  ],
+};
+
+function buildMovingGuideSchema(content = georginaMovingGuide) {
+  const url = `${SITE_URL}${content.route}`;
+  const publisher = {
+    "@type": "Organization",
+    name: "Finally Home Agents",
+    alternateName: "NorthSide GTA",
+    url: SITE_URL,
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Article",
+        "@id": `${url}#article`,
+        headline: content.heading,
+        description: content.description,
+        url,
+        mainEntityOfPage: { "@type": "WebPage", "@id": url },
+        image: `${SITE_URL}${content.heroImage}`,
+        datePublished: "2026-07-29",
+        dateModified: "2026-07-29",
+        author: {
+          "@type": "Person",
+          name: "Matthew Mulhall",
+          jobTitle: "Sales Representative",
+          worksFor: publisher,
+        },
+        publisher,
+        about: {
+          "@type": "Place",
+          name: `${content.town}, Ontario`,
+        },
+      },
+      {
+        "@type": "FAQPage",
+        "@id": `${url}#faq`,
+        mainEntity: content.faqs.map(({ question, answer }) => ({
+          "@type": "Question",
+          name: question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: answer,
+          },
+        })),
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": `${url}#breadcrumb`,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Home",
+            item: `${SITE_URL}/`,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Moving North",
+            item: `${SITE_URL}/buyers`,
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: content.town,
+            item: url,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+module.exports = {
+  SITE_URL,
+  georginaMovingGuide,
+  buildMovingGuideSchema,
+};

--- a/src/data/marketData.json
+++ b/src/data/marketData.json
@@ -2,18 +2,24 @@
   "period": "June 2026",
   "source": "TRREB Market Watch, June 2026",
   "homeType": "All Home Types",
+  "toronto": {
+    "condoAverage": null,
+    "detachedAverage": null
+  },
   "municipalities": {
     "aurora": {
       "name": "Aurora",
       "averageSalePrice": "$1,239,892",
       "salesCount": 76,
-      "avgLdom": 46
+      "avgLdom": 46,
+      "yearOverYear": "-6.7%"
     },
     "newmarket": {
       "name": "Newmarket",
       "averageSalePrice": "$1,018,511",
       "salesCount": 88,
-      "avgLdom": 38
+      "avgLdom": 38,
+      "yearOverYear": "-4.1%"
     },
     "stouffville": {
       "name": "Whitchurch-Stouffville",
@@ -31,7 +37,8 @@
       "name": "Georgina",
       "averageSalePrice": "$794,410",
       "salesCount": 85,
-      "avgLdom": 52
+      "avgLdom": 52,
+      "yearOverYear": "-7.2%"
     },
     "uxbridge": {
       "name": "Uxbridge",

--- a/vercel.json
+++ b/vercel.json
@@ -59,6 +59,7 @@
   "rewrites": [
     { "source": "/about", "destination": "/about/index.html" },
     { "source": "/buyers", "destination": "/buyers/index.html" },
+    { "source": "/moving-to-georgina-from-toronto", "destination": "/moving-to-georgina-from-toronto/index.html" },
     { "source": "/sellers", "destination": "/sellers/index.html" },
     { "source": "/homeanalysis", "destination": "/homeanalysis/index.html" },
     { "source": "/contact", "destination": "/contact/index.html" },


### PR DESCRIPTION
## What changed
- Adds the prerendered `/moving-to-georgina-from-toronto` landing page using the site’s existing header, typography, buttons, assets, and Georgina compliance footer.
- Introduces a reusable Toronto-to-town page template plus a Georgina content file, with the mock’s section order and seven FAQs.
- Reads June 2026 Georgina/Newmarket/Aurora figures from `marketData.json`, including sign-aware YoY display, and adds null Toronto condo/detached placeholders that hide the comparison until populated.
- Adds Article, FAQPage, and BreadcrumbList JSON-LD, static metadata, sitemap entry, Vercel rewrite, and prerender coverage.
- Adds internal links from the Georgina community page, buyers page, and neighbourhood guide, plus outbound links to the community profile, TasteHub, town comparison, quiz, contact, and WhatsApp.
- Uses a prominent end CTA instead of a sticky mobile bar because the site already has a floating chat control.

## Why
Gives Toronto families a focused, crawlable Georgina relocation guide while keeping market figures centralized and creating a reusable pattern for the remaining six town guides.

## Impact
The clean URL serves full prerendered HTML with unique SEO metadata and structured data. Toronto comparison copy remains hidden until Matthew fills the two placeholder values.

## Validation
- `npm run build` ✅
- 32 prerendered route checks and 13 insight checks ✅
- All SEO, sitemap, cache, AI-search, and image audits ✅
- Desktop and 390px mobile browser checks: no overflow, broken images, or console errors ✅
- `git diff --check` ✅

The unrelated untracked duplicate insight JSON files were not included.