### PR TITLE
Add East Gwillimbury and Uxbridge Toronto relocation guides

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -17,6 +17,16 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://northsidegta.ca/moving-to-east-gwillimbury-from-toronto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://northsidegta.ca/moving-to-uxbridge-from-toronto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://northsidegta.ca/sellers</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -96,6 +96,8 @@ function main() {
     { path: '/', changefreq: 'weekly', priority: '1.0' },
     { path: '/buyers', changefreq: 'weekly', priority: '0.9' },
     { path: '/moving-to-georgina-from-toronto', changefreq: 'monthly', priority: '0.8' },
+    { path: '/moving-to-east-gwillimbury-from-toronto', changefreq: 'monthly', priority: '0.8' },
+    { path: '/moving-to-uxbridge-from-toronto', changefreq: 'monthly', priority: '0.8' },
     { path: '/sellers', changefreq: 'weekly', priority: '0.9' },
     { path: '/homeanalysis', changefreq: 'monthly', priority: '0.7' },
     { path: '/communities', changefreq: 'monthly', priority: '0.8' },

--- a/scripts/prerender-routes.js
+++ b/scripts/prerender-routes.js
@@ -26,6 +26,8 @@ const routeModules = {
   "/about": "../src/AboutPage",
   "/buyers": "../src/BuyersPage",
   "/moving-to-georgina-from-toronto": "../src/MovingToGeorginaFromTorontoPage",
+  "/moving-to-east-gwillimbury-from-toronto": "../src/MovingToEastGwillimburyFromTorontoPage",
+  "/moving-to-uxbridge-from-toronto": "../src/MovingToUxbridgeFromTorontoPage",
   "/sellers": "../src/SellersPage",
   "/homeanalysis": "../src/HomeAnalysisPage",
   "/media": "../src/MediaPage",

--- a/scripts/verify-prerendered-seo.js
+++ b/scripts/verify-prerendered-seo.js
@@ -10,6 +10,32 @@ const buildDir = path.join(rootDir, "build");
 const insightDataDir = path.join(rootDir, "public", "data", "insights");
 const origin = "https://northsidegta.ca";
 const marketData = require(path.join(rootDir, "src", "data", "marketData.json"));
+const { georginaMovingGuide } = require(path.join(
+  rootDir,
+  "src",
+  "content",
+  "movingFromToronto",
+  "georgina.js",
+));
+const { eastGwillimburyMovingGuide } = require(path.join(
+  rootDir,
+  "src",
+  "content",
+  "movingFromToronto",
+  "eastGwillimbury.js",
+));
+const { uxbridgeMovingGuide } = require(path.join(
+  rootDir,
+  "src",
+  "content",
+  "movingFromToronto",
+  "uxbridge.js",
+));
+const movingGuides = [
+  georginaMovingGuide,
+  eastGwillimburyMovingGuide,
+  uxbridgeMovingGuide,
+];
 const retiredInsightSlugs = [
   "lando-test-2",
   "lando-test",
@@ -35,13 +61,13 @@ const townNames = {
 const staticChecks = [
   { route: "/about", h1: "About Finally Home Agents", body: "Matthew and Landon" },
   { route: "/buyers", h1: "You don't have to leave the city", body: "Town strategy" },
-  {
-    route: "/moving-to-georgina-from-toronto",
-    h1: "Moving to Georgina from Toronto: The Honest 2026 Guide",
-    body: "What your Toronto money buys in Georgina",
-    title: "Moving to Georgina from Toronto (2026 Guide) | Finally Home Agents",
+  ...movingGuides.map((guide) => ({
+    route: guide.route,
+    h1: guide.heading,
+    body: guide.money.heading,
+    title: guide.title,
     schema: ["Article", "FAQPage", "BreadcrumbList"],
-  },
+  })),
   { route: "/sellers", h1: "A Better Sale Starts Before the Listing Goes Live", body: "seller" },
   { route: "/homeanalysis", h1: "What’s Your Home Worth", body: "NorthSide GTA Market" },
   { route: "/contact", h1: "Glad you found us", body: "Matthew" },
@@ -348,44 +374,92 @@ Object.entries(marketData.municipalities).forEach(([slug, town]) => {
   });
 });
 
-const movingGuideRoute = "/moving-to-georgina-from-toronto";
-const movingGuideDoc = readRoute(movingGuideRoute);
-const movingGuideText = movingGuideDoc?.querySelector("body")?.text.replace(/\s+/g, " ").trim() || "";
-const movingGuideHtml = movingGuideDoc?.toString() || "";
-[
-  marketData.period,
-  `Source: ${marketData.source}`,
-  marketData.homeType,
-  ...["georgina", "newmarket", "aurora"].flatMap((slug) => {
-    const town = marketData.municipalities[slug];
-    return [
-      town.averageSalePrice,
-      String(town.salesCount),
-      String(town.avgLdom),
-      town.yearOverYear,
-    ];
-  }),
-].forEach((value) => {
-  if (!movingGuideText.includes(value)) {
-    failures.push(`${movingGuideRoute}: moving guide is missing shared market value "${value}"`);
+movingGuides.forEach((guide) => {
+  const movingGuideDoc = readRoute(guide.route);
+  const movingGuideText =
+    movingGuideDoc?.querySelector("body")?.text.replace(/\s+/g, " ").trim() || "";
+  const movingGuideHtml = movingGuideDoc?.toString() || "";
+  [
+    marketData.period,
+    `Source: ${marketData.source}`,
+    marketData.homeType,
+    ...guide.comparisonTowns.flatMap((slug) => {
+      const town = marketData.municipalities[slug];
+      return [
+        town.averageSalePrice,
+        String(town.salesCount),
+        String(town.avgLdom),
+        town.yearOverYear,
+      ];
+    }),
+  ].forEach((value) => {
+    if (!movingGuideText.includes(value)) {
+      failures.push(`${guide.route}: moving guide is missing shared market value "${value}"`);
+    }
+  });
+
+  [
+    `href="${guide.communityProfilePath}"`,
+    `href="${guide.tasteHubPath}"`,
+    'href="/neighbourhood-guide"',
+    'href="/buyers#town-match"',
+    'href="/contact"',
+    'href="https://wa.me/16476684646"',
+  ].forEach((value) => {
+    if (!movingGuideHtml.includes(value)) {
+      failures.push(`${guide.route}: missing outbound link ${value}`);
+    }
+  });
+
+  const faqSchema = schemaNodes(movingGuideDoc, guide.route).find((node) =>
+    nodeHasType(node, "FAQPage"),
+  );
+  if (faqSchema?.mainEntity?.length !== 7) {
+    failures.push(`${guide.route}: expected 7 FAQPage questions`);
+  }
+
+  if (
+    marketData.toronto?.condoAverage == null &&
+    /The average Toronto condo now sells for/.test(movingGuideText)
+  ) {
+    failures.push(
+      `${guide.route}: Toronto comparison must be hidden while placeholder values are null`,
+    );
+  }
+});
+
+const buyersHtml = readRoute("/buyers")?.toString() || "";
+movingGuides.forEach((guide) => {
+  if (!buyersHtml.includes(`href="${guide.route}"`)) {
+    failures.push(`/buyers: missing moving-guide link to ${guide.route}`);
   }
 });
 
 [
-  'href="/communities/georgina"',
-  'href="/tastehub?town=georgina"',
-  'href="/neighbourhood-guide"',
-  'href="/buyers#town-match"',
-  'href="/contact"',
-  'href="https://wa.me/16476684646"',
-].forEach((value) => {
-  if (!movingGuideHtml.includes(value)) {
-    failures.push(`${movingGuideRoute}: missing outbound link ${value}`);
+  eastGwillimburyMovingGuide,
+  uxbridgeMovingGuide,
+].forEach((guide) => {
+  const communityHtml = readRoute(guide.communityProfilePath)?.toString() || "";
+  if (!communityHtml.includes(`href="${guide.route}"`)) {
+    failures.push(`${guide.communityProfilePath}: missing moving-guide banner link`);
   }
 });
 
-if (marketData.toronto?.condoAverage == null && /The average Toronto condo now sells for/.test(movingGuideText)) {
-  failures.push(`${movingGuideRoute}: Toronto comparison must be hidden while placeholder values are null`);
+const eastGwillimburyCommunityText =
+  readRoute("/communities/east-gwillimbury")
+    ?.querySelector("body")
+    ?.text.replace(/\s+/g, " ")
+    .trim() || "";
+if (!eastGwillimburyCommunityText.includes("East Gwillimbury GO station")) {
+  failures.push("/communities/east-gwillimbury: missing correct East Gwillimbury GO station copy");
+}
+if (
+  /East Gwillimbury (?:does not currently have|has no) a GO Train station/i.test(
+    eastGwillimburyCommunityText,
+  ) ||
+  /There is no GO Train station/i.test(eastGwillimburyCommunityText)
+) {
+  failures.push("/communities/east-gwillimbury: still contains the incorrect no-GO-station claim");
 }
 
 const robots = fs.readFileSync(path.join(rootDir, "public", "robots.txt"), "utf8");

--- a/src/App.js
+++ b/src/App.js
@@ -51,6 +51,8 @@ import PowerOfSaleSupportPage from "./PowerOfSaleSupportPage";
 import KeswickLowerPricedHomesPage from "./KeswickLowerPricedHomesPage";
 import UnlockPage from "./UnlockPage";
 import MovingToGeorginaFromTorontoPage from "./MovingToGeorginaFromTorontoPage";
+import MovingToEastGwillimburyFromTorontoPage from "./MovingToEastGwillimburyFromTorontoPage";
+import MovingToUxbridgeFromTorontoPage from "./MovingToUxbridgeFromTorontoPage";
 
 import AuroraPage from "./AuroraPage";
 import NewmarketPage from "./NewmarketPage";
@@ -111,6 +113,8 @@ function App() {
           <Route path="/about"        element={<AboutPage />} />
           <Route path="/buyers"       element={<BuyersPage />} />
           <Route path="/moving-to-georgina-from-toronto" element={<MovingToGeorginaFromTorontoPage />} />
+          <Route path="/moving-to-east-gwillimbury-from-toronto" element={<MovingToEastGwillimburyFromTorontoPage />} />
+          <Route path="/moving-to-uxbridge-from-toronto" element={<MovingToUxbridgeFromTorontoPage />} />
           <Route path="/sellers"      element={<SellersPage />} />
           <Route path="/community"    element={<CommunityPage />} />
           <Route path="/communities"  element={<CommunitiesPage />} />

--- a/src/BuyersPage.js
+++ b/src/BuyersPage.js
@@ -18,8 +18,8 @@ const COMMUNITIES = [
 
 const MOVING_FROM_TORONTO_GUIDES = [
   { town: "Georgina", href: "/moving-to-georgina-from-toronto" },
-  { town: "East Gwillimbury" },
-  { town: "Uxbridge" },
+  { town: "East Gwillimbury", href: "/moving-to-east-gwillimbury-from-toronto" },
+  { town: "Uxbridge", href: "/moving-to-uxbridge-from-toronto" },
   { town: "Newmarket" },
   { town: "Aurora" },
   { town: "Stouffville" },
@@ -626,8 +626,8 @@ export default function BuyersPage() {
             <p className="buyers-eyebrow">Moving from Toronto?</p>
             <h2 id="moving-guides-heading">Start with an honest town guide.</h2>
             <p>
-              Read the live Georgina guide now. Six more Toronto-to-town guides are coming next,
-              and this list is ready to grow with them.
+              Read the live Georgina, East Gwillimbury, and Uxbridge guides now. Four more
+              Toronto-to-town guides are coming next, and this list is ready to grow with them.
             </p>
           </div>
           <ul>

--- a/src/EastGwillimburyPage.js
+++ b/src/EastGwillimburyPage.js
@@ -49,6 +49,10 @@ img{max-width:100%;display:block;}
 .breadcrumb{font-size:12px;color:var(--ink4);padding:16px 0 0;}
 .breadcrumb a{color:var(--green);}
 .breadcrumb span{margin:0 5px;}
+.moving-guide-banner{display:flex;align-items:center;justify-content:space-between;gap:18px;margin:20px 0 0;padding:17px 20px;border:1px solid var(--gborder);border-radius:var(--rl);background:linear-gradient(135deg,var(--gpale),#fff);box-shadow:var(--sh);}
+.moving-guide-banner strong{display:block;color:var(--green);font-family:var(--fd);font-size:17px;}
+.moving-guide-banner span{display:block;margin-top:3px;color:var(--ink3);font-size:12px;}
+.moving-guide-banner a{flex:0 0 auto;border-radius:24px;background:var(--green);padding:10px 17px;color:#fff;font-size:12px;font-weight:600;text-decoration:none;}
 .page-grid{display:grid;grid-template-columns:1fr 300px;gap:32px;align-items:start;padding:28px 0 60px;}
 .sec{background:var(--paper);border-radius:var(--rxl);border:1px solid var(--border);padding:24px;margin-bottom:20px;box-shadow:var(--sh);}
 .sec h2{font-family:var(--fd);font-size:20px;font-weight:700;color:var(--ink);margin-bottom:14px;letter-spacing:-0.01em;}
@@ -148,7 +152,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-watch{background:#fffbeb;border-color:#fde68a;}
 .fit-watch .fit-label{font-weight:600;color:#78350f;font-size:11px;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:6px;}
 .fit-item p{color:var(--ink2);line-height:1.6;}
-@media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
+@media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}.moving-guide-banner{align-items:flex-start;flex-direction:column;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
 `;
 const PAGE_SCHEMA = `{
@@ -169,7 +173,7 @@ const PAGE_SCHEMA = `{
     },
     {
       "@type":"FAQPage",
-      "mainEntity":[{"@type":"Question","name":"What is East Gwillimbury Ontario like?","acceptedAnswer":{"@type":"Answer","text":"East Gwillimbury is York Region's fastest-growing municipality, spanning Sharon, Queensville, Holland Landing, and Mount Albert. It is known for larger new-construction homes, significant infrastructure investment, and the HALP recreation centre opened in 2025."}},{"@type":"Question","name":"Is East Gwillimbury a good place to buy?","acceptedAnswer":{"@type":"Answer","text":"For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. In ${MARKET_DATA.period}, it recorded ${TOWN_MARKET.salesCount} all-home-types sales at an exact average sale price of ${TOWN_MARKET.averageSalePrice} and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}."}},{"@type":"Question","name":"Does East Gwillimbury have GO Train service?","acceptedAnswer":{"@type":"Answer","text":"No — East Gwillimbury does not currently have a GO Train station. The closest stations are in Aurora and Newmarket. Residents primarily commute via Highway 404. The Bradford bypass is improving east-west access."}}]
+      "mainEntity":[{"@type":"Question","name":"What is East Gwillimbury Ontario like?","acceptedAnswer":{"@type":"Answer","text":"East Gwillimbury is York Region's fastest-growing municipality, spanning Sharon, Queensville, Holland Landing, and Mount Albert. It is known for larger new-construction homes, significant infrastructure investment, and the HALP recreation centre opened in 2025."}},{"@type":"Question","name":"Is East Gwillimbury a good place to buy?","acceptedAnswer":{"@type":"Answer","text":"For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. In ${MARKET_DATA.period}, it recorded ${TOWN_MARKET.salesCount} all-home-types sales at an exact average sale price of ${TOWN_MARKET.averageSalePrice} and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}."}},{"@type":"Question","name":"Does East Gwillimbury have GO Train service?","acceptedAnswer":{"@type":"Answer","text":"Yes. East Gwillimbury GO station on Green Lane, near Holland Landing, is on the Barrie line with direct service to Union Station — roughly 70 minutes downtown. Highway 404 also serves drivers, and the Bradford Bypass is improving east-west access."}}]
     },
     {
       "@type":"RealEstateAgent",
@@ -213,6 +217,13 @@ const PAGE_BODY_HTML = `
     <a href="https://northsidegta.ca/neighbourhood-guide">Neighbourhood guide</a><span>&rsaquo;</span>
     <span>East Gwillimbury</span>
   </nav>
+  <aside class="moving-guide-banner" aria-label="Moving to East Gwillimbury guide">
+    <div>
+      <strong>Moving from Toronto?</strong>
+      <span>Prices, commute, communities, and the trade-offs to know before you move.</span>
+    </div>
+    <a href="/moving-to-east-gwillimbury-from-toronto">Read the Honest 2026 Guide &rarr;</a>
+  </aside>
   <div class="page-grid">
 
     <!-- MAIN COLUMN -->
@@ -264,7 +275,7 @@ const PAGE_BODY_HTML = `
           <div style="background:var(--cream);border-radius:var(--r);padding:14px 16px;font-size:13px;color:var(--ink2);line-height:1.75;">
             <div><strong>Distance to DVP/401:</strong> 60 km</div>
             <div><strong>Off-peak drive time:</strong> approximately 50 minutes</div>
-            <div><strong>Transit:</strong> Highway 404 and Bradford bypass — no GO Train station</div>
+            <div><strong>Transit:</strong> East Gwillimbury GO station on Green Lane — direct Barrie-line service to Union in roughly 70 minutes</div>
             <div style="margin-top:8px;font-size:12px;color:var(--ink4);">Drive times are off-peak estimates. Peak-hour commute times are typically 30–60% longer depending on conditions.</div>
           </div>
         </div>
@@ -325,7 +336,7 @@ const PAGE_BODY_HTML = `
           </div>
           <div class="fit-item fit-watch">
             <div class="fit-label">Things to weigh up</div>
-            <p>East Gwillimbury is car-dependent. There is no GO Train station. Daily commuting requires highway driving, typically 45 to 60 minutes off-peak to central Toronto.</p>
+            <p>East Gwillimbury has its own GO station on Green Lane with direct Barrie-line service to Union in roughly 70 minutes. Highway 404 also makes it practical for drivers, though peak traffic still requires planning.</p>
           </div>
         </div>
         <div style="margin-top:12px;background:var(--cream);border-radius:var(--r);padding:13px 15px;font-size:13px;color:var(--ink2);">
@@ -350,7 +361,7 @@ const PAGE_BODY_HTML = `
       <div class="faq-answer">For buyers who want newer construction and larger lots at a reasonable York Region price point, East Gwillimbury offers strong value compared with nearby options. In ${MARKET_DATA.period}, it recorded ${TOWN_MARKET.salesCount} all-home-types sales at an exact average sale price of ${TOWN_MARKET.averageSalePrice} and an Avg. LDOM of ${TOWN_MARKET.avgLdom}. Source: ${MARKET_DATA.source}.</div>
     </details><details class="faq-item">
       <summary class="faq-summary">Does East Gwillimbury have GO Train service? <span class="faq-icon">+</span></summary>
-      <div class="faq-answer">No — East Gwillimbury does not currently have a GO Train station. The closest stations are in Aurora and Newmarket. Residents primarily commute via Highway 404. The Bradford bypass is improving east-west access.</div>
+      <div class="faq-answer">Yes. East Gwillimbury GO station on Green Lane, near Holland Landing, is on the Barrie line with direct service to Union Station — roughly 70 minutes downtown. Highway 404 also serves drivers, and the Bradford Bypass is improving east-west access.</div>
     </details>
       </div>
 

--- a/src/MovingToEastGwillimburyFromTorontoPage.js
+++ b/src/MovingToEastGwillimburyFromTorontoPage.js
@@ -1,0 +1,15 @@
+import React from "react";
+import MovingFromTorontoPage from "./components/movingFromToronto/MovingFromTorontoPage";
+import eastGwillimburyMovingGuideModule from "./content/movingFromToronto/eastGwillimbury";
+
+const { eastGwillimburyMovingGuide, buildMovingGuideSchema } =
+  eastGwillimburyMovingGuideModule;
+
+export default function MovingToEastGwillimburyFromTorontoPage() {
+  return (
+    <MovingFromTorontoPage
+      content={eastGwillimburyMovingGuide}
+      buildSchema={buildMovingGuideSchema}
+    />
+  );
+}

--- a/src/MovingToUxbridgeFromTorontoPage.js
+++ b/src/MovingToUxbridgeFromTorontoPage.js
@@ -1,0 +1,14 @@
+import React from "react";
+import MovingFromTorontoPage from "./components/movingFromToronto/MovingFromTorontoPage";
+import uxbridgeMovingGuideModule from "./content/movingFromToronto/uxbridge";
+
+const { uxbridgeMovingGuide, buildMovingGuideSchema } = uxbridgeMovingGuideModule;
+
+export default function MovingToUxbridgeFromTorontoPage() {
+  return (
+    <MovingFromTorontoPage
+      content={uxbridgeMovingGuide}
+      buildSchema={buildMovingGuideSchema}
+    />
+  );
+}

--- a/src/UxbridgePage.js
+++ b/src/UxbridgePage.js
@@ -49,6 +49,10 @@ img{max-width:100%;display:block;}
 .breadcrumb{font-size:12px;color:var(--ink4);padding:16px 0 0;}
 .breadcrumb a{color:var(--green);}
 .breadcrumb span{margin:0 5px;}
+.moving-guide-banner{display:flex;align-items:center;justify-content:space-between;gap:18px;margin:20px 0 0;padding:17px 20px;border:1px solid var(--gborder);border-radius:var(--rl);background:linear-gradient(135deg,var(--gpale),#fff);box-shadow:var(--sh);}
+.moving-guide-banner strong{display:block;color:var(--green);font-family:var(--fd);font-size:17px;}
+.moving-guide-banner span{display:block;margin-top:3px;color:var(--ink3);font-size:12px;}
+.moving-guide-banner a{flex:0 0 auto;border-radius:24px;background:var(--green);padding:10px 17px;color:#fff;font-size:12px;font-weight:600;text-decoration:none;}
 .page-grid{display:grid;grid-template-columns:1fr 300px;gap:32px;align-items:start;padding:28px 0 60px;}
 .sec{background:var(--paper);border-radius:var(--rxl);border:1px solid var(--border);padding:24px;margin-bottom:20px;box-shadow:var(--sh);}
 .sec h2{font-family:var(--fd);font-size:20px;font-weight:700;color:var(--ink);margin-bottom:14px;letter-spacing:-0.01em;}
@@ -148,7 +152,7 @@ details[open] .faq-icon{transform:rotate(45deg);}
 .fit-watch{background:#fffbeb;border-color:#fde68a;}
 .fit-watch .fit-label{font-weight:600;color:#78350f;font-size:11px;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:6px;}
 .fit-item p{color:var(--ink2);line-height:1.6;}
-@media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}}
+@media(max-width:760px){.page-grid{grid-template-columns:1fr;}.hero-content{padding:24px 20px 28px;}.hero-stats{flex-wrap:wrap;}.highlight-grid{grid-template-columns:1fr;}.fit-grid{grid-template-columns:1fr;}.moving-guide-banner{align-items:flex-start;flex-direction:column;}}
 @media(max-width:640px){.container{padding:0 16px;}.topnav{padding:0 16px;}.topnav-right .topnav-link{display:none;}.hero{height:360px;}}
 `;
 const PAGE_SCHEMA = `{
@@ -213,6 +217,13 @@ const PAGE_BODY_HTML = `
     <a href="https://northsidegta.ca/neighbourhood-guide">Neighbourhood guide</a><span>&rsaquo;</span>
     <span>Uxbridge</span>
   </nav>
+  <aside class="moving-guide-banner" aria-label="Moving to Uxbridge guide">
+    <div>
+      <strong>Moving from Toronto?</strong>
+      <span>Prices, commute, communities, and the trade-offs to know before you move.</span>
+    </div>
+    <a href="/moving-to-uxbridge-from-toronto">Read the Honest 2026 Guide &rarr;</a>
+  </aside>
   <div class="page-grid">
 
     <!-- MAIN COLUMN -->

--- a/src/components/movingFromToronto/MovingFromTorontoPage.js
+++ b/src/components/movingFromToronto/MovingFromTorontoPage.js
@@ -34,12 +34,12 @@ function BudgetBuyCard({ content }) {
   return (
     <aside className="moving-guide__budget-card" aria-labelledby="moving-guide-budget-heading">
       <div>
-        <p className="moving-guide__eyebrow">The $800K comparison</p>
-        <h3 id="moving-guide-budget-heading">{content.heading}</h3>
-        <p>{content.body}</p>
+        <p className="moving-guide__eyebrow">{content.budgetCard.eyebrow}</p>
+        <h3 id="moving-guide-budget-heading">{content.budgetCard.heading}</h3>
+        <p>{content.budgetCard.body}</p>
       </div>
       <img
-        src="/assets/town-logos/georgina.webp"
+        src={content.badgeImage}
         alt=""
         aria-hidden="true"
         width="108"
@@ -54,12 +54,12 @@ export default function MovingFromTorontoPage({ content, buildSchema }) {
   const schema = useMemo(() => buildSchema(content), [buildSchema, content]);
   const canonical = `https://northsidegta.ca${content.route}`;
   const markets = MARKET_DATA.municipalities;
-  const georgina = markets.georgina;
-  const comparisonTowns = ["georgina", "newmarket", "aurora"];
+  const primaryMarket = markets[content.marketKey];
+  const comparisonTowns = content.comparisonTowns;
   const toronto = MARKET_DATA.toronto || {};
   const showTorontoComparison =
     toronto.condoAverage != null && toronto.detachedAverage != null;
-  const georginaTrend = getMarketTrend(georgina.yearOverYear);
+  const primaryTrend = getMarketTrend(primaryMarket.yearOverYear);
 
   return (
     <>
@@ -116,14 +116,19 @@ export default function MovingFromTorontoPage({ content, buildSchema }) {
             <p className="moving-guide__hero-intro">{content.intro}</p>
             <p className="moving-guide__byline">
               By Matthew Mulhall, Finally Home Agents · Updated{" "}
-              <span data-market="lastUpdated">{MARKET_DATA.period}</span>
+              <span data-market="lastUpdated">
+                {MARKET_DATA.lastUpdated || MARKET_DATA.period}
+              </span>
             </p>
             <div className="moving-guide__hero-actions">
               <a className="moving-guide__button moving-guide__button--gold" href={QUIZ_URL}>
                 Take the Town Match Quiz
               </a>
-              <a className="moving-guide__button moving-guide__button--light" href="/communities/georgina">
-                Full Georgina community profile
+              <a
+                className="moving-guide__button moving-guide__button--light"
+                href={content.communityProfilePath}
+              >
+                Full {content.town} community profile
               </a>
             </div>
             <p className="moving-guide__source moving-guide__source--hero">
@@ -134,29 +139,32 @@ export default function MovingFromTorontoPage({ content, buildSchema }) {
 
         <div className="moving-guide__container moving-guide__body">
           <section className="moving-guide__section" aria-labelledby="moving-guide-money-heading">
-            <p className="moving-guide__eyebrow">Toronto budget, Georgina space</p>
-            <h2 id="moving-guide-money-heading">What your Toronto money buys in Georgina</h2>
-            <div className="moving-guide__stats" aria-label={`${MARKET_DATA.period} Georgina market snapshot`}>
+            <p className="moving-guide__eyebrow">{content.money.eyebrow}</p>
+            <h2 id="moving-guide-money-heading">{content.money.heading}</h2>
+            <div
+              className="moving-guide__stats"
+              aria-label={`${MARKET_DATA.period} ${content.town} market snapshot`}
+            >
               <MarketStat
                 label="Average sale price"
-                value={georgina.averageSalePrice}
-                marketKey="georgina.averageSold"
+                value={primaryMarket.averageSalePrice}
+                marketKey={`${content.marketKey}.averageSold`}
               />
               <MarketStat
                 label="Sales count"
-                value={georgina.salesCount}
-                marketKey="georgina.salesCount"
+                value={primaryMarket.salesCount}
+                marketKey={`${content.marketKey}.salesCount`}
               />
               <MarketStat
                 label="Avg. LDOM"
-                value={`${georgina.avgLdom} days`}
-                marketKey="georgina.daysOnMarket"
+                value={`${primaryMarket.avgLdom} days`}
+                marketKey={`${content.marketKey}.daysOnMarket`}
               />
               <MarketStat
                 label="Year over year"
-                value={georginaTrend.label}
-                marketKey="georgina.yearOverYear"
-                className={`moving-guide__stat--${georginaTrend.direction}`}
+                value={primaryTrend.label}
+                marketKey={`${content.marketKey}.yearOverYear`}
+                className={`moving-guide__stat--${primaryTrend.direction}`}
               />
             </div>
             <p className="moving-guide__source">
@@ -168,35 +176,33 @@ export default function MovingFromTorontoPage({ content, buildSchema }) {
                 detached averages {marketValue(toronto.detachedAverage)} (TRREB).
               </p>
             ) : null}
-            <p>
-              In practical terms, the price of a modest Toronto condo puts a detached house with a
-              yard within reach in Keswick — and waterfront-area living within reach for less than
-              a Toronto semi.
-            </p>
-            <BudgetBuyCard content={content.budgetCard} />
+            <p>{content.money.body}</p>
+            <BudgetBuyCard content={content} />
           </section>
 
           <aside className="moving-guide__callout" aria-label="Toronto land transfer tax comparison">
             <div className="moving-guide__callout-mark" aria-hidden="true">$</div>
             <p>
-              <strong>The number Toronto buyers forget:</strong> leaving Toronto means no municipal
-              land transfer tax. On a $770,000 purchase, that's roughly{" "}
-              <strong>$11,500 staying in your pocket</strong> — Toronto is the only municipality in
-              Ontario that charges a second land transfer tax on top of the provincial one.
+              <strong>{content.landTransferTax.headline}</strong>{" "}
+              {content.landTransferTax.beforeSavings}{" "}
+              <strong>{content.landTransferTax.savings}</strong>{" "}
+              {content.landTransferTax.afterSavings}
             </p>
           </aside>
 
           <section className="moving-guide__section" aria-labelledby="moving-guide-communities-heading">
-            <p className="moving-guide__eyebrow">Choose your corner of the lake</p>
-            <h2 id="moving-guide-communities-heading">Keswick, Sutton, or Jackson's Point?</h2>
-            <p>Georgina isn't one place — choosing your corner of it is the real decision.</p>
-            <figure className="moving-guide__feature-image">
-              <img
-                src={content.communityImage}
-                alt={content.communityImageAlt}
-                loading="lazy"
-              />
-            </figure>
+            <p className="moving-guide__eyebrow">{content.communitiesSection.eyebrow}</p>
+            <h2 id="moving-guide-communities-heading">{content.communitiesSection.heading}</h2>
+            <p>{content.communitiesSection.intro}</p>
+            {content.communityImage ? (
+              <figure className="moving-guide__feature-image">
+                <img
+                  src={content.communityImage}
+                  alt={content.communityImageAlt}
+                  loading="lazy"
+                />
+              </figure>
+            ) : null}
             <div className="moving-guide__town-grid">
               {content.communities.map(({ heading, body }) => (
                 <article className="moving-guide__town-card" key={heading}>
@@ -205,13 +211,13 @@ export default function MovingFromTorontoPage({ content, buildSchema }) {
                 </article>
               ))}
             </div>
-            <p className="moving-guide__aside-copy">
-              Also worth knowing: Pefferlaw and Udora for rural properties and acreage.
-            </p>
+            {content.communitiesSection.aside ? (
+              <p className="moving-guide__aside-copy">{content.communitiesSection.aside}</p>
+            ) : null}
             <div className="moving-guide__mini-cta">
               <p>
-                <strong>Not sure which corner fits you?</strong> Tell us your budget and lifestyle
-                — we'll tell you where to look (and where not to).
+                <strong>{content.communitiesSection.miniCtaLead}</strong>{" "}
+                {content.communitiesSection.miniCtaBody}
               </p>
               <a href={WHATSAPP_URL} target="_blank" rel="noopener noreferrer">
                 Ask us on WhatsApp →
@@ -220,9 +226,9 @@ export default function MovingFromTorontoPage({ content, buildSchema }) {
           </section>
 
           <section className="moving-guide__section" aria-labelledby="moving-guide-family-heading">
-            <p className="moving-guide__eyebrow">Life beyond the listing</p>
-            <h2 id="moving-guide-family-heading">Raising kids in Georgina</h2>
-            <p>This is the question behind most moves north, so here's the real picture.</p>
+            <p className="moving-guide__eyebrow">{content.familySection.eyebrow}</p>
+            <h2 id="moving-guide-family-heading">{content.familySection.heading}</h2>
+            <p>{content.familySection.intro}</p>
             <div className="moving-guide__family-grid">
               {content.familyCards.map(({ icon, heading, body }) => (
                 <article className="moving-guide__family-card" key={heading}>
@@ -233,48 +239,34 @@ export default function MovingFromTorontoPage({ content, buildSchema }) {
               ))}
             </div>
             <p className="moving-guide__lifestyle-link">
-              Looking for the places locals actually eat?{" "}
-              <a href="/tastehub?town=georgina">Explore Georgina on TasteHub →</a>
+              {content.familySection.tasteHubLead}{" "}
+              <a href={content.tasteHubPath}>{content.familySection.tasteHubLabel}</a>
             </p>
           </section>
 
           <section className="moving-guide__section moving-guide__commute" aria-labelledby="moving-guide-commute-heading">
-            <p className="moving-guide__eyebrow">The trade-off to pressure-test</p>
-            <h2 id="moving-guide-commute-heading">The honest commute</h2>
-            <p>We won't sugar-coat this — Georgina is a commitment if you work downtown daily.</p>
+            <p className="moving-guide__eyebrow">{content.commute.eyebrow}</p>
+            <h2 id="moving-guide-commute-heading">{content.commute.heading}</h2>
+            <p>{content.commute.intro}</p>
             <div className="moving-guide__commute-grid">
-              <article>
-                <h3>Driving</h3>
-                <p>
-                  Highway 404 now reaches the edge of Keswick, making it highway nearly
-                  door-to-door. Plan on roughly an hour to north Toronto in normal traffic, more
-                  to the downtown core at peak.
-                </p>
-              </article>
-              <article>
-                <h3>GO Transit</h3>
-                <p>
-                  No train station in Georgina itself. The GO 67 Keswick–North York bus runs down
-                  the 404 corridor, and the nearest train stations are East Gwillimbury GO and
-                  Newmarket GO — about 20–25 minutes' drive from Keswick, with all-day service to
-                  Union.
-                </p>
-              </article>
+              {content.commute.items.map(({ heading, body }) => (
+                <article key={heading}>
+                  <h3>{heading}</h3>
+                  <p>{body}</p>
+                </article>
+              ))}
             </div>
             <div className="moving-guide__callout moving-guide__callout--inside">
               <p>
-                <strong>The honest read:</strong> Georgina works best for hybrid workers, people
-                working anywhere in York Region or north Toronto, and anyone whose office days are
-                2–3 per week. Downtown five days a week? Let's talk honestly about whether East
-                Gwillimbury or Newmarket fits better — that conversation is literally what we do.
+                <strong>The honest read:</strong> {content.commute.honestRead}
               </p>
             </div>
           </section>
 
           <section className="moving-guide__section" aria-labelledby="moving-guide-market-heading">
-            <p className="moving-guide__eyebrow">Three-town comparison</p>
+            <p className="moving-guide__eyebrow">{content.marketSection.eyebrow}</p>
             <div className="moving-guide__section-heading-row">
-              <h2 id="moving-guide-market-heading">Georgina market snapshot</h2>
+              <h2 id="moving-guide-market-heading">{content.marketSection.heading}</h2>
               <a href="/neighbourhood-guide">Compare all seven towns →</a>
             </div>
             <div className="moving-guide__table-wrap">
@@ -337,29 +329,19 @@ export default function MovingFromTorontoPage({ content, buildSchema }) {
               <span data-market="lastUpdated">{MARKET_DATA.period}</span> · Source:{" "}
               {MARKET_DATA.source} · {MARKET_DATA.homeType}
             </p>
-            <p>
-              Georgina is the lowest-priced town in the NorthSide GTA — the affordability gap
-              versus Newmarket and Aurora is why so many Toronto movers start their search here.
-            </p>
+            <p>{content.marketSection.conclusion}</p>
           </section>
 
           <aside className="moving-guide__review" aria-label="Client review">
             <div className="moving-guide__stars" aria-label="5 out of 5 stars">★★★★★</div>
-            <blockquote>
-              “What really stood out was that Matt understood our priorities as a family and
-              ensured that these priorities were held in high regard throughout the whole process.”
-            </blockquote>
-            <p>Larissa Halko · Buyer &amp; Seller · Google Reviews (5.0 rating)</p>
+            <blockquote>“{content.review.quote}”</blockquote>
+            <p>{content.review.attribution}</p>
           </aside>
 
           <section className="moving-guide__cta" aria-labelledby="moving-guide-cta-heading">
-            <p className="moving-guide__eyebrow">Two minutes, no pressure</p>
-            <h2 id="moving-guide-cta-heading">Is Georgina right for you?</h2>
-            <p>
-              Not sure whether Georgina, East Gwillimbury, or somewhere else north fits your family
-              best? That's exactly what our Town Match Quiz figures out — two minutes, no contact
-              info required to see your result.
-            </p>
+            <p className="moving-guide__eyebrow">{content.cta.eyebrow}</p>
+            <h2 id="moving-guide-cta-heading">{content.cta.heading}</h2>
+            <p>{content.cta.body}</p>
             <div className="moving-guide__cta-actions">
               <a className="moving-guide__button moving-guide__button--gold" href={QUIZ_URL}>
                 Take the Town Match Quiz →

--- a/src/components/seo/staticRouteMetaConfigs.mjs
+++ b/src/components/seo/staticRouteMetaConfigs.mjs
@@ -1,9 +1,18 @@
 import { BUYERS_SCHEMA } from "./buyersSchema.mjs";
 import sellersSchemaModule from "../../lib/structuredData/sellersPage.js";
 import movingGuideContentModule from "../../content/movingFromToronto/georgina.js";
+import eastGwillimburyMovingGuideModule from "../../content/movingFromToronto/eastGwillimbury.js";
+import uxbridgeMovingGuideModule from "../../content/movingFromToronto/uxbridge.js";
 
 const { buildSellersPageSchema, SELLERS_PAGE_TITLE, SELLERS_PAGE_DESCRIPTION } = sellersSchemaModule;
 const { georginaMovingGuide, buildMovingGuideSchema } = movingGuideContentModule;
+const { eastGwillimburyMovingGuide } = eastGwillimburyMovingGuideModule;
+const { uxbridgeMovingGuide } = uxbridgeMovingGuideModule;
+const MOVING_GUIDES = [
+  georginaMovingGuide,
+  eastGwillimburyMovingGuide,
+  uxbridgeMovingGuide,
+];
 
 const DEFAULT_GLOBAL_META_CONFIG = {
   route: "/",
@@ -570,18 +579,18 @@ const TOWN_REMEDIATION = [
 const SEO_REMEDIATION_ROUTE_META_CONFIGS = [
   { route: "/", meta: routeMeta({ route: "/", title: "NorthSide GTA Real Estate | Finally Home Agents", description: "Buy or sell north of Toronto with Finally Home Agents. Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.", image: HOME_IMAGE, pageType: "WebSite" }) },
   { route: "/buyers", meta: routeMeta({ route: "/buyers", title: "Buying a Home North of Toronto | Finally Home Agents", description: "Buying north of Toronto? Compare Aurora, Newmarket, Stouffville, Uxbridge, Georgina, East Gwillimbury, and Scugog with local buyer guidance.", image: `${SITE_URL}/uploads/buyers-page-seo.jpg`, schema: BUYERS_SCHEMA }) },
-  {
-    route: georginaMovingGuide.route,
+  ...MOVING_GUIDES.map((guide) => ({
+    route: guide.route,
     meta: routeMeta({
-      route: georginaMovingGuide.route,
-      title: georginaMovingGuide.title,
-      description: georginaMovingGuide.description,
-      image: `${SITE_URL}${georginaMovingGuide.heroImage}`,
-      imageAlt: georginaMovingGuide.heroImageAlt,
+      route: guide.route,
+      title: guide.title,
+      description: guide.description,
+      image: `${SITE_URL}${guide.heroImage}`,
+      imageAlt: guide.heroImageAlt,
       pageType: "Article",
-      schema: buildMovingGuideSchema(georginaMovingGuide),
+      schema: buildMovingGuideSchema(guide),
     }),
-  },
+  })),
   { route: "/sellers", meta: routeMeta({ route: "/sellers", title: SELLERS_PAGE_TITLE, description: SELLERS_PAGE_DESCRIPTION, image: SELLERS_IMAGE, imageAlt: SELLERS_IMAGE_ALT, schema: buildSellersPageSchema(), serviceType: "Seller representation" }) },
   { route: "/communities", meta: routeMeta({ route: "/communities", title: "NorthSide GTA Communities | Compare Towns North of Toronto", description: "Compare Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog with Finally Home Agents.", image: COMMUNITY_IMAGE, pageType: "CollectionPage", collectionItems: COMMUNITY_ITEMS }) },
   { route: "/contact", meta: routeMeta({ route: "/contact", title: "Contact Finally Home Agents | NorthSide GTA Real Estate", description: "Contact Matthew and Landon Mulhall for buying, selling, and local real estate guidance across Georgina, East Gwillimbury, Newmarket, Aurora, Stouffville, Uxbridge, and Scugog.", image: `${SITE_URL}/uploads/og-contact-northsidegta.jpg`, pageType: "ContactPage" }) },

--- a/src/content/movingFromToronto/eastGwillimbury.js
+++ b/src/content/movingFromToronto/eastGwillimbury.js
@@ -1,0 +1,199 @@
+const { buildMovingGuideSchema } = require("./georgina");
+
+const eastGwillimburyMovingGuide = {
+  town: "East Gwillimbury",
+  slug: "east-gwillimbury",
+  route: "/moving-to-east-gwillimbury-from-toronto",
+  title: "Moving to East Gwillimbury from Toronto (2026 Guide) | Finally Home Agents",
+  description:
+    "Thinking of moving to East Gwillimbury from Toronto? Holland Landing, Sharon, Queensville & Mount Albert compared — new builds, real prices, the honest commute.",
+  heroImage: "/Images/eastgwillimbury-banner.jpg",
+  heroImageAlt: "New family homes in East Gwillimbury, Ontario",
+  badgeImage: "/assets/town-logos/east-gwillimbury.webp",
+  badgeImageAlt: "East Gwillimbury NorthSide GTA town badge",
+  communityImage: "/uploads/insights/east-gwillimbury-queensville-aerial-2026.jpg",
+  communityImageAlt: "Aerial view of newer family homes in Queensville, East Gwillimbury",
+  marketKey: "east-gwillimbury",
+  comparisonTowns: ["east-gwillimbury", "newmarket", "georgina"],
+  communityProfilePath: "/communities/east-gwillimbury",
+  tasteHubPath: "/tastehub?town=east-gwillimbury",
+  kicker: "Relocation Guide · East Gwillimbury",
+  heading: "Moving to East Gwillimbury from Toronto: The Honest 2026 Guide",
+  intro:
+    "Trade a Toronto semi for a five-year-old detached with a three-car garage — East Gwillimbury is where Toronto families go when the priority is the house itself. Here's what the move actually looks like: the good, the trade-offs, and the numbers.",
+  money: {
+    eyebrow: "Toronto budget, East Gwillimbury space",
+    heading: "What your Toronto money buys in East Gwillimbury",
+    body:
+      "East Gwillimbury is the NorthSide GTA's new-build capital — York Region's fastest-growing municipality, where most of the housing stock in Sharon and Queensville is under ten years old. This is the town for buyers who walk into 1980s listings and think \"I don't want a renovation project.\"",
+  },
+  budgetCard: {
+    eyebrow: "The $1.1M comparison",
+    heading: "What does $1.1M buy in East Gwillimbury?",
+    body:
+      "A 4–5 bedroom estate detached on a 50–60 ft lot in Queensville or Sharon — typically 2,600–3,200 sq ft, three-car garage, big backyard, built within the last five years. In Toronto, $1.1M is a dated semi on a narrow lot — before renovation costs.",
+  },
+  landTransferTax: {
+    headline: "Leaving Toronto means no municipal land transfer tax.",
+    beforeSavings: "On a $1.1M purchase, that's roughly",
+    savings: "$19,000 staying in your pocket",
+    afterSavings: "— enough to finish the basement in that new build.",
+  },
+  communitiesSection: {
+    eyebrow: "Choose your community",
+    heading: "Sharon, Queensville, Holland Landing, or Mount Albert?",
+    intro:
+      "East Gwillimbury is four distinct communities plus countryside — and they suit different moves.",
+    aside:
+      "Also worth knowing: rural East Gwillimbury for acreage between the communities.",
+    miniCtaLead: "Not sure which community fits?",
+    miniCtaBody:
+      "Tell us your budget and timeline — we'll tell you where the value is right now.",
+  },
+  communities: [
+    {
+      heading: "Sharon — the established heart",
+      body:
+        "Heritage village core (home of the historic Sharon Temple), estate subdivisions, and the town's top-rated elementary school. The blend of new homes and old-town character.",
+    },
+    {
+      heading: "Queensville — the new frontier",
+      body:
+        "The fastest-growing community: master-planned streets, brand-new schools and parks, and the widest choice of new-construction homes. If you want to pick your lot and finishes, look here.",
+    },
+    {
+      heading: "Holland Landing — closest to everything",
+      body:
+        "The most established community, minutes from Yonge Street, Newmarket amenities, and East Gwillimbury GO station. Older stock mixed with new pockets — often the best value entry point.",
+    },
+    {
+      heading: "Mount Albert — small-town east side",
+      body:
+        "A genuine village feel on the quieter east side, with its own main street, arena, and more land for the money.",
+    },
+  ],
+  familySection: {
+    eyebrow: "Life beyond the listing",
+    heading: "Raising kids in East Gwillimbury",
+    intro: "This is the question behind most moves north, so here's the real picture.",
+    tasteHubLead: "Looking for the places locals actually eat?",
+    tasteHubLabel: "Explore East Gwillimbury on TasteHub →",
+  },
+  familyCards: [
+    {
+      icon: "🏊",
+      heading: "The HALP (opened 2025)",
+      body:
+        "The Health and Active Living Plaza is the town's brand-new aquatic and recreation centre — pools, fitness, programs, and a café. Like the town itself: new, modern, built for families.",
+    },
+    {
+      icon: "🏫",
+      heading: "Schools",
+      body:
+        "Sharon Public School is the area's standout (Fraser 7.8), Queensville PS serves the new subdivisions, and secondary students attend Dr. John M. Denison SS in neighbouring Newmarket. Catholic options via York Catholic DSB.",
+    },
+    {
+      icon: "🌳",
+      heading: "Outside the door",
+      body:
+        "Holland Landing Conservation Area, Rogers Reservoir trails, and the Nokiidaa Trail linking East Gwillimbury to Newmarket and Aurora along the East Holland River.",
+    },
+    {
+      icon: "🏒",
+      heading: "Community sports",
+      body:
+        "Minor hockey and skating at the Sharon and Mount Albert arenas, soccer and baseball leagues, and new parks in every subdivision.",
+    },
+    {
+      icon: "🏥",
+      heading: "Healthcare",
+      body:
+        "Southlake Regional Health Centre is 10–15 minutes away in Newmarket — closer than for any other town we serve except Newmarket itself.",
+    },
+    {
+      icon: "🛒",
+      heading: "The honest trade-off",
+      body:
+        "The amenity base is still catching up to the growth. You'll do most shopping in Newmarket (10–15 min), and the town can feel like a work-in-progress: construction, new roads, businesses still arriving. If you want \"finished,\" look at Aurora or Newmarket.",
+    },
+  ],
+  commute: {
+    eyebrow: "The trade-off to pressure-test",
+    heading: "The honest commute",
+    intro:
+      "East Gwillimbury has an advantage most buyers don't realize: its own GO train station.",
+    items: [
+      {
+        heading: "GO Transit",
+        body:
+          "East Gwillimbury GO station (Green Lane, by Holland Landing) is on the Barrie line with direct service to Union — roughly 70 minutes downtown, no driving south to catch a train.",
+      },
+      {
+        heading: "Driving",
+        body:
+          "Highway 404 runs along the town's spine — about 50 minutes off-peak to the DVP/401, longer at peak. The Bradford Bypass (under construction) will add an east-west link toward the 400.",
+      },
+    ],
+    honestRead:
+      "The 404 + GO station combination makes East Gwillimbury one of the most commute-practical towns north of Newmarket. Hybrid workers get the best of it; five-day downtown commuters should test the full GO trip once before committing.",
+  },
+  marketSection: {
+    eyebrow: "Three-town comparison",
+    heading: "East Gwillimbury market snapshot",
+    conclusion:
+      "East Gwillimbury sits between Georgina's affordability and Aurora's price point — but no other town in the NorthSide GTA gives you a newer house for the money.",
+  },
+  review: {
+    quote:
+      "Their professionalism and personal attention set them apart. Throughout the entire process these Finally Home Agents exceeded our expectations. If you're thinking about selling, they should be your first and only choice.",
+    attribution: "Susan Booth · Seller · Holland Landing · Google Reviews (5.0 rating)",
+  },
+  cta: {
+    eyebrow: "Two minutes, no pressure",
+    heading: "Is East Gwillimbury right for you?",
+    body:
+      "Not sure whether East Gwillimbury, Georgina, or somewhere else north fits your family best? That's exactly what our Town Match Quiz figures out — two minutes, no contact info required to see your result.",
+  },
+  faqs: [
+    {
+      question: "Is East Gwillimbury a good place to live?",
+      answer:
+        "East Gwillimbury is York Region's fastest-growing municipality, known for newer detached homes on larger lots across Sharon, Queensville, Holland Landing, and Mount Albert. It suits families who want new construction, space, and Highway 404 or GO train access, with amenities still developing locally.",
+    },
+    {
+      question: "Does East Gwillimbury have a GO train station?",
+      answer:
+        "Yes. East Gwillimbury GO station on Green Lane, near Holland Landing, is on the Barrie line with direct service to Union Station — roughly 70 minutes downtown.",
+    },
+    {
+      question: "How far is East Gwillimbury from Toronto?",
+      answer:
+        "About 55–65 km. Driving via Highway 404 takes roughly 50 minutes off-peak to the DVP/401, longer at peak. The GO train from East Gwillimbury station takes about 70 minutes to Union.",
+    },
+    {
+      question: "Is East Gwillimbury cheaper than Toronto?",
+      answer:
+        "For what you get, significantly. The money that buys a dated Toronto semi buys a recent-build 4–5 bedroom detached with a multi-car garage in Sharon or Queensville — and buyers leaving Toronto avoid the municipal land transfer tax, saving roughly $19,000 on a typical purchase here.",
+    },
+    {
+      question: "What's the difference between Sharon, Queensville, Holland Landing, and Mount Albert?",
+      answer:
+        "Sharon blends heritage character with estate subdivisions and the area's top elementary school. Queensville is the newest, fastest-growing community with the most new construction. Holland Landing is the most established and closest to Newmarket and the GO station. Mount Albert is a quieter village on the east side.",
+    },
+    {
+      question: "Is East Gwillimbury good for families?",
+      answer:
+        "Yes — it's built for them. The new HALP recreation centre (2025), new schools and parks in Queensville, arenas in Sharon and Mount Albert, and the Nokiidaa Trail system serve a family-first population, with Southlake hospital 10–15 minutes away.",
+    },
+    {
+      question: "Who can help me buy a home in East Gwillimbury?",
+      answer:
+        "Finally Home Agents (Matthew and Landon Mulhall, HomeLife Optimum Realty, Brokerage) live and work in the NorthSide GTA and guide Toronto buyers through East Gwillimbury community-by-community — including new-build purchases, where builder contracts need experienced eyes.",
+    },
+  ],
+};
+
+module.exports = {
+  eastGwillimburyMovingGuide,
+  buildMovingGuideSchema,
+};

--- a/src/content/movingFromToronto/georgina.js
+++ b/src/content/movingFromToronto/georgina.js
@@ -13,14 +13,42 @@ const georginaMovingGuide = {
   badgeImageAlt: "Georgina NorthSide GTA town badge",
   communityImage: "/uploads/insights/georgina-keswick-lakefront-aerial-2026.jpg",
   communityImageAlt: "Aerial view of Keswick homes along the Lake Simcoe shoreline in Georgina",
+  marketKey: "georgina",
+  comparisonTowns: ["georgina", "newmarket", "aurora"],
+  communityProfilePath: "/communities/georgina",
+  tasteHubPath: "/tastehub?town=georgina",
   kicker: "Relocation Guide · Georgina",
   heading: "Moving to Georgina from Toronto: The Honest 2026 Guide",
   intro:
     "Sell a Toronto condo, buy a detached house on the Lake Simcoe side of the GTA — that's the trade more Toronto families are making every year. Here's what that move actually looks like: the good, the trade-offs, and the numbers.",
+  money: {
+    eyebrow: "Toronto budget, Georgina space",
+    heading: "What your Toronto money buys in Georgina",
+    body:
+      "In practical terms, the price of a modest Toronto condo puts a detached house with a yard within reach in Keswick — and waterfront-area living within reach for less than a Toronto semi.",
+  },
   budgetCard: {
+    eyebrow: "The $800K comparison",
     heading: "What does $800K buy in Georgina?",
     body:
       "A detached 3–4 bed family home in Keswick with a garage and real backyard — or a renovated bungalow near the lake in Sutton or Jackson's Point. In Toronto, $800K is a two-bed condo with maintenance fees.",
+  },
+  landTransferTax: {
+    headline: "The number Toronto buyers forget:",
+    beforeSavings:
+      "leaving Toronto means no municipal land transfer tax. On a $770,000 purchase, that's roughly",
+    savings: "$11,500 staying in your pocket",
+    afterSavings:
+      "— Toronto is the only municipality in Ontario that charges a second land transfer tax on top of the provincial one.",
+  },
+  communitiesSection: {
+    eyebrow: "Choose your corner of the lake",
+    heading: "Keswick, Sutton, or Jackson's Point?",
+    intro: "Georgina isn't one place — choosing your corner of it is the real decision.",
+    aside: "Also worth knowing: Pefferlaw and Udora for rural properties and acreage.",
+    miniCtaLead: "Not sure which corner fits you?",
+    miniCtaBody:
+      "Tell us your budget and lifestyle — we'll tell you where to look (and where not to).",
   },
   communities: [
     {
@@ -39,6 +67,13 @@ const georginaMovingGuide = {
         "Steps to Lake Simcoe, marinas, beaches, and cottage-country character in a year-round community. Waterfront living here is still attainable in a way that stopped being true in most of Ontario years ago.",
     },
   ],
+  familySection: {
+    eyebrow: "Life beyond the listing",
+    heading: "Raising kids in Georgina",
+    intro: "This is the question behind most moves north, so here's the real picture.",
+    tasteHubLead: "Looking for the places locals actually eat?",
+    tasteHubLabel: "Explore Georgina on TasteHub →",
+  },
   familyCards: [
     {
       icon: "🏊",
@@ -77,6 +112,42 @@ const georginaMovingGuide = {
         "Fewer restaurants and big-box stores than Newmarket or Aurora — you'll drive 20 minutes for some errands. Most families call it a fair trade for the mortgage payment and the lake.",
     },
   ],
+  commute: {
+    eyebrow: "The trade-off to pressure-test",
+    heading: "The honest commute",
+    intro: "We won't sugar-coat this — Georgina is a commitment if you work downtown daily.",
+    items: [
+      {
+        heading: "Driving",
+        body:
+          "Highway 404 now reaches the edge of Keswick, making it highway nearly door-to-door. Plan on roughly an hour to north Toronto in normal traffic, more to the downtown core at peak.",
+      },
+      {
+        heading: "GO Transit",
+        body:
+          "No train station in Georgina itself. The GO 67 Keswick–North York bus runs down the 404 corridor, and the nearest train stations are East Gwillimbury GO and Newmarket GO — about 20–25 minutes' drive from Keswick, with all-day service to Union.",
+      },
+    ],
+    honestRead:
+      "Georgina works best for hybrid workers, people working anywhere in York Region or north Toronto, and anyone whose office days are 2–3 per week. Downtown five days a week? Let's talk honestly about whether East Gwillimbury or Newmarket fits better — that conversation is literally what we do.",
+  },
+  marketSection: {
+    eyebrow: "Three-town comparison",
+    heading: "Georgina market snapshot",
+    conclusion:
+      "Georgina is the lowest-priced town in the NorthSide GTA — the affordability gap versus Newmarket and Aurora is why so many Toronto movers start their search here.",
+  },
+  review: {
+    quote:
+      "What really stood out was that Matt understood our priorities as a family and ensured that these priorities were held in high regard throughout the whole process.",
+    attribution: "Larissa Halko · Buyer & Seller · Google Reviews (5.0 rating)",
+  },
+  cta: {
+    eyebrow: "Two minutes, no pressure",
+    heading: "Is Georgina right for you?",
+    body:
+      "Not sure whether Georgina, East Gwillimbury, or somewhere else north fits your family best? That's exactly what our Town Match Quiz figures out — two minutes, no contact info required to see your result.",
+  },
   faqs: [
     {
       question: "Is Georgina a good place to live?",

--- a/src/content/movingFromToronto/uxbridge.js
+++ b/src/content/movingFromToronto/uxbridge.js
@@ -1,0 +1,191 @@
+const { buildMovingGuideSchema } = require("./georgina");
+
+const uxbridgeMovingGuide = {
+  town: "Uxbridge",
+  slug: "uxbridge",
+  route: "/moving-to-uxbridge-from-toronto",
+  title: "Moving to Uxbridge from Toronto (2026 Guide) | Finally Home Agents",
+  description:
+    "Thinking of moving to Uxbridge from Toronto? Trail Capital of Canada — acreage, heritage downtown, real prices, and the honest commute, compared for Toronto movers.",
+  heroImage: "/Images/uxbridge-banner.jpg",
+  heroImageAlt: "Heritage downtown streetscape in Uxbridge, Ontario",
+  badgeImage: "/assets/town-logos/uxbridge.webp",
+  badgeImageAlt: "Uxbridge NorthSide GTA town badge",
+  communityImage: "/uploads/insights/uxbridge-aerial-neighbourhood-2026.jpg",
+  communityImageAlt: "Aerial view of homes, countryside, and trails in Uxbridge, Ontario",
+  marketKey: "uxbridge",
+  comparisonTowns: ["uxbridge", "stouffville", "newmarket"],
+  communityProfilePath: "/communities/uxbridge",
+  tasteHubPath: "/tastehub?town=uxbridge",
+  kicker: "Relocation Guide · Uxbridge",
+  heading: "Moving to Uxbridge from Toronto: The Honest 2026 Guide",
+  intro:
+    "This is the \"we want land and quiet\" move. Uxbridge is the Trail Capital of Canada — a heritage downtown surrounded by forest, farms, and acreage properties that simply don't exist closer to the city. Here's what the move actually looks like: the good, the trade-offs, and the numbers.",
+  money: {
+    eyebrow: "Toronto budget, Uxbridge space",
+    heading: "What your Toronto money buys in Uxbridge",
+    body:
+      "Uxbridge isn't the cheapest town we serve — it's the one where your money buys a different kind of life. In-town heritage homes with mature trees, newer family subdivisions, and beyond the town line: acreage, workshops, barns, and privacy.",
+  },
+  budgetCard: {
+    eyebrow: "The $1M comparison",
+    heading: "What does $1M buy in Uxbridge?",
+    body:
+      "In town: a detached 4-bed family home near the trail network and a walkable heritage downtown. Outside town: a country property with real land — the kind of listing that makes Toronto visitors ask \"wait, for how much?\" In Toronto, $1M is a semi on a 20-foot lot.",
+  },
+  landTransferTax: {
+    headline: "Leaving Toronto means no municipal land transfer tax.",
+    beforeSavings: "On a $1M purchase, that's roughly",
+    savings: "$16,500 staying in your pocket",
+    afterSavings:
+      "— Toronto is the only municipality in Ontario that charges a second land transfer tax.",
+  },
+  communitiesSection: {
+    eyebrow: "Choose your corner",
+    heading: "Town, hamlet, or rural Uxbridge?",
+    intro:
+      "\"Uxbridge\" means both a town and a township — and the difference matters to your search.",
+    miniCtaLead: "Acreage buying has its own rules — wells, septic, zoning, conservation authority.",
+    miniCtaBody: "Ask us anything before you fall for a listing.",
+  },
+  communities: [
+    {
+      heading: "Uxbridge town — heritage main street living",
+      body:
+        "A genuinely charming downtown (shops, cafés, the historic Roxy Theatre), established neighbourhoods, newer subdivisions on the edges, and trails from your doorstep. Small-town life with real culture.",
+    },
+    {
+      heading: "The hamlets — Goodwood, Leaskdale, Zephyr, Sandford",
+      body:
+        "Village clusters surrounded by countryside. Leaskdale is literary Canada (Lucy Maud Montgomery's manse); Goodwood sits closest to Stouffville and the commuter routes.",
+    },
+    {
+      heading: "Rural Uxbridge — the acreage move",
+      body:
+        "Rolling Oak Ridges Moraine country: horse farms, wooded lots, ponds, shops and outbuildings. This is where \"more space\" becomes an understatement — and where we spend a lot of time with Toronto buyers.",
+    },
+  ],
+  familySection: {
+    eyebrow: "Life beyond the listing",
+    heading: "Raising kids in Uxbridge",
+    intro: "This is the question behind most moves north, so here's the real picture.",
+    tasteHubLead: "Looking for the places locals actually eat?",
+    tasteHubLabel: "Explore Uxbridge on TasteHub →",
+  },
+  familyCards: [
+    {
+      icon: "🥾",
+      heading: "Trail Capital of Canada",
+      body:
+        "220+ km of managed trails through the Oak Ridges Moraine, Durham Forest, and countryside — hiking, mountain biking, cross-country skiing. Kids here genuinely grow up in the woods.",
+    },
+    {
+      icon: "🏊",
+      heading: "Uxpool & the arena",
+      body:
+        "Uxpool has served the town since 1971 — six lanes, swim lessons, squash courts. The Uxbridge Arena & Community Centre runs minor hockey, lacrosse, and public skates.",
+    },
+    {
+      icon: "🏫",
+      heading: "Schools",
+      body:
+        "Durham District and Durham Catholic boards; Uxbridge Secondary School anchors the town, with elementary schools in town and the hamlets. (School catchment is one of the first things we map for rural properties — it changes at concession-road resolution.)",
+    },
+    {
+      icon: "🌳",
+      heading: "Elgin Park & the fairgrounds",
+      body:
+        "The town's gathering place — playgrounds, bandshell, ponds, and the Uxbridge Fall Fair, running since 1864. The York-Durham Heritage Railway runs vintage trains from the historic station.",
+    },
+    {
+      icon: "🏥",
+      heading: "Healthcare",
+      body:
+        "Uxbridge Cottage Hospital (Oak Valley Health) is right in town — rare for a town this size — with Markham Stouffville Hospital ~25 minutes south.",
+    },
+    {
+      icon: "🛒",
+      heading: "The honest trade-off",
+      body:
+        "One grocery run covers most needs, but big-box shopping means Stouffville or Newmarket (~25 min). Winter on rural roads is real — snow tires and a longer driveway to clear. That's the price of the view.",
+    },
+  ],
+  commute: {
+    eyebrow: "The trade-off to pressure-test",
+    heading: "The honest commute",
+    intro: "Uxbridge is the deepest-country move we serve, and the commute reflects it.",
+    items: [
+      {
+        heading: "Driving",
+        body:
+          "About 60 km to the DVP/401 — roughly an hour off-peak via Highway 404 or 407 (the 407 ETR toll buys reliability). Markham/Scarborough workers do noticeably better than downtown workers here.",
+      },
+      {
+        heading: "GO Transit",
+        body:
+          "No GO train in Uxbridge. The GO 71 bus runs from Toronto Street through Goodwood to Lincolnville GO at the top of the Stouffville line — train to Union from there. It works, but it's a two-leg trip; most commuters drive to Lincolnville or Old Elm and ride from there.",
+      },
+    ],
+    honestRead:
+      "Uxbridge is best for remote and hybrid workers, Durham/Markham commuters, and anyone whose downtown days are occasional. If you need Union Station daily, Stouffville gives you the small-town main street with the train — we'll tell you honestly which fits.",
+  },
+  marketSection: {
+    eyebrow: "Three-town comparison",
+    heading: "Uxbridge market snapshot",
+    conclusion:
+      "Uxbridge trades at a similar price point to its neighbours — the difference is what the money buys: land, trees, and privacy instead of proximity.",
+  },
+  review: {
+    quote:
+      "Matthew and the team really took the time and care to help us find the right place. He made the sometimes overwhelming burden of moving seem so smooth. I would greatly recommend that anyone looking for a home seek out Matthew and the team at Finally Home Agents.",
+    attribution: "Devin Tappenden · Buyer · Uxbridge · Google Reviews (5.0 rating)",
+  },
+  cta: {
+    eyebrow: "Two minutes, no pressure",
+    heading: "Is Uxbridge right for you?",
+    body:
+      "Not sure whether Uxbridge, Stouffville, or somewhere else north fits your family best? That's exactly what our Town Match Quiz figures out — two minutes, no contact info required to see your result.",
+  },
+  faqs: [
+    {
+      question: "Is Uxbridge a good place to live?",
+      answer:
+        "Uxbridge offers a heritage downtown, a strong community culture, its own hospital, and unmatched access to nature — it's the Trail Capital of Canada with 220+ km of trails. It suits families and buyers seeking space, acreage, or small-town character, with a car-dependent lifestyle as the trade-off.",
+    },
+    {
+      question: "How far is Uxbridge from Toronto?",
+      answer:
+        "About 60 km northeast. Driving takes roughly an hour off-peak via Highway 404 or the 407. There's no GO train in town; the GO 71 bus connects to Lincolnville GO station on the Stouffville line.",
+    },
+    {
+      question: "Why is Uxbridge called the Trail Capital of Canada?",
+      answer:
+        "The township maintains one of Canada's largest managed trail networks — over 220 km through the Oak Ridges Moraine, Durham Forest, and countryside, used year-round for hiking, mountain biking, and cross-country skiing.",
+    },
+    {
+      question: "Is Uxbridge cheaper than Toronto?",
+      answer:
+        "For what you get, dramatically. Toronto semi money buys an in-town detached near trails — or a rural property with acreage. Buyers leaving Toronto also avoid the municipal land transfer tax, saving roughly $16,500 on a typical purchase here.",
+    },
+    {
+      question: "What should I know about buying rural property in Uxbridge?",
+      answer:
+        "Country properties involve wells, septic systems, zoning, and Oak Ridges Moraine conservation rules that city purchases never touch. Budget for inspections beyond the standard home inspection, and work with representation experienced in rural transactions.",
+    },
+    {
+      question: "Is Uxbridge good for families?",
+      answer:
+        "Yes — Uxpool, the arena's minor hockey and lacrosse programs, Elgin Park, the fall fair, and the trail network give kids an outdoor childhood, and the town has its own hospital. Big-box shopping and some activities mean a 25-minute drive.",
+    },
+    {
+      question: "Who can help me buy a home in Uxbridge?",
+      answer:
+        "Finally Home Agents (Matthew and Landon Mulhall, HomeLife Optimum Realty, Brokerage) live and work in the NorthSide GTA and guide Toronto buyers through Uxbridge — town, hamlet, and acreage — including the rural due diligence that catches buyers out.",
+    },
+  ],
+};
+
+module.exports = {
+  uxbridgeMovingGuide,
+  buildMovingGuideSchema,
+};

--- a/src/data/marketData.json
+++ b/src/data/marketData.json
@@ -1,5 +1,6 @@
 {
   "period": "June 2026",
+  "lastUpdated": "June 2026",
   "source": "TRREB Market Watch, June 2026",
   "homeType": "All Home Types",
   "toronto": {
@@ -25,13 +26,15 @@
       "name": "Whitchurch-Stouffville",
       "averageSalePrice": "$1,329,155",
       "salesCount": 54,
-      "avgLdom": 41
+      "avgLdom": 41,
+      "yearOverYear": "+4.7%"
     },
     "east-gwillimbury": {
       "name": "East Gwillimbury",
       "averageSalePrice": "$1,062,808",
       "salesCount": 39,
-      "avgLdom": 57
+      "avgLdom": 57,
+      "yearOverYear": "-11.7%"
     },
     "georgina": {
       "name": "Georgina",
@@ -44,7 +47,8 @@
       "name": "Uxbridge",
       "averageSalePrice": "$1,140,111",
       "salesCount": 33,
-      "avgLdom": 47
+      "avgLdom": 47,
+      "yearOverYear": "+7.0%"
     },
     "scugog": {
       "name": "Scugog",

--- a/vercel.json
+++ b/vercel.json
@@ -60,6 +60,8 @@
     { "source": "/about", "destination": "/about/index.html" },
     { "source": "/buyers", "destination": "/buyers/index.html" },
     { "source": "/moving-to-georgina-from-toronto", "destination": "/moving-to-georgina-from-toronto/index.html" },
+    { "source": "/moving-to-east-gwillimbury-from-toronto", "destination": "/moving-to-east-gwillimbury-from-toronto/index.html" },
+    { "source": "/moving-to-uxbridge-from-toronto", "destination": "/moving-to-uxbridge-from-toronto/index.html" },
     { "source": "/sellers", "destination": "/sellers/index.html" },
     { "source": "/homeanalysis", "destination": "/homeanalysis/index.html" },
     { "source": "/contact", "destination": "/contact/index.html" },


### PR DESCRIPTION
## What changed
- Adds fully prerendered Toronto relocation guides for East Gwillimbury and Uxbridge using the reusable template introduced by the Georgina guide.
- Refactors the shared template so all town-specific copy, comparison towns, reviews, links, imagery, and CTAs come from per-town content files.
- Preserves the supplied section order and includes all seven verbatim FAQs on each page.
- Reads every snapshot value from `marketData.json`, including exact June 2026 average sale price, sales count, Avg. LDOM, last-updated label, and sign-aware YoY display.
- Adds the East Gwillimbury, Stouffville, and Uxbridge June YoY values needed by the new comparison tables.
- Corrects the East Gwillimbury community page’s inaccurate no-GO-station claim in visible commute copy, buyer-fit copy, visible FAQ, and FAQ schema. It now identifies East Gwillimbury GO on Green Lane, direct Barrie-line service to Union, and the roughly 70-minute trip.
- Adds guide banners to the East Gwillimbury and Uxbridge community pages and updates the buyers page to link all three live guides while leaving the remaining four marked coming soon.
- Adds Article, FAQPage, and BreadcrumbList JSON-LD, unique static metadata, sitemap entries, Vercel rewrites, route registration, prerendering, and build-gate coverage for both routes.

## Routes
- `/moving-to-east-gwillimbury-from-toronto`
- `/moving-to-uxbridge-from-toronto`

## Validation
- `npm run build` ✅
- 21 routes prerendered ✅
- 34 SEO route checks and 13 insight checks ✅
- All community, sitemap, cache, AI-search, shared-market, schema, and image audits ✅
- Desktop (1440px) and mobile (390px) checks: no overflow, broken images, or console errors ✅
- One H1 and seven visible/schema FAQs per new page ✅
- Community guide banners and all three buyers-page guide links verified ✅
- East Gwillimbury’s old no-station claim absent site-wide ✅
- `git diff --check` ✅

The unrelated untracked duplicate insight JSON files were not included.